### PR TITLE
fix: get btc sends working by allowing optional to+value to be used instead of recipients

### DIFF
--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -132,7 +132,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         feeSpeed
       } = tx
 
-      if (!recipients && !(value && to)) {
+      if (!recipients && (!value || !to)) {
         throw new Error('BitcoinChainAdapter: recipients or (to and value) are required')
       }
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -132,7 +132,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         feeSpeed
       } = tx
 
-      if (!recipients && (!value || !to)) {
+      if (!recipients && !(value && to)) {
         throw new Error('BitcoinChainAdapter: recipients or (to and value) are required')
       }
 


### PR DESCRIPTION
get btc sends working by allowing optional to+value to be used instead of recipients.

Allows it to be called in the same way as the eth chain adapter buildSendTransaction()