### PR TITLE
feat: add getSendMaxAmount to swapper

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/caip": "^1.2.2",
-    "@shapeshiftoss/types": "^1.11.2",
+    "@shapeshiftoss/types": "^1.11.3",
     "axios": "^0.24.0",
     "lodash": "^4.17.21"
   },

--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -25,7 +25,7 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@shapeshiftoss/types": "^1.11.2"
+    "@shapeshiftoss/types": "^1.11.3"
   },
   "devDependencies": {
     "axios": "^0.24.0"

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/hdwallet-core": "^1.17.1",
-    "@shapeshiftoss/types": "^1.11.2",
+    "@shapeshiftoss/types": "^1.11.3",
     "@shapeshiftoss/unchained-client": "^3.3.0",
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.1",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/caip": "^1.2.0",
-    "@shapeshiftoss/types": "^1.11.2",
+    "@shapeshiftoss/types": "^1.11.3",
     "axios": "^0.21.2",
     "dayjs": "^1.10.6"
   }

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@shapeshiftoss/chain-adapters": "^1.13.4",
     "@shapeshiftoss/hdwallet-core": "^1.17.1",
-    "@shapeshiftoss/types": "^1.11.2",
+    "@shapeshiftoss/types": "^1.11.3",
     "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",
     "retry-axios": "^2.6.0",

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -11,12 +11,9 @@ import {
   GetQuoteInput,
   MinMaxOutput,
   Quote,
+  SendMaxAmountInput,
   SwapperType
 } from '@shapeshiftoss/types'
-
-// TODO:(ryankk) import from types packages
-import { SendMaxAmountInput } from './swappers/zrx/ZrxSwapper'
-
 
 export class SwapError extends Error {}
 

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -14,6 +14,10 @@ import {
   SwapperType
 } from '@shapeshiftoss/types'
 
+// TODO:(ryankk) import from types packages
+import { SendMaxAmountInput } from './swappers/zrx/ZrxSwapper'
+
+
 export class SwapError extends Error {}
 
 export interface Swapper {
@@ -69,4 +73,9 @@ export interface Swapper {
    * Get the txid of an approve infinite transaction
    */
   approveInfinite(args: ApproveInfiniteInput<ChainTypes, SwapperType>): Promise<string>
+
+  /**
+   * Get max swap balance (minus fees) for sell asset
+   */
+  getSendMaxAmount(args: SendMaxAmountInput): Promise<string>
 }

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -59,4 +59,8 @@ export class ThorchainSwapper implements Swapper {
   async approveInfinite(): Promise<string> {
     throw new Error('ThorchainSwapper: approveInfinite unimplemented')
   }
+
+  async getSendMaxAmount(): Promise<string> {
+    throw new Error('ThorchainSwapper: getSendMaxAmount unimplemented')
+  }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -1,6 +1,6 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { ChainTypes, GetQuoteInput, Quote, SwapperType } from '@shapeshiftoss/types'
+import { ChainTypes, GetQuoteInput, Quote, SwapperType, chainAdapters } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import { ZrxError } from '../..'
@@ -11,6 +11,7 @@ import { approvalNeeded } from './approvalNeeded/approvalNeeded'
 import { approveInfinite } from './approveInfinite/approveInfinite'
 import { getMinMax } from './getMinMax/getMinMax'
 import { getZrxQuote } from './getQuote/getQuote'
+import { getSendMaxAmount } from './getSendMaxAmount/getSendMaxAmount'
 import { getUsdRate } from './utils/helpers/helpers'
 import { BTC, FOX, WETH } from './utils/test-data/assets'
 import { setupQuote } from './utils/test-data/setupSwapQuote'
@@ -38,6 +39,10 @@ jest.mock('./approvalNeeded/approvalNeeded', () => ({
 
 jest.mock('./approveInfinite/approveInfinite', () => ({
   approveInfinite: jest.fn()
+}))
+
+jest.mock('./getSendMaxAmount/getSendMaxAmount', () => ({
+  getSendMaxAmount: jest.fn()
 }))
 
 describe('ZrxSwapper', () => {
@@ -124,5 +129,17 @@ describe('ZrxSwapper', () => {
     const args = { quote, wallet }
     await swapper.approveInfinite(args)
     expect(approveInfinite).toHaveBeenCalled()
+  })
+
+  it('calls getSendMaxAmount on swapper.getSendMaxAmount', async () => {
+    const swapper = new ZrxSwapper(zrxSwapperDeps)
+    const args = {
+      quote,
+      wallet,
+      sellAssetAccountId: '0',
+      feeEstimateKey: chainAdapters.FeeDataKey.Average
+    }
+    await swapper.getSendMaxAmount(args)
+    expect(getSendMaxAmount).toHaveBeenCalled()
   })
 })

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -1,6 +1,6 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { ChainTypes, GetQuoteInput, Quote, SwapperType, chainAdapters } from '@shapeshiftoss/types'
+import { chainAdapters, ChainTypes, GetQuoteInput, Quote, SwapperType } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import { ZrxError } from '../..'

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -32,7 +32,7 @@ export type SendMaxAmountInput = {
   wallet: HDWallet
   quote: Quote<ChainTypes, SwapperType>
   sellAssetAccountId: string
-  feeEstimateKey: chainAdapters.FeeDataKey
+  feeEstimateKey?: chainAdapters.FeeDataKey
 }
 
 export type ZrxSwapperDeps = {

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -11,8 +11,8 @@ import {
   GetQuoteInput,
   MinMaxOutput,
   Quote,
-  SwapperType,
-  chainAdapters
+  SendMaxAmountInput,
+  SwapperType
 } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
@@ -23,18 +23,8 @@ import { buildQuoteTx } from './buildQuoteTx/buildQuoteTx'
 import { executeQuote } from './executeQuote/executeQuote'
 import { getMinMax } from './getMinMax/getMinMax'
 import { getZrxQuote } from './getQuote/getQuote'
-import { getUsdRate } from './utils/helpers/helpers'
 import { getSendMaxAmount } from './getSendMaxAmount/getSendMaxAmount'
-
-// TODO:(ryankk) move HDWallet import and SendMaxAmountInput into '@shapeshiftoss/types'
-import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-export type SendMaxAmountInput = {
-  wallet: HDWallet
-  quote: Quote<ChainTypes, SwapperType>
-  sellAssetAccountId: string
-  feeEstimateKey?: chainAdapters.FeeDataKey
-}
-
+import { getUsdRate } from './utils/helpers/helpers'
 export type ZrxSwapperDeps = {
   adapterManager: ChainAdapterManager
   web3: Web3

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -11,7 +11,8 @@ import {
   GetQuoteInput,
   MinMaxOutput,
   Quote,
-  SwapperType
+  SwapperType,
+  chainAdapters
 } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
@@ -23,6 +24,16 @@ import { executeQuote } from './executeQuote/executeQuote'
 import { getMinMax } from './getMinMax/getMinMax'
 import { getZrxQuote } from './getQuote/getQuote'
 import { getUsdRate } from './utils/helpers/helpers'
+import { getSendMaxAmount } from './getSendMaxAmount/getSendMaxAmount'
+
+// TODO:(ryankk) move HDWallet import and SendMaxAmountInput into '@shapeshiftoss/types'
+import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+export type SendMaxAmountInput = {
+  wallet: HDWallet
+  quote: Quote<ChainTypes, SwapperType>
+  sellAssetAccountId: string
+  feeEstimateKey: chainAdapters.FeeDataKey
+}
 
 export type ZrxSwapperDeps = {
   adapterManager: ChainAdapterManager
@@ -91,5 +102,9 @@ export class ZrxSwapper implements Swapper {
 
   async approveInfinite(args: ApproveInfiniteInput<ChainTypes, SwapperType>): Promise<string> {
     return approveInfinite(this.deps, args)
+  }
+
+  getSendMaxAmount(args: SendMaxAmountInput): Promise<string> {
+    return getSendMaxAmount(this.deps, args)
   }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -104,7 +104,7 @@ export class ZrxSwapper implements Swapper {
     return approveInfinite(this.deps, args)
   }
 
-  getSendMaxAmount(args: SendMaxAmountInput): Promise<string> {
+  async getSendMaxAmount(args: SendMaxAmountInput): Promise<string> {
     return getSendMaxAmount(this.deps, args)
   }
 }

--- a/packages/swapper/src/swappers/zrx/approvalNeeded/approvalNeeded.test.ts
+++ b/packages/swapper/src/swappers/zrx/approvalNeeded/approvalNeeded.test.ts
@@ -1,10 +1,10 @@
-import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { ChainTypes } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import { APPROVAL_GAS_LIMIT } from '../utils/constants'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
+import { setupZrxDeps } from '../utils/test-data/setupZrxDeps'
 import { zrxService } from '../utils/zrxService'
 import { approvalNeeded } from './approvalNeeded'
 
@@ -28,23 +28,8 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-const setup = () => {
-  const unchainedUrls = {
-    [ChainTypes.Ethereum]: {
-      httpUrl: 'http://localhost:31300',
-      wsUrl: 'ws://localhost:31300'
-    }
-  }
-  const ethNodeUrl = 'http://localhost:1000'
-  const adapterManager = new ChainAdapterManager(unchainedUrls)
-  const web3Provider = new Web3.providers.HttpProvider(ethNodeUrl)
-  const web3 = new Web3(web3Provider)
-
-  return { web3, adapterManager }
-}
-
 describe('approvalNeeded', () => {
-  const { web3, adapterManager } = setup()
+  const { web3Instance: web3, adapterManager } = setupZrxDeps()
   const args = { web3, adapterManager }
   const walletAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   const wallet = ({

--- a/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
@@ -15,7 +15,7 @@ export async function approveInfinite(
 ) {
   const adapter: ChainAdapter<ChainTypes.Ethereum> = adapterManager.byChain(ChainTypes.Ethereum)
   const bip32Params = adapter.buildBIP32Params({
-    accountNumber: Number(quote.sellAssetAccountId || quote.sellAssetAccountId) || 0
+    accountNumber: quote.sellAssetAccountId ? Number(quote.sellAssetAccountId) : 0
   }) // TODO: Add account number
   const receiveAddress = await adapter.getAddress({ wallet, bip32Params })
 

--- a/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
@@ -8,6 +8,7 @@ import { AFFILIATE_ADDRESS, DEFAULT_SLIPPAGE, MAX_ALLOWANCE } from '../utils/con
 import { grantAllowance } from '../utils/helpers/helpers'
 import { zrxService } from '../utils/zrxService'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
+import { bnOrZero } from '../utils/bignumber'
 
 export async function approveInfinite(
   { adapterManager, web3 }: ZrxSwapperDeps,
@@ -15,7 +16,7 @@ export async function approveInfinite(
 ) {
   const adapter: ChainAdapter<ChainTypes.Ethereum> = adapterManager.byChain(ChainTypes.Ethereum)
   const bip32Params = adapter.buildBIP32Params({
-    accountNumber: quote.sellAssetAccountId ? Number(quote.sellAssetAccountId) : 0
+    accountNumber: bnOrZero(quote.sellAssetAccountId).toNumber()
   }) // TODO: Add account number
   const receiveAddress = await adapter.getAddress({ wallet, bip32Params })
 

--- a/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/approveInfinite/approveInfinite.ts
@@ -4,11 +4,11 @@ import { AxiosResponse } from 'axios'
 
 import { SwapError } from '../../../api'
 import { erc20Abi } from '../utils/abi/erc20-abi'
+import { bnOrZero } from '../utils/bignumber'
 import { AFFILIATE_ADDRESS, DEFAULT_SLIPPAGE, MAX_ALLOWANCE } from '../utils/constants'
 import { grantAllowance } from '../utils/helpers/helpers'
 import { zrxService } from '../utils/zrxService'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
-import { bnOrZero } from '../utils/bignumber'
 
 export async function approveInfinite(
   { adapterManager, web3 }: ZrxSwapperDeps,

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -9,7 +9,7 @@ import { getSendMaxAmount } from './getSendMaxAmount'
 describe('getSendMaxAmount', () => {
   const { web3Instance, adapterManager } = setupZrxDeps()
   const { quoteInput: quote } = setupQuote()
-  const deps = { web3Instance, adapterManager }
+  const deps = { web3: web3Instance, adapterManager }
   const wallet = ({
     ethGetAddress: jest.fn(() => Promise.resolve('0xc770eefad204b5180df6a14ee197d99d808ee52d')),
     ethSignTx: jest.fn(() => Promise.resolve({}))

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -56,7 +56,7 @@ describe('getSendMaxAmount', () => {
 
   it('should throw an error if ETH balance is less than the estimated fee', async () => {
     const ethBalance = '100'
-    const feePerTx = '1000'
+    const txFee = '1000'
     const args = {
       quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
       wallet,
@@ -71,7 +71,7 @@ describe('getSendMaxAmount', () => {
       ),
       getFeeData: jest.fn(() =>
         Promise.resolve({
-          [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx } }
+          [chainAdapters.FeeDataKey.Average]: { txFee }
         })
       )
     })
@@ -102,7 +102,7 @@ describe('getSendMaxAmount', () => {
 
   it('should return max ETH balance in wei (balance minus txFee)', async () => {
     const ethBalance = '1000'
-    const feePerTx = '100'
+    const txFee = '100'
     const args = {
       quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
       wallet,
@@ -117,19 +117,19 @@ describe('getSendMaxAmount', () => {
       ),
       getFeeData: jest.fn(() =>
         Promise.resolve({
-          [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx } }
+          [chainAdapters.FeeDataKey.Average]: { txFee }
         })
       )
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(
-      new BigNumber(ethBalance).minus(feePerTx).toString()
+      new BigNumber(ethBalance).minus(txFee).toString()
     )
   })
 
   it('should return max ETH balance in wei (balance minus txFee) with correct fee data key', async () => {
     const ethBalance = '1000'
-    const feePerTx = '500'
+    const txFee = '500'
     const args = {
       quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
       wallet,
@@ -145,13 +145,13 @@ describe('getSendMaxAmount', () => {
       ),
       getFeeData: jest.fn(() =>
         Promise.resolve({
-          [chainAdapters.FeeDataKey.Fast]: { chainSpecific: { feePerTx } }
+          [chainAdapters.FeeDataKey.Fast]: { txFee }
         })
       )
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(
-      new BigNumber(ethBalance).minus(feePerTx).toString()
+      new BigNumber(ethBalance).minus(txFee).toString()
     )
   })
 })

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -1,0 +1,5 @@
+describe('getSendMaxAmount', () => {
+  it('is truthy', () => {
+    expect(true).toBeTruthy()
+  })
+})

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -1,9 +1,10 @@
-import BigNumber from 'bignumber.js'
-import { chainAdapters } from '@shapeshiftoss/types'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { getSendMaxAmount } from './getSendMaxAmount'
-import { setupZrxDeps, chainAdapterMockFuncs } from '../utils/test-data/setupZrxDeps'
+import { chainAdapters } from '@shapeshiftoss/types'
+import BigNumber from 'bignumber.js'
+
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
+import { chainAdapterMockFuncs, setupZrxDeps } from '../utils/test-data/setupZrxDeps'
+import { getSendMaxAmount } from './getSendMaxAmount'
 
 describe('getSendMaxAmount', () => {
   const { web3Instance, adapterManager } = setupZrxDeps()

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -1,5 +1,95 @@
+import BigNumber from 'bignumber.js'
+import { chainAdapters } from '@shapeshiftoss/types'
+import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { getSendMaxAmount } from './getSendMaxAmount'
+import { setupZrxDeps, chainAdapterMockFuncs } from '../utils/test-data/setupZrxDeps'
+import { setupQuote } from '../utils/test-data/setupSwapQuote'
+
 describe('getSendMaxAmount', () => {
-  it('is truthy', () => {
-    expect(true).toBeTruthy()
+  const { web3Instance, adapterManager } = setupZrxDeps()
+  const { quoteInput: quote } = setupQuote()
+  const deps = { web3Instance, adapterManager }
+  const wallet = ({
+    ethGetAddress: jest.fn(() => Promise.resolve('0xc770eefad204b5180df6a14ee197d99d808ee52d')),
+    ethSignTx: jest.fn(() => Promise.resolve({}))
+  } as unknown) as HDWallet
+
+  it('should throw an error if no asset balance is found', async () => {
+    const balance = '1000'
+    const args = {
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: 'notFound' } },
+      wallet,
+      sellAssetAccountId: quote.sellAssetAccountId,
+      feeEstimateKey: chainAdapters.FeeDataKey.Average
+    }
+    ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
+      ...chainAdapterMockFuncs,
+      getAccount: jest.fn(() =>
+        Promise.resolve({
+          chainSpecific: { tokens: [{ contract: 'contractAddress', balance }] }
+        })
+      )
+    })
+
+    await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
+      `No balance found for ${quote.sellAsset.symbol}`
+    )
   })
+
+  it('should throw an error if no asset balance is found', async () => {
+    const balance = '1000'
+    const feePerTx = '100'
+    const args = {
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: 'notFound' } },
+      wallet,
+      sellAssetAccountId: quote.sellAssetAccountId,
+      feeEstimateKey: chainAdapters.FeeDataKey.Average
+    }
+    ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
+      ...chainAdapterMockFuncs,
+      getAccount: jest.fn(() =>
+        Promise.resolve({
+          chainSpecific: { tokens: [{ contract: 'contractAddress', balance }] }
+        })
+      ),
+      getFeeData: jest.fn(() =>
+        Promise.resolve({
+          [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx } }
+        })
+      )
+    })
+
+    await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
+      `No balance found for ${quote.sellAsset.symbol}`
+    )
+  })
+
+  it('should throw an error if ETH balance is less than the estimated fee', async () => {
+    const balance = '100'
+    const feePerTx = '1000'
+    const args = {
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: 'contractAddress' } },
+      wallet,
+      sellAssetAccountId: quote.sellAssetAccountId,
+      feeEstimateKey: chainAdapters.FeeDataKey.Average
+    }
+    ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
+      ...chainAdapterMockFuncs,
+      getAccount: jest.fn(() =>
+        Promise.resolve({
+          chainSpecific: { tokens: [{ contract: 'contractAddress', balance }] }
+        })
+      ),
+      getFeeData: jest.fn(() =>
+        Promise.resolve({
+          [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx } }
+        })
+      )
+    })
+
+    await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
+      'ETH balance is less than estimated fee'
+    )
+  })
+
 })

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -100,7 +100,7 @@ describe('getSendMaxAmount', () => {
     expect(await getSendMaxAmount(deps, args)).toEqual(erc20Balance)
   })
 
-  it('should return max ETH balance (balance minus txFee)', async () => {
+  it('should return max ETH balance in wei (balance minus txFee)', async () => {
     const ethBalance = '1000'
     const feePerTx = '100'
     const args = {
@@ -127,7 +127,7 @@ describe('getSendMaxAmount', () => {
     )
   })
 
-  it('should return max ETH balance (balance minus txFee) with correct fee data key', async () => {
+  it('should return max ETH balance in wei (balance minus txFee) with correct fee data key', async () => {
     const ethBalance = '1000'
     const feePerTx = '500'
     const args = {

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -2,8 +2,8 @@ import { chainAdapters, ChainTypes, SendMaxAmountInput } from '@shapeshiftoss/ty
 import BigNumber from 'bignumber.js'
 
 import { SwapError } from '../../../api'
-import { ZrxSwapperDeps } from '../ZrxSwapper'
 import { bnOrZero } from '../utils/bignumber'
+import { ZrxSwapperDeps } from '../ZrxSwapper'
 
 export async function getSendMaxAmount(
   { adapterManager }: ZrxSwapperDeps,

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -23,7 +23,8 @@ export async function getSendMaxAmount(
   let balance: string | undefined
   if (tokenId) {
     balance = account.chainSpecific.tokens?.find(
-      (token) => token.contract.toLowerCase() === tokenId.toLowerCase()
+      (token: chainAdapters.ethereum.TokenWithBalance) =>
+        token.contract.toLowerCase() === tokenId.toLowerCase()
     )?.balance
   } else {
     balance = account.balance

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -50,7 +50,7 @@ export async function getSendMaxAmount(
 
   const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
 
-  if (!sendMaxAmount.gt(0)) {
+  if (sendMaxAmount.lt(0)) {
     throw new SwapError('ETH balance is less than estimated fee')
   }
 

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js'
 
 import { SwapError } from '../../../api'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
+import { bnOrZero } from '../utils/bignumber'
 
 export async function getSendMaxAmount(
   { adapterManager }: ZrxSwapperDeps,
@@ -14,7 +15,9 @@ export async function getSendMaxAmount(
   }: SendMaxAmountInput
 ): Promise<string> {
   const adapter = adapterManager.byChain(ChainTypes.Ethereum)
-  const bip32Params = adapter.buildBIP32Params({ accountNumber: Number(sellAssetAccountId) })
+  const bip32Params = adapter.buildBIP32Params({
+    accountNumber: bnOrZero(sellAssetAccountId).toNumber()
+  })
   const ethAddress = await adapter.getAddress({ wallet, bip32Params })
 
   const account = await adapter.getAccount(ethAddress)

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -39,17 +39,12 @@ export async function getSendMaxAmount(
     return balance
   }
 
-  let feeEstimates
-  try {
-    feeEstimates = await adapter.getFeeData({
-      to: quote.depositAddress,
-      from: ethAddress,
-      value: balance,
-      contractAddress: tokenId
-    })
-  } catch (err) {
-    throw new SwapError(`getSendMaxAmount:getFeeData - ${err}`)
-  }
+  const feeEstimates = await adapter.getFeeData({
+    to: quote.depositAddress,
+    from: ethAddress,
+    value: balance,
+    contractAddress: tokenId
+  })
 
   const estimatedFee = feeEstimates[feeEstimateKey].chainSpecific.feePerTx
 

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -41,12 +41,14 @@ export async function getSendMaxAmount(
 
   const feeEstimates = await adapter.getFeeData({
     to: quote.depositAddress,
-    from: ethAddress,
     value: balance,
-    contractAddress: tokenId
+    chainSpecific: {
+      from: ethAddress,
+      contractAddress: tokenId
+    }
   })
 
-  const estimatedFee = feeEstimates[feeEstimateKey].chainSpecific.feePerTx
+  const estimatedFee = feeEstimates[feeEstimateKey].txFee
 
   const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
 

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -1,16 +1,11 @@
+import { chainAdapters, ChainTypes, SendMaxAmountInput } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
-import { ChainTypes, chainAdapters } from '@shapeshiftoss/types'
-import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import { SendMaxAmountInput } from '../ZrxSwapper'
-import { SwapError } from '../../../api'
 
-// TODO:(ryankk) move type into types package
-type SendMaxAmountDeps = {
-  adapterManager: ChainAdapterManager
-}
+import { SwapError } from '../../../api'
+import { ZrxSwapperDeps } from '../ZrxSwapper'
 
 export async function getSendMaxAmount(
-  { adapterManager }: SendMaxAmountDeps,
+  { adapterManager }: ZrxSwapperDeps,
   {
     wallet,
     quote,
@@ -35,7 +30,7 @@ export async function getSendMaxAmount(
   }
 
   if (!balance) {
-    throw new Error(`No balance found for ${ tokenId ? quote.sellAsset.symbol : 'ETH'}`)
+    throw new SwapError(`No balance found for ${tokenId ? quote.sellAsset.symbol : 'ETH'}`)
   }
 
   // return the erc20 token balance. No need to subtract the fee.
@@ -52,7 +47,7 @@ export async function getSendMaxAmount(
       contractAddress: tokenId
     })
   } catch (err) {
-    throw new Error(`getSendMaxAmount:getFeeData - ${err}`)
+    throw new SwapError(`getSendMaxAmount:getFeeData - ${err}`)
   }
 
   const estimatedFee = feeEstimates[feeEstimateKey].chainSpecific.feePerTx
@@ -60,7 +55,7 @@ export async function getSendMaxAmount(
   const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
 
   if (!sendMaxAmount.gt(0)) {
-    throw new Error('ETH balance is less than estimated fee')
+    throw new SwapError('ETH balance is less than estimated fee')
   }
 
   return sendMaxAmount.toString()

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -1,0 +1,39 @@
+import BigNumber from 'bignumber.js'
+import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
+import { SendMaxAmountInput } from '../ZrxSwapper'
+import { SwapError } from '../../../api'
+
+// TODO:(ryankk) move type into types package
+type SendMaxAmountDeps = {
+  adapterManager: ChainAdapterManager
+}
+
+export async function getSendMaxAmount(
+  { adapterManager }: SendMaxAmountDeps,
+  { wallet, quote, sellAssetAccountId, feeEstimateKey }: SendMaxAmountInput
+): Promise<string> {
+  const adapter = adapterManager.byChain(ChainTypes.Ethereum)
+  const bip32Params = adapter.buildBIP32Params({ accountNumber: Number(sellAssetAccountId) })
+  const ethAddress = await adapter.getAddress({ wallet, bip32Params })
+
+  const { balance } = await adapter.getAccount(ethAddress)
+
+  // TODO:(ryankk) make sure these values passed into 'getFeeData' are correct
+  const feeEstimates = await adapter.getFeeData({
+    to: quote.depositAddress,
+    from: ethAddress,
+    value: balance,
+    contractAddress: quote.sellAsset.tokenId
+  })
+
+  const estimatedFee = feeEstimates[feeEstimateKey].chainSpecific.feePerTx
+
+  const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
+
+  if (!sendMaxAmount.gt(0)) {
+    throw new SwapError('ETH balance is less than estimated fee')
+  }
+
+  return sendMaxAmount.toString()
+}

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -23,7 +23,7 @@ export async function getSendMaxAmount(
   let balance: string | undefined
   if (tokenId) {
     balance = account.chainSpecific.tokens?.find(
-      (token) => token.contract.toLowerCase() === tokenId?.toLowerCase()
+      (token) => token.contract.toLowerCase() === tokenId.toLowerCase()
     )?.balance
   } else {
     balance = account.balance

--- a/packages/swapper/src/swappers/zrx/utils/bignumber.ts
+++ b/packages/swapper/src/swappers/zrx/utils/bignumber.ts
@@ -8,4 +8,3 @@ export const bnOrZero = (n: BigNumber.Value | null | undefined): BN => {
   const value = bn(n || 0)
   return value.isNaN() ? bn(0) : value
 }
-

--- a/packages/swapper/src/swappers/zrx/utils/bignumber.ts
+++ b/packages/swapper/src/swappers/zrx/utils/bignumber.ts
@@ -1,0 +1,11 @@
+import BigNumber from 'bignumber.js'
+
+export type BN = BigNumber
+
+export const bn = (n: BigNumber.Value, base = 10): BN => new BigNumber(n, base)
+
+export const bnOrZero = (n: BigNumber.Value | null | undefined): BN => {
+  const value = bn(n || 0)
+  return value.isNaN() ? bn(0) : value
+}
+

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
@@ -1,4 +1,3 @@
-import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { ChainTypes } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
@@ -13,10 +12,10 @@ import {
   normalizeAmount
 } from '../helpers/helpers'
 import { setupQuote } from '../test-data/setupSwapQuote'
+import { setupZrxDeps } from '../test-data/setupZrxDeps'
 import { zrxService } from '../zrxService'
 
 jest.mock('web3')
-jest.mock('@shapeshiftoss/chain-adapters')
 const axios = jest.createMockFromModule('axios')
 
 //@ts-ignore
@@ -36,29 +35,9 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-// @ts-ignore
-ChainAdapterManager.mockImplementation(() => ({
-  byChain: jest.fn(() => ({
-    buildBIP32Params: jest.fn(() => ({ purpose: 44, coinType: 60, accountNumber: 0 })),
-    buildSendTransaction: jest.fn(() => Promise.resolve({ txToSign: {} })),
-    signTransaction: jest.fn(() => Promise.resolve('signedTx')),
-    broadcastTransaction: jest.fn(() => Promise.resolve('broadcastedTx'))
-  }))
-}))
-
 const setup = () => {
-  const unchainedUrls = {
-    [ChainTypes.Ethereum]: {
-      httpUrl: 'http://localhost:31300',
-      wsUrl: 'ws://localhost:31300'
-    }
-  }
-  const adapterManager = new ChainAdapterManager(unchainedUrls)
+  const { web3Instance, adapterManager } = setupZrxDeps()
   const adapter = adapterManager.byChain(ChainTypes.Ethereum)
-
-  const ethNodeUrl = 'http://localhost:1000'
-  const web3Provider = new Web3.providers.HttpProvider(ethNodeUrl)
-  const web3Instance = new Web3(web3Provider)
 
   return { web3Instance, adapter }
 }

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -107,9 +107,12 @@ export const getUsdRate = async (input: Pick<Asset, 'symbol' | 'tokenId'>): Prom
       }
     }
   )
-  if (!rateResponse.data.price) throw new ZrxError('getUsdRate - Failed to get price data')
 
-  return new BigNumber(1).dividedBy(rateResponse.data.price).toString()
+  const price = new BigNumber(rateResponse.data.price)
+
+  if (!price.gt(0)) throw new ZrxError('getUsdRate - Failed to get price data')
+
+  return new BigNumber(1).dividedBy(price).toString()
 }
 
 export const grantAllowance = async ({

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
@@ -1,5 +1,5 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import { ChainTypes, chainAdapters } from '@shapeshiftoss/types'
+import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 jest.mock('@shapeshiftoss/chain-adapters')
@@ -24,7 +24,7 @@ export const chainAdapterMockFuncs = {
 
 // @ts-ignore
 ChainAdapterManager.mockImplementation(() => ({
-  byChain: jest.fn(() => (chainAdapterMockFuncs))
+  byChain: jest.fn(() => chainAdapterMockFuncs)
 }))
 
 export const setupZrxDeps = () => {

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
@@ -17,7 +17,7 @@ export const chainAdapterMockFuncs = {
   ),
   getFeeData: jest.fn(() =>
     Promise.resolve({
-      [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx: '10000' } }
+      [chainAdapters.FeeDataKey.Average]: { txFee: '10000' }
     })
   )
 }

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
@@ -1,6 +1,31 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainTypes, chainAdapters } from '@shapeshiftoss/types'
 import Web3 from 'web3'
+
+jest.mock('@shapeshiftoss/chain-adapters')
+
+export const chainAdapterMockFuncs = {
+  buildBIP32Params: jest.fn(() => ({ purpose: 44, coinType: 60, accountNumber: 0 })),
+  buildSendTransaction: jest.fn(() => Promise.resolve({ txToSign: {} })),
+  signTransaction: jest.fn(() => Promise.resolve('signedTx')),
+  broadcastTransaction: jest.fn(() => Promise.resolve('broadcastedTx')),
+  getAddress: jest.fn(() => Promise.resolve('address')),
+  getAccount: jest.fn(() =>
+    Promise.resolve({
+      chainSpecific: { tokens: [{ contract: 'contractAddress', balance: '1000000' }] }
+    })
+  ),
+  getFeeData: jest.fn(() =>
+    Promise.resolve({
+      [chainAdapters.FeeDataKey.Average]: { chainSpecific: { feePerTx: '10000' } }
+    })
+  )
+}
+
+// @ts-ignore
+ChainAdapterManager.mockImplementation(() => ({
+  byChain: jest.fn(() => (chainAdapterMockFuncs))
+}))
 
 export const setupZrxDeps = () => {
   const unchainedUrls = {


### PR DESCRIPTION
- Add `getSendMaxAmount` helper function to ZrxSwapper. This gives us the ability to get the max amount a eth address can swap.

closes #167 