### PR TITLE
chore: bump package versions

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "@shapeshiftoss/types": "^1.0.2"
+    "@shapeshiftoss/types": "^1.1.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.172"

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -25,19 +25,19 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@shapeshiftoss/hdwallet-core": "^1.16.6",
-    "@shapeshiftoss/types": "^1.0.2",
-    "@shapeshiftoss/unchained-client": "^1.3.1",
+    "@shapeshiftoss/hdwallet-core": "^1.17.0",
+    "@shapeshiftoss/types": "^1.1.0",
+    "@shapeshiftoss/unchained-client": "^1.4.4",
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",
     "coinselect": "^3.1.12",
-    "ethers": "^5.4.4",
+    "ethers": "^5.4.7",
     "multicoin-address-validator": "^0.5.2",
-    "web3-utils": "^1.5.2"
+    "web3-utils": "^1.6.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/hdwallet-native": "^1.16.6",
+    "@shapeshiftoss/hdwallet-native": "^1.17.0",
     "@types/multicoin-address-validator": "^0.5.0"
   }
 }

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,5 +1,5 @@
 import { ChainTypes } from '@shapeshiftoss/types'
-import { BitcoinAPI, EthereumAPI } from '@shapeshiftoss/unchained-client'
+import { bitcoin, ethereum } from '@shapeshiftoss/unchained-client'
 import { ChainAdapter, isChainAdapterOfType } from './api'
 import { BitcoinChainAdapter } from './bitcoin'
 import { EthereumChainAdapter } from './ethereum'
@@ -18,12 +18,12 @@ export class ChainAdapterManager {
       ([type, basePath]) => {
         switch (type) {
           case ChainTypes.Ethereum: {
-            const provider = new EthereumAPI.V1Api(new EthereumAPI.Configuration({ basePath }))
+            const provider = new ethereum.api.V1Api(new ethereum.api.Configuration({ basePath }))
             return this.addChain(type, () => new EthereumChainAdapter({ provider }))
           }
           case ChainTypes.Bitcoin: {
             const coinName = 'Bitcoin'
-            const provider = new BitcoinAPI.V1Api(new BitcoinAPI.Configuration({ basePath }))
+            const provider = new bitcoin.api.V1Api(new bitcoin.api.Configuration({ basePath }))
             return this.addChain(type, () => new BitcoinChainAdapter({ provider, coinName }))
           }
           default:

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,6 +1,6 @@
 import { ChainTypes } from '@shapeshiftoss/types'
 import { bitcoin, ethereum } from '@shapeshiftoss/unchained-client'
-import { ChainAdapter, isChainAdapterOfType } from './api'
+import { ChainAdapter } from './api'
 import { BitcoinChainAdapter } from './bitcoin'
 import { EthereumChainAdapter } from './ethereum'
 
@@ -43,7 +43,7 @@ export class ChainAdapterManager {
    * @param {ChainTypes} network - Coin/network symbol from Asset query
    * @param {Function} factory - A function that returns a ChainAdapter instance
    */
-  addChain<T extends ChainTypes>(chain: T, factory: () => ChainAdapter<T>): void {
+  addChain<T extends ChainTypes>(chain: T, factory: () => ChainAdapter<ChainTypes>): void {
     if (typeof chain !== 'string' || typeof factory !== 'function') {
       throw new Error('Parameter validation error')
     }
@@ -65,12 +65,8 @@ export class ChainAdapterManager {
       const factory = this.supported.get(chain)
       if (factory) {
         adapter = factory()
-        if (!adapter || !isChainAdapterOfType(chain, adapter)) {
-          throw new Error(
-            `Adapter type [${
-              adapter ? adapter.getType() : typeof adapter
-            }] does not match requested type [${chain}]`
-          )
+        if (!adapter) {
+          throw new Error(`Adapter not available for [${chain}]`)
         }
         this.instances.set(chain, adapter)
       }

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,12 +1,5 @@
 import { ChainAdapters, ChainTypes } from '@shapeshiftoss/types'
 
-export const isChainAdapterOfType = <U extends ChainTypes>(
-  chainType: U,
-  x: ChainAdapter<ChainTypes>
-): x is ChainAdapter<U> => {
-  return x.getType() === chainType
-}
-
 export interface ChainAdapter<T extends ChainTypes> {
   /**
    * Get type of adapter

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -9,7 +9,7 @@ import { ChainAdapterManager } from '../ChainAdapterManager'
 import { BTCInputScriptType, BTCSignTx } from '@shapeshiftoss/hdwallet-core'
 import { ChainAdapter } from '../'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BitcoinAPI } from '@shapeshiftoss/unchained-client'
+import { bitcoin } from '@shapeshiftoss/unchained-client'
 import dotenv from 'dotenv'
 import { BIP32Params, ChainTypes } from '@shapeshiftoss/types'
 dotenv.config({
@@ -71,7 +71,7 @@ describe('BitcoinChainAdapter', () => {
 
   describe.skip('getAccount', () => {
     it('should return account info for a specified address', async () => {
-      const exampleResponse: BitcoinAPI.BitcoinAccount = {
+      const exampleResponse: bitcoin.api.BitcoinAccount = {
         pubkey: '1EjpFGTWJ9CGRJUMA3SdQSdigxM31aXAFx',
         balance: '0'
       }

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -13,13 +13,13 @@ import {
   supportsBTC
 } from '@shapeshiftoss/hdwallet-core'
 import { BIP32Params, ChainAdapters, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
-import { BitcoinAPI } from '@shapeshiftoss/unchained-client'
+import { bitcoin } from '@shapeshiftoss/unchained-client'
 import { ChainAdapter } from '../api'
 import { toPath, toRootDerivationPath } from '../bip32'
 import { ErrorHandler } from '../error/ErrorHandler'
 
 export type BitcoinChainAdapterDependencies = {
-  provider: BitcoinAPI.V1Api
+  provider: bitcoin.api.V1Api
 }
 
 type UtxoCoinName = {
@@ -27,7 +27,7 @@ type UtxoCoinName = {
 }
 
 export class BitcoinChainAdapter implements ChainAdapter<ChainTypes.Bitcoin> {
-  private readonly provider: BitcoinAPI.V1Api
+  private readonly provider: bitcoin.api.V1Api
   private readonly defaultBIP32Params: BIP32Params = {
     purpose: 84, // segwit native
     coinType: 0,
@@ -152,7 +152,7 @@ export class BitcoinChainAdapter implements ChainAdapter<ChainTypes.Bitcoin> {
       const estimatedFees = await this.getFeeData()
       const satoshiPerByte = estimatedFees[feeSpeed ?? ChainAdapters.FeeDataKey.Average].feePerUnit
 
-      type MappedUtxos = Omit<BitcoinAPI.Utxo, 'value'> & { value: number }
+      type MappedUtxos = Omit<bitcoin.api.Utxo, 'value'> & { value: number }
       const mappedUtxos: MappedUtxos[] = utxos.map((x) => ({ ...x, value: Number(x.value) }))
 
       const coinSelectResult = coinSelect<MappedUtxos, ChainAdapters.Bitcoin.Recipient>(

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -11,14 +11,14 @@ import {
   ContractTypes,
   NetworkTypes
 } from '@shapeshiftoss/types'
-import { EthereumAPI } from '@shapeshiftoss/unchained-client'
+import { ethereum } from '@shapeshiftoss/unchained-client'
 import { ChainAdapter } from '../api'
 import { toPath } from '../bip32'
 import { ErrorHandler } from '../error/ErrorHandler'
 import erc20Abi from './erc20Abi.json'
 
 export type EthereumChainAdapterDependencies = {
-  provider: EthereumAPI.V1Api
+  provider: ethereum.api.V1Api
 }
 
 type ZrxFeeResult = {
@@ -51,7 +51,7 @@ async function getErc20Data(to: string, value: string, contractAddress?: string)
 }
 
 export class EthereumChainAdapter implements ChainAdapter<ChainTypes.Ethereum> {
-  private readonly provider: EthereumAPI.V1Api
+  private readonly provider: ethereum.api.V1Api
   private readonly defaultBIP32Params: BIP32Params = {
     purpose: 44,
     coinType: 60,
@@ -98,7 +98,7 @@ export class EthereumChainAdapter implements ChainAdapter<ChainTypes.Ethereum> {
 
   async getTxHistory({
     pubkey
-  }: EthereumAPI.V1ApiGetTxHistoryRequest): Promise<
+  }: ethereum.api.V1ApiGetTxHistoryRequest): Promise<
     ChainAdapters.TxHistoryResponse<ChainTypes.Ethereum>
   > {
     try {

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@shapeshiftoss/types": "^1.0.2",
+    "@shapeshiftoss/types": "^1.1.0",
     "axios": "^0.21.2",
     "dayjs": "^1.10.6"
   }

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -20,8 +20,8 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@shapeshiftoss/chain-adapters": "^1.1.1",
-    "@shapeshiftoss/hdwallet-core": "^1.16.6",
+    "@shapeshiftoss/chain-adapters": "^1.2.0",
+    "@shapeshiftoss/hdwallet-core": "^1.17.0",
     "@shapeshiftoss/types": "^1.0.2",
     "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@shapeshiftoss/chain-adapters": "^1.2.0",
     "@shapeshiftoss/hdwallet-core": "^1.17.0",
-    "@shapeshiftoss/types": "^1.0.2",
+    "@shapeshiftoss/types": "^1.1.0",
     "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",
     "retry-axios": "^2.6.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,6 +20,6 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@shapeshiftoss/hdwallet-core": "^1.16.6"
+    "@shapeshiftoss/hdwallet-core": "^1.17.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "useUnknownInCatchVariables": false,
     "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,
     "strictPropertyInitialization": false /* Enable strict checking of property initialization in classes. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    "useUnknownInCatchVariables": false,
     "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,
     "strictPropertyInitialization": false /* Enable strict checking of property initialization in classes. */,

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,7 +631,7 @@
     "@ethersproject/logger" "^5.4.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bignumber@^5.0.7":
+"@ethersproject/bignumber@5.4.2", "@ethersproject/bignumber@^5.0.7":
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.2.tgz#44232e015ae4ce82ac034de549eb3583c71283d8"
   integrity sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==
@@ -2269,10 +2269,10 @@
     randombytes "^2.1.0"
     web-encoding "^1.1.5"
 
-"@shapeshiftoss/fiosdk@1.2.1-shapeshift.4":
-  version "1.2.1-shapeshift.4"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/fiosdk/-/fiosdk-1.2.1-shapeshift.4.tgz#f9b057852befb0309d94ea8623feaa06194fae2f"
-  integrity sha512-WM3jrRw3H9AvBYUb0OGkYNI4BzjQl17HdeVpcpIhhOMX6hvsPptLpUd22MEovilz34B4f1X0QcTF15PH4LdMoA==
+"@shapeshiftoss/fiosdk@1.2.1-shapeshift.6":
+  version "1.2.1-shapeshift.6"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/fiosdk/-/fiosdk-1.2.1-shapeshift.6.tgz#f4b4bfd4dd32b304145b1396d17e08c9dc74d162"
+  integrity sha512-/99+WvaD6RapyKJBUqnBn7JdhxDUvxIcWVdsyzoQrHKTBnAk6V33r3b61DOqcj4ZDXiDxFl1MzfmGHuN64UB6g==
   dependencies:
     "@shapeshiftoss/fiojs" "1.0.1-shapeshift.2"
     bip39 "^3.0.2"
@@ -2281,10 +2281,10 @@
     web-encoding "^1.1.0"
     wif "^2.0.6"
 
-"@shapeshiftoss/hdwallet-core@1.16.6", "@shapeshiftoss/hdwallet-core@^1.16.6":
-  version "1.16.6"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.16.6.tgz#e81eb42fdeb49356d0e77bec31663a32fcb97033"
-  integrity sha512-DHH2h1RkdImMKehT4ODuLY5QD3yJLEtk0ZKTteSe97pCsTMIOTxZcNWH/4YBr0GPwXRLiIgRQzi3Z6FFHar9+A==
+"@shapeshiftoss/hdwallet-core@1.17.0", "@shapeshiftoss/hdwallet-core@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.17.0.tgz#92f89db523169af74bf149c9e0b9dd5826d27cd9"
+  integrity sha512-FV+RPjOQeSI4rDvu2UsEWKo3LDlyKRXgvrgEiemfF9J8rhRDbK939MvPARD7RVXWDFfaDJ0SODpcNQe4iOxZNA==
   dependencies:
     eventemitter2 "^5.0.1"
     lodash "^4.17.21"
@@ -2299,14 +2299,14 @@
     lodash "^4.17.21"
     rxjs "^6.4.0"
 
-"@shapeshiftoss/hdwallet-native@^1.16.6":
-  version "1.16.6"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-native/-/hdwallet-native-1.16.6.tgz#ac74148957b11ebcc086ea0dcd7b5cf3feb9da2c"
-  integrity sha512-DUrF7EOWRm74NnyQQcL6cLQKCT8GvEIEpYFBYlrHelSb9OvcTCSmh4V5oFBKgqjgvo24rHJh/oopTnegMVOEkQ==
+"@shapeshiftoss/hdwallet-native@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-native/-/hdwallet-native-1.17.0.tgz#ca7ce54c2757ab25890e65ddf47c3f6518bea2d3"
+  integrity sha512-xfmM1WEsZ50h1oFYTW6xcoOyG6eSqhZIAvEyjaxjTNfQPfUAc244w4Qnsv9gcGxbR0n/bfAu8UNCvIO1kLjuFQ==
   dependencies:
     "@bithighlander/bitcoin-cash-js-lib" "5.2.1"
-    "@shapeshiftoss/fiosdk" "1.2.1-shapeshift.4"
-    "@shapeshiftoss/hdwallet-core" "1.16.6"
+    "@shapeshiftoss/fiosdk" "1.2.1-shapeshift.6"
+    "@shapeshiftoss/hdwallet-core" "1.17.0"
     "@zxing/text-encoding" "^0.9.0"
     bchaddrjs "^0.4.9"
     bignumber.js "^9.0.1"
@@ -2324,10 +2324,10 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
-"@shapeshiftoss/unchained-client@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-1.3.1.tgz#f8b9fb0c77159b604aad99ded2af5e502e377d20"
-  integrity sha512-jk/SANB1/NUbI3tvqeG5Q5ws6YzN/BmZ1/DGInkAaYzAWKhyAj8wtTC2E4v5BsdrZj68Wbl5ZFYFYpG+kZYLSA==
+"@shapeshiftoss/unchained-client@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-1.4.4.tgz#457e1b66b922ef9f55c6ec31d7be993994611463"
+  integrity sha512-V/pj9BwPCs3BnB/XFPcvm7LulQo4Xf1959w1p6I33/EXgq2WK6T5ME2b/e7sVf/74sp8Pl0jj/yym/hcXvIvmg==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -5212,10 +5212,10 @@ ethers@5.4.4:
     "@ethersproject/web" "5.4.0"
     "@ethersproject/wordlists" "5.4.0"
 
-ethers@^5.4.4:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.6.tgz#fe0a023956b5502c947f58e82fbcf9a73e5e75b6"
-  integrity sha512-F7LXARyB/Px3AQC6/QKedWZ8eqCkgOLORqL4B/F0Mag/K+qJSFGqsR36EaOZ6fKg3ZonI+pdbhb4A8Knt/43jQ==
+ethers@^5.4.7:
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.7.tgz#0fd491a5da7c9793de2d6058d76b41b1e7efba8f"
+  integrity sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==
   dependencies:
     "@ethersproject/abi" "5.4.1"
     "@ethersproject/abstract-provider" "5.4.1"
@@ -5223,7 +5223,7 @@ ethers@^5.4.4:
     "@ethersproject/address" "5.4.0"
     "@ethersproject/base64" "5.4.0"
     "@ethersproject/basex" "5.4.0"
-    "@ethersproject/bignumber" "5.4.1"
+    "@ethersproject/bignumber" "5.4.2"
     "@ethersproject/bytes" "5.4.0"
     "@ethersproject/constants" "5.4.0"
     "@ethersproject/contracts" "5.4.1"
@@ -11469,7 +11469,7 @@ web3-shh@1.6.0:
     web3-core-subscriptions "1.6.0"
     web3-net "1.6.0"
 
-web3-utils@1.6.0:
+web3-utils@1.6.0, web3-utils@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.6.0.tgz#1975c5ee5b7db8a0836eb7004848a7cd962d1ddc"
   integrity sha512-bgCAWAeQnJF035YTFxrcHJ5mGEfTi/McsjqldZiXRwlHK7L1PyOqvXiQLE053dlzvy1kdAxWl/sSSfLMyNUAXg==


### PR DESCRIPTION
a few of the packages weren't depending on the new types, and swapper was using an old version of chain adapters. 

this unifies things so we can get web working.