### PR TITLE
chore: refactor bitcoin.getFeeData

### DIFF
--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -10,6 +10,7 @@ import {
   supportsBTC
 } from '@shapeshiftoss/hdwallet-core'
 import { BIP32Params, chainAdapters, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { FeeData, FeeDataKey } from '@shapeshiftoss/types/dist/chain-adapters'
 import { bitcoin } from '@shapeshiftoss/unchained-client'
 import coinSelect from 'coinselect'
 import WAValidator from 'multicoin-address-validator'
@@ -287,31 +288,21 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     ]
 
     const estimatedFees = calculateEstimatedFees(satsPerByte, utxos, value, to)
-
+    const keys = Object.values(FeeDataKey)
     /*
       Return undefined for unknown fee amounts so that we can still show any fees that we can calculate
       The consumer of this API should handle the `undefined` case and show "N/A" or something similar
      */
-    return {
-      [chainAdapters.FeeDataKey.Fast]: {
-        txFee: estimatedFees[0]?.toString(),
+    return keys.reduce((accum, key, idx) => {
+      accum[key] = {
+        txFee: estimatedFees[idx]?.toString(),
         chainSpecific: {
-          satoshiPerByte: satsPerByte[0]?.toString()
-        }
-      },
-      [chainAdapters.FeeDataKey.Average]: {
-        txFee: estimatedFees[1]?.toString(),
-        chainSpecific: {
-          satoshiPerByte: satsPerByte[1]?.toString()
-        }
-      },
-      [chainAdapters.FeeDataKey.Slow]: {
-        txFee: estimatedFees[2]?.toString(),
-        chainSpecific: {
-          satoshiPerByte: satsPerByte[2]?.toString()
+          satoshiPerByte: satsPerByte[idx]?.toString()
         }
       }
-    }
+
+      return accum
+    }, {} as Record<chainAdapters.FeeDataKey, FeeData<ChainTypes.Bitcoin>>)
   }
 
   async getAddress({

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -280,20 +280,18 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
       return ErrorHandler('BitcoinChainAdapter: fee data is unavailable')
     }
 
+    const feeDataKeys = Object.values(FeeDataKey)
     // We have to round because coinselect library uses sats per byte which cant be decimals
-    const satsPerByte = [
-      convertSatsPerKilobyteToPerByte(feeData?.fast?.satsPerKiloByte),
-      convertSatsPerKilobyteToPerByte(feeData?.average?.satsPerKiloByte),
-      convertSatsPerKilobyteToPerByte(feeData?.slow?.satsPerKiloByte)
-    ]
+    const satsPerByte = feeDataKeys.map((key) =>
+      convertSatsPerKilobyteToPerByte(feeData?.[key]?.satsPerKiloByte)
+    )
 
     const estimatedFees = calculateEstimatedFees(satsPerByte, utxos, value, to)
-    const keys = Object.values(FeeDataKey)
     /*
       Return undefined for unknown fee amounts so that we can still show any fees that we can calculate
       The consumer of this API should handle the `undefined` case and show "N/A" or something similar
      */
-    return keys.reduce((accum, key, idx) => {
+    return feeDataKeys.reduce((accum, key, idx) => {
       accum[key] = {
         txFee: estimatedFees[idx]?.toString(),
         chainSpecific: {

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from './bip32'
-export * from './utxoUtils'

--- a/packages/chain-adapters/src/utils/utxoUtils.ts
+++ b/packages/chain-adapters/src/utils/utxoUtils.ts
@@ -1,6 +1,10 @@
 import { BTCInputScriptType, BTCOutputScriptType } from '@shapeshiftoss/hdwallet-core'
-import { Asset } from '@shapeshiftoss/types'
+import { Asset} from '@shapeshiftoss/types'
 import { BIP32Params, UtxoAccountType } from '@shapeshiftoss/types'
+// eslint-disable-next-line prettier/prettier
+import type { bitcoin } from '@shapeshiftoss/unchained-client'
+import { BigNumber } from 'bignumber.js'
+import coinSelect from 'coinselect'
 
 /**
  * Utility function to convert a BTCInputScriptType to the corresponding BTCOutputScriptType
@@ -24,8 +28,6 @@ export const toBtcOutputScriptType = (x: BTCInputScriptType) => {
 
 /**
  * Utility function to get BIP32Params and scriptType for chain-adapter functions (getAddress, buildSendTransaction)
- * @param scriptType
- * @param asset
  * @returns object with BIP32Params and scriptType or undefined
  */
 export const utxoAccountParams = (
@@ -64,4 +66,35 @@ export const utxoAccountParams = (
     default:
       throw new TypeError('utxoAccountType')
   }
+}
+
+/**
+ * Convert sats per kilobyte to sats per byte
+ */
+export const convertSatsPerKilobyteToPerByte = (value: BigNumber.Value | undefined) =>
+  value ? new BigNumber(value).div(1024).integerValue() : undefined
+
+/**
+ * Get a list of possible transaction fees for a given set of UTXOs and an amount to be transacted
+ *
+ * @returns {Array.<BigNumber | undefined>} - Array of estimated fees or undefined.  Returns undefined if an estimated fee cannot be calculated
+ *
+ * @param {Array.<BigNumber | undefined>} satsPerByte - array of fees in sats per byte
+ * @param utxos - array of Utxos that can be used to build a transaction for {amount}
+ * @param amount - the amount to be transacted
+ * @param to - The destination address
+ */
+export const calculateEstimatedFees = (satsPerByte: (BigNumber | undefined)[], utxos: bitcoin.api.Utxo[], amount: number | string, to: string) => {
+  if (!isFinite(Number(amount))) throw new Error('Invalid amount')
+  const convertedUtxos = utxos.map((x) => ({ ...x, value: Number(x.value) }))
+
+  return satsPerByte.map(fee => {
+      let result: BigNumber | undefined
+      if (fee) {
+        const estFee = coinSelect(convertedUtxos, [{ value: Number(amount), address: to }], fee.toNumber()).fee
+        result = estFee ? new BigNumber(estFee) : undefined
+      }
+
+      return result
+    })
 }

--- a/packages/types/src/chain-adapters/bitcoin.ts
+++ b/packages/types/src/chain-adapters/bitcoin.ts
@@ -75,7 +75,7 @@ export type NodeTransaction = {
 }
 
 export type FeeData = {
-  satoshiPerByte: string
+  satoshiPerByte?: string
 }
 
 export type BuildTxInput = {

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -86,7 +86,7 @@ export type QuoteFeeData<T1 extends ChainTypes, T2 extends SwapperType> = {
 // feePerUnit = sats/kbyte
 
 export type FeeData<T extends ChainTypes> = {
-  txFee: string
+  txFee?: string
 } & ChainSpecificFeeData<T>
 
 export type FeeDataEstimate<T extends ChainTypes> = {


### PR DESCRIPTION
* DRY up the code
* allow flexibility to have `n` estimated fees instead of always being `3`
* if some fees aren't available, return undefined so we can return at least some fee data if it's available (instead of all or nothing)