### PR TITLE
refactor: simplify #177 a bit

### DIFF
--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -294,8 +294,7 @@ describe('BitcoinChainAdapter', () => {
             {
               addressType: 'spend',
               amount: '400',
-              address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
-              scriptType: 'p2wpkh'
+              address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4'
             },
             {
               addressType: 'change',

--- a/packages/chain-adapters/src/utils/utxoUtils.ts
+++ b/packages/chain-adapters/src/utils/utxoUtils.ts
@@ -1,6 +1,26 @@
-import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
+import { BTCInputScriptType, BTCOutputScriptType } from '@shapeshiftoss/hdwallet-core'
 import { Asset } from '@shapeshiftoss/types'
 import { BIP32Params, UtxoAccountType } from '@shapeshiftoss/types'
+
+/**
+ * Utility function to convert a BTCInputScriptType to the corresponding BTCOutputScriptType
+ * @param x a BTCInputScriptType
+ * @returns the corresponding BTCOutputScriptType
+ */
+export const toBtcOutputScriptType = (x: BTCInputScriptType) => {
+  switch (x) {
+    case BTCInputScriptType.SpendWitness:
+      return BTCOutputScriptType.PayToWitness
+    case BTCInputScriptType.SpendP2SHWitness:
+      return BTCOutputScriptType.PayToP2SHWitness
+    case BTCInputScriptType.SpendMultisig:
+      return BTCOutputScriptType.PayToMultisig
+    case BTCInputScriptType.SpendAddress:
+      return BTCOutputScriptType.PayToAddress
+    default:
+      throw new TypeError('scriptType')
+  }
+}
 
 /**
  * Utility function to get BIP32Params and scriptType for chain-adapter functions (getAddress, buildSendTransaction)


### PR DESCRIPTION
- we only need to calculate the change address type once
- turns out we don't even need to specify `scriptType` on `BTCOutputAddressType.Spend` outputs!