### PR TITLE
ci: bump package versions to allow semantic release to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/asset-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Service to return supported asset details",
   "homepage": "",
   "license": "MIT",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/chain-adapters",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "> TODO: description",
   "homepage": "",
   "license": "MIT",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/market-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ShapeShift market data service",
   "homepage": "",
   "license": "MIT",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TODO: description",
   "repository": "https://github.com/shapeshift/lib",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/types",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Common types shared across packages",
   "repository": "https://github.com/shapeshift/lib",
   "license": "MIT",


### PR DESCRIPTION
we previously manually published `1.0.0` for the `asset-service` and semantic release tries to release the same version.

bump them all and it *should* work