### PR TITLE
ci: don't persist wrong git credentials on checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Cache dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
i *think* this is what's causing ci not to be able to push to `main`

https://stackoverflow.com/questions/63733822/cant-push-to-protected-branch-in-github-action