### PR TITLE
feat: add SendMaxAmountInput to base types

### DIFF
--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -1,6 +1,6 @@
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 
-import { QuoteFeeData, SignTxInput } from './chain-adapters'
+import { FeeDataKey, QuoteFeeData, SignTxInput } from './chain-adapters'
 
 /** Common */
 
@@ -181,4 +181,11 @@ export type ApprovalNeededOutput = {
 export type ApproveInfiniteInput<C extends ChainTypes, S extends SwapperType> = {
   quote: Quote<C, S>
   wallet: HDWallet
+}
+
+export type SendMaxAmountInput = {
+  wallet: HDWallet
+  quote: Quote<ChainTypes, SwapperType>
+  sellAssetAccountId: string
+  feeEstimateKey?: FeeDataKey
 }


### PR DESCRIPTION
- Add types needed for max trade PR for [web](https://github.com/shapeshift/web/pull/316/files) and [lib](https://github.com/shapeshift/lib/pull/200/files)