### PR TITLE
ci: commitlint config for dependabot

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  "extends": ['@commitlint/config-conventional'],
+	"rules": {
+    "scope-enum": [0, "always", []],
+  }
+}


### PR DESCRIPTION
commitlint was too aggressive and won't accept dependabot PR titles like `chore(deps): bump semver-regex from 3.1.2 to 3.1.3`

this changes the rule to ignore the scope, e.g. the `(deps)` in `chore(deps): ...` to make ci great again