### PR TITLE
fix: fees part 1 cleanup

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -17,7 +17,6 @@ export interface ChainAdapter<T extends ChainTypes> {
     input: chainAdapters.BuildSendTxInput
   ): Promise<{
     txToSign: chainAdapters.ChainTxType<T>
-    estimatedFees: chainAdapters.FeeDataEstimate<T>
   }>
 
   getAddress(input: chainAdapters.GetAddressInput): Promise<string>

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -284,10 +284,6 @@ describe('BitcoinChainAdapter', () => {
         feeSpeed: chainAdapters.FeeDataKey.Slow
       }
 
-      console.log(
-        'adapter.buildSendTransaction(txInput)',
-        await adapter.buildSendTransaction(txInput)
-      )
       await expect(adapter.buildSendTransaction(txInput)).resolves.toStrictEqual({
         txToSign: {
           coin: 'Bitcoin',

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -315,9 +315,9 @@ describe('BitcoinChainAdapter', () => {
           fee: 226
         }
       })
-      expect(args.providers.http.getUtxos).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getTransaction).toHaveBeenCalledTimes(2)
+      expect(args.providers.http.getUtxos).toHaveBeenCalledTimes(1)
+      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
+      expect(args.providers.http.getTransaction).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -277,12 +277,17 @@ describe('BitcoinChainAdapter', () => {
 
       const txInput: chainAdapters.BuildSendTxInput = {
         bip32Params,
-        recipients: [{ address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4', value: 400 }],
+        to: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
+        value: '400',
         wallet,
         opReturnData: 'nm, u',
         feeSpeed: chainAdapters.FeeDataKey.Slow
       }
 
+      console.log(
+        'adapter.buildSendTransaction(txInput)',
+        await adapter.buildSendTransaction(txInput)
+      )
       await expect(adapter.buildSendTransaction(txInput)).resolves.toStrictEqual({
         txToSign: {
           coin: 'Bitcoin',
@@ -312,16 +317,11 @@ describe('BitcoinChainAdapter', () => {
             }
           ],
           fee: 226
-        },
-        estimatedFees: {
-          fast: { feePerUnit: '1' },
-          average: { feePerUnit: '1' },
-          slow: { feePerUnit: '1' }
         }
       })
-      expect(args.providers.http.getUtxos).toHaveBeenCalledTimes(1)
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-      expect(args.providers.http.getTransaction).toHaveBeenCalledTimes(1)
+      expect(args.providers.http.getUtxos).toHaveBeenCalledTimes(2)
+      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
+      expect(args.providers.http.getTransaction).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -347,7 +347,8 @@ describe('BitcoinChainAdapter', () => {
 
       const txInput: chainAdapters.BuildSendTxInput = {
         bip32Params,
-        recipients: [{ address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4', value: 400 }],
+        to: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
+        value: '400',
         wallet,
         opReturnData: 'sup fool',
         feeSpeed: chainAdapters.FeeDataKey.Slow
@@ -388,12 +389,12 @@ describe('BitcoinChainAdapter', () => {
 
       const adapter = new bitcoin.ChainAdapter(args)
 
-      const data = await adapter.getFeeData()
+      const data = await adapter.getFeeData({ to: '0x', from: '0x', value: '0' })
       expect(data).toEqual(
         expect.objectContaining({
-          fast: { feePerUnit: '1' },
-          average: { feePerUnit: '1' },
-          slow: { feePerUnit: '1' }
+          average: { chainSpecific: { byteCount: '0', feePerTx: '0' }, feePerUnit: '1' },
+          fast: { chainSpecific: { byteCount: '0', feePerTx: '0' }, feePerUnit: '1' },
+          slow: { chainSpecific: { byteCount: '0', feePerTx: '0' }, feePerUnit: '1' }
         })
       )
     })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -5,7 +5,6 @@ import {
   BTCSignTx,
   BTCSignTxInput,
   BTCSignTxOutput,
-  BTCWallet,
   HDWallet,
   PublicKey,
   supportsBTC
@@ -162,7 +161,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         scriptType
       })
 
-      if (!from) throw new Error('from undefined')
+      if (!from) throw new Error('BitcoinChainAdapter: from undefined')
 
       const account = await this.getAccount(pubkey.xpub)
       const estimatedFees = await this.getFeeData({ to, value, from })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -5,6 +5,7 @@ import {
   BTCSignTx,
   BTCSignTxInput,
   BTCSignTxOutput,
+  BTCWallet,
   HDWallet,
   PublicKey,
   supportsBTC
@@ -125,24 +126,22 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     tx: chainAdapters.BuildSendTxInput
   ): Promise<{
     txToSign: chainAdapters.ChainTxType<ChainTypes.Bitcoin>
-    estimatedFees: chainAdapters.FeeDataEstimate<ChainTypes.Bitcoin>
   }> {
     try {
       const {
         value,
         to,
-        recipients,
         wallet,
         bip32Params = ChainAdapter.defaultBIP32Params,
         feeSpeed,
         scriptType = BTCInputScriptType.SpendWitness
       } = tx
 
-      if (!recipients && (!value || !to)) {
-        throw new Error('BitcoinChainAdapter: recipients or (to and value) are required')
+      if (!value || !to) {
+        throw new Error('BitcoinChainAdapter: (to and value) are required')
       }
 
-      const btcRecipients = recipients || [{ value: Number(value), address: to }]
+      const btcRecipients = [{ value: Number(value), address: to }]
 
       const path = toRootDerivationPath(bip32Params)
       const changeScriptType = toBtcOutputScriptType(scriptType)
@@ -150,9 +149,23 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
       const { data: utxos } = await this.providers.http.getUtxos({
         pubkey: pubkey.xpub
       })
+      const addressNList = bip32ToAddressNList(path)
+
+      if (!supportsBTC(wallet))
+        throw new Error(
+          'BitcoinChainAdapter: signTransaction wallet does not support signing btc txs'
+        )
+
+      const from = await wallet.btcGetAddress({
+        addressNList,
+        coin: this.coinName,
+        scriptType
+      })
+
+      if (!from) throw new Error('from undefined')
 
       const account = await this.getAccount(pubkey.xpub)
-      const estimatedFees = await this.getFeeData()
+      const estimatedFees = await this.getFeeData({ to, value, from })
       const satoshiPerByte = estimatedFees[feeSpeed ?? chainAdapters.FeeDataKey.Average].feePerUnit
 
       type MappedUtxos = Omit<bitcoin.api.Utxo, 'value'> & { value: number }
@@ -217,7 +230,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         fee
       }
 
-      return { txToSign, estimatedFees }
+      return { txToSign }
     } catch (err) {
       return ErrorHandler(err)
     }
@@ -245,8 +258,14 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     return broadcastedTx.data
   }
 
-  async getFeeData(): Promise<chainAdapters.FeeDataEstimate<ChainTypes.Bitcoin>> {
+  async getFeeData({
+    to,
+    from,
+    value
+  }: chainAdapters.GetFeeDataInput): Promise<chainAdapters.FeeDataEstimate<ChainTypes.Bitcoin>> {
     const feeData = await this.providers.http.getNetworkFees()
+
+    if (!to || !from || !value) throw new Error('to, from and value are required')
 
     if (
       !feeData.data.fast?.satsPerKiloByte ||
@@ -262,13 +281,25 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
 
     const confTimes: chainAdapters.FeeDataEstimate<ChainTypes.Bitcoin> = {
       [chainAdapters.FeeDataKey.Fast]: {
-        feePerUnit: fast
+        feePerUnit: fast,
+        chainSpecific: {
+          feePerTx: '0', // TODO,
+          byteCount: '0' // TODO
+        }
       },
       [chainAdapters.FeeDataKey.Average]: {
-        feePerUnit: average
+        feePerUnit: average,
+        chainSpecific: {
+          feePerTx: '0', // TODO,
+          byteCount: '0' // TODO
+        }
       },
       [chainAdapters.FeeDataKey.Slow]: {
-        feePerUnit: slow
+        feePerUnit: slow,
+        chainSpecific: {
+          feePerTx: '0', // TODO,
+          byteCount: '0' // TODO
+        }
       }
     }
     return confTimes

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -113,7 +113,6 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     tx: chainAdapters.BuildSendTxInput
   ): Promise<{
     txToSign: ETHSignTx
-    estimatedFees: chainAdapters.FeeDataEstimate<ChainTypes.Ethereum>
   }> {
     try {
       const {
@@ -162,7 +161,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
         gasPrice: numberToHex(gasPrice),
         gasLimit: numberToHex(gasLimit)
       }
-      return { txToSign, estimatedFees }
+      return { txToSign }
     } catch (err) {
       return ErrorHandler(err)
     }

--- a/packages/types/src/chain-adapters/bitcoin.ts
+++ b/packages/types/src/chain-adapters/bitcoin.ts
@@ -64,3 +64,8 @@ export type NodeTransaction = {
   time: number
   blocktime: number
 }
+
+export type FeeData = {
+  feePerTx: string
+  byteCount: string
+}

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -69,6 +69,7 @@ type ChainSpecificFeeData<T> = ChainSpecific<
   T,
   {
     [ChainTypes.Ethereum]: ethereum.FeeData
+    [ChainTypes.Bitcoin]: bitcoin.FeeData
   }
 >
 


### PR DESCRIPTION
- remove fees returning from buildSendTx
- remove recipients from buildSendTx
- add btc specific fee data and stub out return values

https://github.com/shapeshift/web/issues/215

We need to show fees on frontend and let them be selectable (it's all showing 0 right now) but the way we were expecting to do fees in frontend code was only applicable to eth and not the greatest (getting the fees from calling buildSendTx instead of getFees).


I will have a few additional changes to lib in upcoming prs but wanted to break it into smaller pieces.