### PR TITLE
chore: bump logger version to 4.0

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/logger",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "A simple JSON logger with no external dependencies",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
a package in `unchained` was already published as `@shapeshiftoss/logger`