### PR TITLE
ci: use environment in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This Should(TM) allow us to scope the secrets needed to publish the package so they're only available when actually publishing.