### PR TITLE
fix: update vulnerable axios version

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -28,7 +28,7 @@
     "@shapeshiftoss/hdwallet-core": "^1.16.3",
     "@shapeshiftoss/hdwallet-native": "^1.15.5-alpha.1",
     "@shapeshiftoss/types": "^1.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.2",
     "bignumber.js": "^9.0.1",
     "ethers": "^5.4.4",
     "multicoin-address-validator": "^0.5.2",


### PR DESCRIPTION
Remediation
Upgrade axios to version 0.21.2 or later. For example:

axios@^0.21.2:
  version "0.21.2"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2021-3749
high severity
Vulnerable versions: <= 0.21.1
Patched version: 0.21.2
axios is vulnerable to Inefficient Regular Expression Complexity