### PR TITLE
fix: eth nonce is expected to be hex in hdwallet

### DIFF
--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -158,7 +158,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
         to: destAddress,
         chainId: 1, // TODO: implement for multiple chains
         data,
-        nonce: String(chainSpecific.nonce),
+        nonce: numberToHex(chainSpecific.nonce),
         gasPrice: numberToHex(gasPrice),
         gasLimit: numberToHex(gasLimit)
       }


### PR DESCRIPTION
This fixes Eth sends not working for KeepKey.

They work for native because native does the conversion inside `ethSignTx` but converting it here will still be fine (I tested it)