### PR TITLE
chore: release asset service

### DIFF
--- a/packages/asset-service/src/service/AssetServiceTestData.ts
+++ b/packages/asset-service/src/service/AssetServiceTestData.ts
@@ -74,7 +74,7 @@ export const mockBaseAssets: BaseAsset[] = [
   },
   {
     chain: ChainTypes.Bitcoin,
-    network: NetworkTypes.MAINNET, // <---------- mainnet
+    network: NetworkTypes.MAINNET,
     symbol: 'BTC',
     name: 'Bitcoin',
     precision: 8,
@@ -89,7 +89,7 @@ export const mockBaseAssets: BaseAsset[] = [
   },
   {
     chain: ChainTypes.Bitcoin,
-    network: NetworkTypes.TESTNET, // <---------- testnet
+    network: NetworkTypes.TESTNET,
     symbol: 'BTC',
     name: 'Bitcoin',
     precision: 8,


### PR DESCRIPTION
semantic release needs to be fooled into releasing this package based on the commit type because the asset service was previously release, this is just teething issues with our config.

the trivial changes are just so the commit analyzer picks up a change in this package.