### PR TITLE
chore: add addressNList to getAddress

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -28,7 +28,7 @@ const main = async () => {
     const chainAdapterManager = new ChainAdapterManager(unchainedUrls)
     const wallet = await getWallet()
     const ethChainAdapter = chainAdapterManager.byChain(ChainTypes.Ethereum)
-    const address = await ethChainAdapter.getAddress({ wallet, path: defaultEthPath })
+    const { address } = await ethChainAdapter.getAddress({ wallet, path: defaultEthPath })
 
     const balanceInfo = await ethChainAdapter.getBalance(address)
     // const txHistory = await ethChainAdapter.getTxHistory(address)

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -6,6 +6,7 @@ import {
   ChainTypes,
   FeeDataEstimate,
   GetAddressInput,
+  GetAddressOutput,
   GetFeeDataInput,
   SignTxInput,
   TxHistoryResponse,
@@ -32,7 +33,7 @@ export interface ChainAdapter {
     input: BuildSendTxInput
   ): Promise<{ txToSign: ETHSignTx; estimatedFees: FeeDataEstimate }>
 
-  getAddress(input: GetAddressInput): Promise<string>
+  getAddress(input: GetAddressInput): Promise<GetAddressOutput>
 
   signTransaction(signTxInput: SignTxInput): Promise<string>
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -9,6 +9,7 @@ import {
   BuildSendTxInput,
   SignTxInput,
   GetAddressInput,
+  GetAddressOutput,
   GetFeeDataInput,
   BalanceResponse,
   ChainTypes,
@@ -95,7 +96,7 @@ export class EthereumChainAdapter implements ChainAdapter {
       const addressNList = bip32ToAddressNList(path)
 
       const data = await getErc20Data(to, tx?.value, erc20ContractAddress)
-      const from = await this.getAddress({ wallet, path })
+      const { address: from } = await this.getAddress({ wallet, path })
       const nonce = await this.provider.getNonce(from)
 
       let gasPrice = fee
@@ -187,14 +188,18 @@ export class EthereumChainAdapter implements ChainAdapter {
     }
   }
 
-  getAddress = async (input: GetAddressInput): Promise<string> => {
+  getAddress = async (input: GetAddressInput): Promise<GetAddressOutput> => {
     const { wallet, path } = input
     const addressNList = bip32ToAddressNList(path)
     const ethAddress = await (wallet as ETHWallet).ethGetAddress({
       addressNList,
       showDisplay: false
     })
-    return ethAddress as string
+
+    return {
+      address: ethAddress as string,
+      addressNList
+    }
   }
 
   async validateAddress(address: string): Promise<ValidAddressResult> {

--- a/packages/swapper/src/swappers/zrx/buildQuoteTx/buildQuoteTx.ts
+++ b/packages/swapper/src/swappers/zrx/buildQuoteTx/buildQuoteTx.ts
@@ -83,7 +83,7 @@ export async function buildQuoteTx(
   }
 
   const adapter: ChainAdapter = adapterManager.byChain(buyAsset.chain)
-  const receiveAddress = await adapter.getAddress({ wallet, path: DEFAULT_ETH_PATH })
+  const { address: receiveAddress } = await adapter.getAddress({ wallet, path: DEFAULT_ETH_PATH })
 
   if (new BigNumber(slippage || 0).gt(MAX_SLIPPAGE)) {
     throw new SwapError(

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -244,9 +244,15 @@ export type SignTxInput = {
   txToSign: ETHSignTx
   wallet: HDWallet
 }
+
 export type GetAddressInput = {
   wallet: HDWallet
   path: string
+}
+
+export interface GetAddressOutput {
+  address: string
+  addressNList: number[]
 }
 
 export type GetFeeDataInput = {


### PR DESCRIPTION
- Add `addressNList` to `getAddress` function inside of ChainAdapters.

Note: This is a breaking change.

Closes #88 