### PR TITLE
ci: revert lint PR title before install

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,12 +19,13 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn install --frozen-lockfile
+      # needs to run after install
       - name: Commitlint PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: printf '%s' "$TITLE" | npx commitlint
-      - name: Install
-        run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
       - name: Lint


### PR DESCRIPTION
This reverts commit dc9882525add97ab466aab3abc4b04de2e6f4044.

this was only working because of the yarn install cache. i am dum dum.
