### PR TITLE
upgrade hdwallet - NOTE: probably needs some more changes in the chain-adapters

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -21,8 +21,8 @@
     "adapterCli": "yarn build && node ./dist/ChainAdapterCLI.js"
   },
   "dependencies": {
-    "@shapeshiftoss/hdwallet-core": "^1.15.5-alpha.0",
-    "@shapeshiftoss/hdwallet-native": "^1.15.5-alpha.1",
+    "@shapeshiftoss/hdwallet-core": "^1.16.1",
+    "@shapeshiftoss/hdwallet-native": "^1.16.1",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "ethers": "^5.4.4",


### PR DESCRIPTION
See PR #439 in the legacy chain-adapters repo for additional changes that we need to port over.