### PR TITLE
feat: chain specific buildtx

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/hdwallet-core": "^1.17.1",
-    "@shapeshiftoss/types": "^1.9.0",
+    "@shapeshiftoss/types": "^1.9.1",
     "@shapeshiftoss/unchained-client": "^3.0.0",
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.1",

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,6 +1,6 @@
 import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { BIP32Params, ChainTypes } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 
 import { ChainAdapterManager } from './ChainAdapterManager'

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,143 +1,143 @@
-import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
-import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
-import dotenv from 'dotenv'
+// import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
+// import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
+// import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+// import dotenv from 'dotenv'
 
-import { ChainAdapterManager } from './ChainAdapterManager'
+// import { ChainAdapterManager } from './ChainAdapterManager'
 
-dotenv.config()
+// dotenv.config()
 
-const foxContractAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+// const foxContractAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 
-const getWallet = async (): Promise<NativeHDWallet> => {
-  const nativeAdapterArgs: NativeAdapterArgs = {
-    mnemonic: process.env.CLI_MNEMONIC,
-    deviceId: 'test'
-  }
-  const wallet = new NativeHDWallet(nativeAdapterArgs)
-  await wallet.initialize()
+// const getWallet = async (): Promise<NativeHDWallet> => {
+//   const nativeAdapterArgs: NativeAdapterArgs = {
+//     mnemonic: process.env.CLI_MNEMONIC,
+//     deviceId: 'test'
+//   }
+//   const wallet = new NativeHDWallet(nativeAdapterArgs)
+//   await wallet.initialize()
 
-  return wallet
-}
+//   return wallet
+// }
 
-const unchainedUrls = {
-  [ChainTypes.Bitcoin]: {
-    httpUrl: 'https://api.bitcoin.shapeshift.com',
-    wsUrl: 'wss://api.bitcoin.shapeshift.com'
-  },
-  [ChainTypes.Ethereum]: {
-    httpUrl: 'https://api.ethereum.shapeshift.com',
-    wsUrl: 'wss://api.ethereum.shapeshift.com'
-  }
-}
+// const unchainedUrls = {
+//   [ChainTypes.Bitcoin]: {
+//     httpUrl: 'https://api.bitcoin.shapeshift.com',
+//     wsUrl: 'wss://api.bitcoin.shapeshift.com'
+//   },
+//   [ChainTypes.Ethereum]: {
+//     httpUrl: 'https://api.ethereum.shapeshift.com',
+//     wsUrl: 'wss://api.ethereum.shapeshift.com'
+//   }
+// }
 
-const main = async () => {
-  try {
-    const chainAdapterManager = new ChainAdapterManager(unchainedUrls)
-    const wallet = await getWallet()
+// const main = async () => {
+//   try {
+//     const chainAdapterManager = new ChainAdapterManager(unchainedUrls)
+//     const wallet = await getWallet()
 
-    /** BITCOIN CLI */
-    const btcChainAdapter = chainAdapterManager.byChain(ChainTypes.Bitcoin)
-    const btcBip32Params: BIP32Params = {
-      purpose: 84,
-      coinType: 0,
-      accountNumber: 0,
-      isChange: false,
-      index: 10
-    }
+//     /** BITCOIN CLI */
+//     const btcChainAdapter = chainAdapterManager.byChain(ChainTypes.Bitcoin)
+//     const btcBip32Params: BIP32Params = {
+//       purpose: 84,
+//       coinType: 0,
+//       accountNumber: 0,
+//       isChange: false,
+//       index: 10
+//     }
 
-    const btcAddress = await btcChainAdapter.getAddress({
-      wallet,
-      bip32Params: btcBip32Params,
-      scriptType: BTCInputScriptType.SpendWitness
-    })
-    console.log('btcAddress:', btcAddress)
+//     const btcAddress = await btcChainAdapter.getAddress({
+//       wallet,
+//       bip32Params: btcBip32Params,
+//       scriptType: BTCInputScriptType.SpendWitness
+//     })
+//     console.log('btcAddress:', btcAddress)
 
-    const btcAccount = await btcChainAdapter.getAccount(btcAddress)
-    console.log('btcAccount:', btcAccount)
+//     const btcAccount = await btcChainAdapter.getAccount(btcAddress)
+//     console.log('btcAccount:', btcAccount)
 
-    const txInput = {
-      asset: { id: '123', symbol: 'BTC' },
-      recipients: [{ address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4', value: 400 }],
-      wallet,
-      opReturnData: 'sup fool',
-      bip32Params: btcBip32Params,
-      feeSpeed: chainAdapters.FeeDataKey.Slow
-    }
+//     const txInput = {
+//       asset: { id: '123', symbol: 'BTC' },
+//       recipients: [{ address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4', value: 400 }],
+//       wallet,
+//       opReturnData: 'sup fool',
+//       bip32Params: btcBip32Params,
+//       feeSpeed: chainAdapters.FeeDataKey.Slow
+//     }
 
-    try {
-      const btcUnsignedTx = await btcChainAdapter.buildSendTransaction(txInput)
-      const btcSignedTx = await btcChainAdapter.signTransaction({
-        wallet,
-        txToSign: btcUnsignedTx.txToSign
-      })
-      console.log('btcSignedTx:', btcSignedTx)
-    } catch (err) {
-      console.log('btcTx error:', err.message)
-    }
+//     try {
+//       const btcUnsignedTx = await btcChainAdapter.buildSendTransaction(txInput)
+//       const btcSignedTx = await btcChainAdapter.signTransaction({
+//         wallet,
+//         txToSign: btcUnsignedTx.txToSign
+//       })
+//       console.log('btcSignedTx:', btcSignedTx)
+//     } catch (err) {
+//       console.log('btcTx error:', err.message)
+//     }
 
-    // const btcTxID = await btcChainAdapter.broadcastTransaction(btcSignedTx)
-    // console.log('btcTxID: ', txid)
+//     // const btcTxID = await btcChainAdapter.broadcastTransaction(btcSignedTx)
+//     // console.log('btcTxID: ', txid)
 
-    /** ETHEREUM CLI */
-    const ethChainAdapter = chainAdapterManager.byChain(ChainTypes.Ethereum)
-    const ethBip32Params: BIP32Params = { purpose: 44, coinType: 60, accountNumber: 0 }
+//     /** ETHEREUM CLI */
+//     const ethChainAdapter = chainAdapterManager.byChain(ChainTypes.Ethereum)
+//     const ethBip32Params: BIP32Params = { purpose: 44, coinType: 60, accountNumber: 0 }
 
-    const ethAddress = await ethChainAdapter.getAddress({ wallet, bip32Params: ethBip32Params })
-    console.log('ethAddress:', ethAddress)
+//     const ethAddress = await ethChainAdapter.getAddress({ wallet, bip32Params: ethBip32Params })
+//     console.log('ethAddress:', ethAddress)
 
-    const ethAccount = await ethChainAdapter.getAccount(ethAddress)
-    console.log('ethAccount:', ethAccount)
+//     const ethAccount = await ethChainAdapter.getAccount(ethAddress)
+//     console.log('ethAccount:', ethAccount)
 
-    await ethChainAdapter.subscribeTxs(
-      { addresses: [ethAddress] },
-      (msg) => console.log(msg),
-      (err) => console.log(err)
-    )
+//     await ethChainAdapter.subscribeTxs(
+//       { addresses: [ethAddress] },
+//       (msg) => console.log(msg),
+//       (err) => console.log(err)
+//     )
 
-    // send eth example
-    try {
-      const ethUnsignedTx = await ethChainAdapter.buildSendTransaction({
-        to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
-        value: '1',
-        wallet,
-        bip32Params: ethBip32Params
-      })
-      const ethSignedTx = await ethChainAdapter.signTransaction({
-        wallet,
-        txToSign: ethUnsignedTx.txToSign
-      })
-      console.log('ethSignedTx:', ethSignedTx)
-    } catch (err) {
-      console.log('ethTx error:', err.message)
-    }
+//     // send eth example
+//     try {
+//       const ethUnsignedTx = await ethChainAdapter.buildSendTransaction({
+//         to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
+//         value: '1',
+//         wallet,
+//         bip32Params: ethBip32Params
+//       })
+//       const ethSignedTx = await ethChainAdapter.signTransaction({
+//         wallet,
+//         txToSign: ethUnsignedTx.txToSign
+//       })
+//       console.log('ethSignedTx:', ethSignedTx)
+//     } catch (err) {
+//       console.log('ethTx error:', err.message)
+//     }
 
-    // const ethTxID = await ethChainAdapter.broadcastTransaction(ethSignedTx)
-    // console.log('ethTxID:', ethTxID)
+//     // const ethTxID = await ethChainAdapter.broadcastTransaction(ethSignedTx)
+//     // console.log('ethTxID:', ethTxID)
 
-    // send fox example (erc20)
-    try {
-      const erc20UnsignedTx = await ethChainAdapter.buildSendTransaction({
-        to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
-        value: '1',
-        wallet,
-        bip32Params: ethBip32Params,
-        erc20ContractAddress: foxContractAddress
-      })
-      const erc20SignedTx = await ethChainAdapter.signTransaction({
-        wallet,
-        txToSign: erc20UnsignedTx.txToSign
-      })
-      console.log('erc20SignedTx:', erc20SignedTx)
-    } catch (err) {
-      console.log('erc20Tx error:', err.message)
-    }
+//     // send fox example (erc20)
+//     try {
+//       const erc20UnsignedTx = await ethChainAdapter.buildSendTransaction({
+//         to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
+//         value: '1',
+//         wallet,
+//         bip32Params: ethBip32Params,
+//         erc20ContractAddress: foxContractAddress
+//       })
+//       const erc20SignedTx = await ethChainAdapter.signTransaction({
+//         wallet,
+//         txToSign: erc20UnsignedTx.txToSign
+//       })
+//       console.log('erc20SignedTx:', erc20SignedTx)
+//     } catch (err) {
+//       console.log('erc20Tx error:', err.message)
+//     }
 
-    // const erc20TxID = await ethChainAdapter.broadcastTransaction(erc20SignedTx)
-    // console.log('erc20TxID:', erc20TxID)
-  } catch (err) {
-    console.error(err)
-  }
-}
+//     // const erc20TxID = await ethChainAdapter.broadcastTransaction(erc20SignedTx)
+//     // console.log('erc20TxID:', erc20TxID)
+//   } catch (err) {
+//     console.error(err)
+//   }
+// }
 
-main().then(() => console.log('DONE'))
+// main().then(() => console.log('DONE'))

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,143 +1,143 @@
-// import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
-// import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-// import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
-// import dotenv from 'dotenv'
+import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
+import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
+import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import dotenv from 'dotenv'
 
-// import { ChainAdapterManager } from './ChainAdapterManager'
+import { ChainAdapterManager } from './ChainAdapterManager'
 
-// dotenv.config()
+dotenv.config()
 
-// const foxContractAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+const foxContractAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 
-// const getWallet = async (): Promise<NativeHDWallet> => {
-//   const nativeAdapterArgs: NativeAdapterArgs = {
-//     mnemonic: process.env.CLI_MNEMONIC,
-//     deviceId: 'test'
-//   }
-//   const wallet = new NativeHDWallet(nativeAdapterArgs)
-//   await wallet.initialize()
+const getWallet = async (): Promise<NativeHDWallet> => {
+  const nativeAdapterArgs: NativeAdapterArgs = {
+    mnemonic: process.env.CLI_MNEMONIC,
+    deviceId: 'test'
+  }
+  const wallet = new NativeHDWallet(nativeAdapterArgs)
+  await wallet.initialize()
 
-//   return wallet
-// }
+  return wallet
+}
 
-// const unchainedUrls = {
-//   [ChainTypes.Bitcoin]: {
-//     httpUrl: 'https://api.bitcoin.shapeshift.com',
-//     wsUrl: 'wss://api.bitcoin.shapeshift.com'
-//   },
-//   [ChainTypes.Ethereum]: {
-//     httpUrl: 'https://api.ethereum.shapeshift.com',
-//     wsUrl: 'wss://api.ethereum.shapeshift.com'
-//   }
-// }
+const unchainedUrls = {
+  [ChainTypes.Bitcoin]: {
+    httpUrl: 'https://api.bitcoin.shapeshift.com',
+    wsUrl: 'wss://api.bitcoin.shapeshift.com'
+  },
+  [ChainTypes.Ethereum]: {
+    httpUrl: 'https://api.ethereum.shapeshift.com',
+    wsUrl: 'wss://api.ethereum.shapeshift.com'
+  }
+}
 
-// const main = async () => {
-//   try {
-//     const chainAdapterManager = new ChainAdapterManager(unchainedUrls)
-//     const wallet = await getWallet()
+const main = async () => {
+  try {
+    const chainAdapterManager = new ChainAdapterManager(unchainedUrls)
+    const wallet = await getWallet()
 
-//     /** BITCOIN CLI */
-//     const btcChainAdapter = chainAdapterManager.byChain(ChainTypes.Bitcoin)
-//     const btcBip32Params: BIP32Params = {
-//       purpose: 84,
-//       coinType: 0,
-//       accountNumber: 0,
-//       isChange: false,
-//       index: 10
-//     }
+    /** BITCOIN CLI */
+    const btcChainAdapter = chainAdapterManager.byChain(ChainTypes.Bitcoin)
+    const btcBip32Params: BIP32Params = {
+      purpose: 84,
+      coinType: 0,
+      accountNumber: 0,
+      isChange: false,
+      index: 10
+    }
 
-//     const btcAddress = await btcChainAdapter.getAddress({
-//       wallet,
-//       bip32Params: btcBip32Params,
-//       scriptType: BTCInputScriptType.SpendWitness
-//     })
-//     console.log('btcAddress:', btcAddress)
+    const btcAddress = await btcChainAdapter.getAddress({
+      wallet,
+      bip32Params: btcBip32Params,
+      scriptType: BTCInputScriptType.SpendWitness
+    })
+    console.log('btcAddress:', btcAddress)
 
-//     const btcAccount = await btcChainAdapter.getAccount(btcAddress)
-//     console.log('btcAccount:', btcAccount)
+    const btcAccount = await btcChainAdapter.getAccount(btcAddress)
+    console.log('btcAccount:', btcAccount)
 
-//     const txInput = {
-//       asset: { id: '123', symbol: 'BTC' },
-//       recipients: [{ address: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4', value: 400 }],
-//       wallet,
-//       opReturnData: 'sup fool',
-//       bip32Params: btcBip32Params,
-//       feeSpeed: chainAdapters.FeeDataKey.Slow
-//     }
+    const txInput = {
+      to: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
+      value: '400',
+      wallet,
+      bip32Params: btcBip32Params,
+      chainSpecific: { scriptType: BTCInputScriptType.SpendAddress, satoshiPerByte: '4' }
+    }
 
-//     try {
-//       const btcUnsignedTx = await btcChainAdapter.buildSendTransaction(txInput)
-//       const btcSignedTx = await btcChainAdapter.signTransaction({
-//         wallet,
-//         txToSign: btcUnsignedTx.txToSign
-//       })
-//       console.log('btcSignedTx:', btcSignedTx)
-//     } catch (err) {
-//       console.log('btcTx error:', err.message)
-//     }
+    try {
+      const btcUnsignedTx = await btcChainAdapter.buildSendTransaction(txInput)
+      const btcSignedTx = await btcChainAdapter.signTransaction({
+        wallet,
+        txToSign: btcUnsignedTx.txToSign
+      })
+      console.log('btcSignedTx:', btcSignedTx)
+    } catch (err) {
+      console.log('btcTx error:', err.message)
+    }
 
-//     // const btcTxID = await btcChainAdapter.broadcastTransaction(btcSignedTx)
-//     // console.log('btcTxID: ', txid)
+    // const btcTxID = await btcChainAdapter.broadcastTransaction(btcSignedTx)
+    // console.log('btcTxID: ', txid)
 
-//     /** ETHEREUM CLI */
-//     const ethChainAdapter = chainAdapterManager.byChain(ChainTypes.Ethereum)
-//     const ethBip32Params: BIP32Params = { purpose: 44, coinType: 60, accountNumber: 0 }
+    /** ETHEREUM CLI */
+    const ethChainAdapter = chainAdapterManager.byChain(ChainTypes.Ethereum)
+    const ethBip32Params: BIP32Params = { purpose: 44, coinType: 60, accountNumber: 0 }
 
-//     const ethAddress = await ethChainAdapter.getAddress({ wallet, bip32Params: ethBip32Params })
-//     console.log('ethAddress:', ethAddress)
+    const ethAddress = await ethChainAdapter.getAddress({ wallet, bip32Params: ethBip32Params })
+    console.log('ethAddress:', ethAddress)
 
-//     const ethAccount = await ethChainAdapter.getAccount(ethAddress)
-//     console.log('ethAccount:', ethAccount)
+    const ethAccount = await ethChainAdapter.getAccount(ethAddress)
+    console.log('ethAccount:', ethAccount)
 
-//     await ethChainAdapter.subscribeTxs(
-//       { addresses: [ethAddress] },
-//       (msg) => console.log(msg),
-//       (err) => console.log(err)
-//     )
+    await ethChainAdapter.subscribeTxs(
+      { addresses: [ethAddress] },
+      (msg) => console.log(msg),
+      (err) => console.log(err)
+    )
 
-//     // send eth example
-//     try {
-//       const ethUnsignedTx = await ethChainAdapter.buildSendTransaction({
-//         to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
-//         value: '1',
-//         wallet,
-//         bip32Params: ethBip32Params
-//       })
-//       const ethSignedTx = await ethChainAdapter.signTransaction({
-//         wallet,
-//         txToSign: ethUnsignedTx.txToSign
-//       })
-//       console.log('ethSignedTx:', ethSignedTx)
-//     } catch (err) {
-//       console.log('ethTx error:', err.message)
-//     }
+    // send eth example
+    try {
+      const ethUnsignedTx = await ethChainAdapter.buildSendTransaction({
+        to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
+        value: '1',
+        wallet,
+        bip32Params: ethBip32Params,
+        chainSpecific: { fee: '0', gasLimit: '0' }
+      })
+      const ethSignedTx = await ethChainAdapter.signTransaction({
+        wallet,
+        txToSign: ethUnsignedTx.txToSign
+      })
+      console.log('ethSignedTx:', ethSignedTx)
+    } catch (err) {
+      console.log('ethTx error:', err.message)
+    }
 
-//     // const ethTxID = await ethChainAdapter.broadcastTransaction(ethSignedTx)
-//     // console.log('ethTxID:', ethTxID)
+    // const ethTxID = await ethChainAdapter.broadcastTransaction(ethSignedTx)
+    // console.log('ethTxID:', ethTxID)
 
-//     // send fox example (erc20)
-//     try {
-//       const erc20UnsignedTx = await ethChainAdapter.buildSendTransaction({
-//         to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
-//         value: '1',
-//         wallet,
-//         bip32Params: ethBip32Params,
-//         erc20ContractAddress: foxContractAddress
-//       })
-//       const erc20SignedTx = await ethChainAdapter.signTransaction({
-//         wallet,
-//         txToSign: erc20UnsignedTx.txToSign
-//       })
-//       console.log('erc20SignedTx:', erc20SignedTx)
-//     } catch (err) {
-//       console.log('erc20Tx error:', err.message)
-//     }
+    // send fox example (erc20)
+    try {
+      const erc20UnsignedTx = await ethChainAdapter.buildSendTransaction({
+        to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
+        value: '1',
+        wallet,
+        bip32Params: ethBip32Params,
+        chainSpecific: { fee: '0', gasLimit: '0', erc20ContractAddress: foxContractAddress }
+      })
+      const erc20SignedTx = await ethChainAdapter.signTransaction({
+        wallet,
+        txToSign: erc20UnsignedTx.txToSign
+      })
+      console.log('erc20SignedTx:', erc20SignedTx)
+    } catch (err) {
+      console.log('erc20Tx error:', err.message)
+    }
 
-//     // const erc20TxID = await ethChainAdapter.broadcastTransaction(erc20SignedTx)
-//     // console.log('erc20TxID:', erc20TxID)
-//   } catch (err) {
-//     console.error(err)
-//   }
-// }
+    // const erc20TxID = await ethChainAdapter.broadcastTransaction(erc20SignedTx)
+    // console.log('erc20TxID:', erc20TxID)
+  } catch (err) {
+    console.error(err)
+  }
+}
 
-// main().then(() => console.log('DONE'))
+main().then(() => console.log('DONE'))

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -14,7 +14,7 @@ export interface ChainAdapter<T extends ChainTypes> {
   getTxHistory(input: chainAdapters.TxHistoryInput): Promise<chainAdapters.TxHistoryResponse<T>>
 
   buildSendTransaction(
-    input: chainAdapters.BuildSendTxInput
+    input: chainAdapters.BuildSendTxInput<T>
   ): Promise<{
     txToSign: chainAdapters.ChainTxType<T>
   }>

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -275,13 +275,16 @@ describe('BitcoinChainAdapter', () => {
         isChange: false
       }
 
-      const txInput: chainAdapters.BuildSendTxInput = {
+      const txInput: chainAdapters.BuildSendTxInput<ChainTypes.Bitcoin> = {
         bip32Params,
         to: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
         value: '400',
         wallet,
-        opReturnData: 'nm, u',
-        feeSpeed: chainAdapters.FeeDataKey.Slow
+        chainSpecific: {
+          opReturnData: 'nm, u',
+          scriptType: BTCInputScriptType.SpendWitness,
+          satoshiPerByte: '1'
+        }
       }
 
       await expect(adapter.buildSendTransaction(txInput)).resolves.toStrictEqual({
@@ -341,13 +344,16 @@ describe('BitcoinChainAdapter', () => {
         isChange: false
       }
 
-      const txInput: chainAdapters.BuildSendTxInput = {
+      const txInput: chainAdapters.BuildSendTxInput<ChainTypes.Bitcoin> = {
         bip32Params,
         to: 'bc1qppzsgs9pt63cx9x994wf4e3qrpta0nm6htk9v4',
         value: '400',
         wallet,
-        opReturnData: 'sup fool',
-        feeSpeed: chainAdapters.FeeDataKey.Slow
+        chainSpecific: {
+          opReturnData: 'sup fool',
+          scriptType: BTCInputScriptType.SpendWitness,
+          satoshiPerByte: '1'
+        }
       }
 
       const unsignedTx = await adapter.buildSendTransaction(txInput)

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -132,7 +132,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         to,
         wallet,
         bip32Params = ChainAdapter.defaultBIP32Params,
-        chainSpecific: { satoshiPerByte, opReturnData, scriptType }
+        chainSpecific: { satoshiPerByte, scriptType }
       } = tx
 
       if (!value || !to) {

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -122,7 +122,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
   }
 
   async buildSendTransaction(
-    tx: chainAdapters.BuildSendTxInput
+    tx: chainAdapters.BuildSendTxInput<ChainTypes.Bitcoin>
   ): Promise<{
     txToSign: chainAdapters.ChainTxType<ChainTypes.Bitcoin>
   }> {
@@ -132,8 +132,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         to,
         wallet,
         bip32Params = ChainAdapter.defaultBIP32Params,
-        feeSpeed,
-        scriptType = BTCInputScriptType.SpendWitness
+        chainSpecific: { satoshiPerByte, opReturnData, scriptType }
       } = tx
 
       if (!value || !to) {
@@ -164,8 +163,6 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
       if (!from) throw new Error('BitcoinChainAdapter: from undefined')
 
       const account = await this.getAccount(pubkey.xpub)
-      const estimatedFees = await this.getFeeData({ to, value, from })
-      const satoshiPerByte = estimatedFees[feeSpeed ?? chainAdapters.FeeDataKey.Average].feePerUnit
 
       type MappedUtxos = Omit<bitcoin.api.Utxo, 'value'> & { value: number }
       const mappedUtxos: MappedUtxos[] = utxos.map((x) => ({ ...x, value: Number(x.value) }))

--- a/packages/swapper/src/swappers/zrx/executeQuote/executeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/executeQuote/executeQuote.ts
@@ -43,8 +43,10 @@ export async function executeQuote(
       value,
       wallet,
       to: quote.depositAddress,
-      fee: numberToHex(quote.feeData?.chainSpecific?.gasPrice || 0),
-      gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0),
+      chainSpecific: {
+        fee: numberToHex(quote.feeData?.chainSpecific?.gasPrice || 0),
+        gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0)
+      },
       bip32Params
     })
   } catch (error) {

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -137,12 +137,14 @@ export const grantAllowance = async ({
   try {
     const { txToSign } = await adapter.buildSendTransaction({
       wallet,
-      erc20ContractAddress: quote.sellAsset.tokenId,
       to: quote.sellAsset.tokenId,
-      fee: numberToHex(quote.feeData?.chainSpecific?.gasPrice || 0),
-      gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0),
       bip32Params,
-      value: '0'
+      value: '0',
+      chainSpecific: {
+        erc20ContractAddress: quote.sellAsset.tokenId,
+        fee: numberToHex(quote.feeData?.chainSpecific?.gasPrice || 0),
+        gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0)
+      }
     })
 
     grantAllowanceTxToSign = {

--- a/packages/types/src/chain-adapters/bitcoin.ts
+++ b/packages/types/src/chain-adapters/bitcoin.ts
@@ -69,3 +69,9 @@ export type FeeData = {
   feePerTx: string
   byteCount: string
 }
+
+export type BuildTxInput = {
+  opReturnData?: string
+  scriptType: BTCInputScriptType
+  satoshiPerByte: string
+}

--- a/packages/types/src/chain-adapters/ethereum.ts
+++ b/packages/types/src/chain-adapters/ethereum.ts
@@ -44,3 +44,9 @@ export type QuoteFeeData = {
    */
   totalFee?: string
 }
+
+export type BuildTxInput = {
+  fee: string
+  gasLimit: string
+  erc20ContractAddress?: string
+}

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -1,4 +1,4 @@
-import { BTCInputScriptType, BTCSignTx, ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { BTCSignTx, ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 
 import { BIP32Params, ChainTypes, NetworkTypes, SwapperType } from '../base'
 import { ChainAndSwapperSpecific, ChainSpecific } from '../utility'
@@ -160,21 +160,6 @@ type ChainTxTypeInner = {
 }
 
 export type ChainTxType<T> = T extends keyof ChainTxTypeInner ? ChainTxTypeInner[T] : never
-
-// export type BuildSendTxInput = {
-//   to?: string
-//   value?: string
-//   wallet: HDWallet
-//   /** In base units **/
-//   fee?: string
-//   /** Optional param for eth txs indicating what ERC20 is being sent **/
-//   erc20ContractAddress?: string
-//   opReturnData?: string
-//   scriptType?: BTCInputScriptType
-//   gasLimit?: string
-//   bip32Params?: BIP32Params
-//   feeSpeed?: FeeDataKey
-// }
 
 export type BuildSendTxInput<T extends ChainTypes> = {
   to: string

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -161,21 +161,35 @@ type ChainTxTypeInner = {
 
 export type ChainTxType<T> = T extends keyof ChainTxTypeInner ? ChainTxTypeInner[T] : never
 
-export type BuildSendTxInput = {
-  to?: string
-  value?: string
+// export type BuildSendTxInput = {
+//   to?: string
+//   value?: string
+//   wallet: HDWallet
+//   /** In base units **/
+//   fee?: string
+//   /** Optional param for eth txs indicating what ERC20 is being sent **/
+//   erc20ContractAddress?: string
+//   opReturnData?: string
+//   scriptType?: BTCInputScriptType
+//   gasLimit?: string
+//   bip32Params?: BIP32Params
+//   feeSpeed?: FeeDataKey
+// }
+
+export type BuildSendTxInput<T extends ChainTypes> = {
+  to: string
+  value: string
   wallet: HDWallet
-  /** In base units **/
-  fee?: string
-  /** Optional param for eth txs indicating what ERC20 is being sent **/
-  erc20ContractAddress?: string
-  recipients?: Array<bitcoin.Recipient>
-  opReturnData?: string
-  scriptType?: BTCInputScriptType
-  gasLimit?: string
-  bip32Params?: BIP32Params
-  feeSpeed?: FeeDataKey
-}
+  bip32Params?: BIP32Params // TODO maybe these shouldnt be optional
+} & ChainSpecificBuildTxData<T>
+
+type ChainSpecificBuildTxData<T> = ChainSpecific<
+  T,
+  {
+    [ChainTypes.Ethereum]: ethereum.BuildTxInput
+    [ChainTypes.Bitcoin]: bitcoin.BuildTxInput
+  }
+>
 
 export type SignTxInput<TxType> = {
   txToSign: TxType


### PR DESCRIPTION
- Make buildSendTxInput generic with different eth and btc chainSpecific fields
- Pass satoshiPerByte into btc buildSendTx instead of deriving in it (so there is never a difference between what user is told vs what fee it sends with)
- make gas fee and gasLimit required for eth instead of calling getFeeData in buildSendTx

This moves us further towards doing fees correctly: https://github.com/shapeshift/web/issues/215