### PR TITLE
feat: enable getAddress to show on device

### DIFF
--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -256,7 +256,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     const addressNList = bip32ToAddressNList(path)
     const ethAddress = await (wallet as ETHWallet).ethGetAddress({
       addressNList,
-      showDisplay: false
+      showDisplay: Boolean(input.showOnDevice)
     })
     return ethAddress as string
   }

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -191,6 +191,10 @@ export interface TxHistoryInput {
 export type GetAddressInputBase = {
   wallet: HDWallet
   bip32Params?: BIP32Params
+  /**
+   * Request that the address be shown to the user by the device, if supported
+   */
+  showOnDevice?: boolean
 }
 
 export type GetAddressInput = GetAddressInputBase | bitcoin.GetAddressInput


### PR DESCRIPTION
This is needed for the Receive screen to allow the user to manually verify the address from the device