### PR TITLE
feat: add contract param to getTxHistory

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,7 +1,7 @@
-import { PaginationParams } from './types/PaginationParams.type'
+import { Params } from './types/Params.type'
 import { ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 
-type Transaction = {
+export type Transaction = {
   network: string
   symbol: string
   txid: string
@@ -126,7 +126,7 @@ export interface ChainAdapter {
   /**
    * Get Transaction History for an address
    */
-  getTxHistory(address: string, paginationParams?: PaginationParams): Promise<TxHistoryResponse>
+  getTxHistory(address: string, params?: Params): Promise<TxHistoryResponse>
 
   buildSendTransaction(input: BuildSendTxInput): Promise<any>
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -12,7 +12,7 @@ import {
   ValidAddressResultType
 } from '../api'
 import { BlockchainProvider } from '../types/BlockchainProvider.type'
-import { PaginationParams } from '../types/PaginationParams.type'
+import { Params } from '../types/Params.type'
 import { ErrorHandler } from '../error/ErrorHandler'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { numberToHex } from 'web3-utils'
@@ -47,10 +47,10 @@ export class EthereumChainAdapter implements ChainAdapter {
 
   getTxHistory = async (
     address: string,
-    paginationParams?: PaginationParams
+    params?: Params
   ): Promise<TxHistoryResponse> => {
     try {
-      return this.provider.getTxHistory(address, paginationParams)
+      return this.provider.getTxHistory(address, params)
     } catch (err) {
       return ErrorHandler(err)
     }

--- a/packages/chain-adapters/src/providers/UnchainedProvider.ts
+++ b/packages/chain-adapters/src/providers/UnchainedProvider.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios'
-import { PaginationParams } from '../types/PaginationParams.type'
+import { Params } from '../types/Params.type'
 import { BlockchainProvider } from '../types/BlockchainProvider.type'
 import { TxHistoryResponse, BalanceResponse, BroadcastTxResponse, FeeEstimateInput } from '..'
 import https from 'https'
@@ -24,9 +24,9 @@ export class UnchainedProvider implements BlockchainProvider {
     return data
   }
 
-  async getTxHistory(address: string, paginationParams?: PaginationParams) {
+  async getTxHistory(address: string, params?: Params) {
     const { data } = await this.axios.get<TxHistoryResponse>(`/txs/${address}`, {
-      params: paginationParams
+      params: params
     })
     return data
   }

--- a/packages/chain-adapters/src/types/BlockchainProvider.type.ts
+++ b/packages/chain-adapters/src/types/BlockchainProvider.type.ts
@@ -1,9 +1,9 @@
-import { PaginationParams } from './PaginationParams.type'
+import { Params } from './Params.type'
 import { TxHistoryResponse, FeeEstimateInput, BalanceResponse } from '../api'
 
 export interface BlockchainProvider {
   getBalance: (address: string) => Promise<BalanceResponse | undefined>
-  getTxHistory: (address: string, paginationParams?: PaginationParams) => Promise<TxHistoryResponse>
+  getTxHistory: (address: string, params?: Params) => Promise<TxHistoryResponse>
   getNonce: (address: string) => Promise<number>
   broadcastTx: (hex: string) => Promise<string>
   getFeePrice: () => Promise<string>

--- a/packages/chain-adapters/src/types/PaginationParams.type.ts
+++ b/packages/chain-adapters/src/types/PaginationParams.type.ts
@@ -1,4 +1,0 @@
-export type PaginationParams = Partial<{
-  page: number
-  pageSize: number
-}>

--- a/packages/chain-adapters/src/types/Params.type.ts
+++ b/packages/chain-adapters/src/types/Params.type.ts
@@ -1,0 +1,5 @@
+export type Params = Partial<{
+  page: number
+  pageSize: number
+  contract: string
+}>


### PR DESCRIPTION
- Rename `PaginationParams` to `Params`
- Add `contract` to `getTxHistory` params for filtering tx history by contract address.