### PR TITLE
feat: export CAIP2 and CAIP19 as string alias

### DIFF
--- a/packages/caip/src/caip19/caip19.ts
+++ b/packages/caip/src/caip19/caip19.ts
@@ -1,7 +1,10 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+
 import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 import { fromCAIP2, toCAIP2 } from './../caip2/caip2'
+
+export type CAIP19 = string
 
 export enum AssetNamespace {
   ERC20 = 'erc20',

--- a/packages/caip/src/caip2/caip2.ts
+++ b/packages/caip/src/caip2/caip2.ts
@@ -2,6 +2,8 @@
 
 import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
+export type CAIP2 = string
+
 export enum ChainNamespace {
   Ethereum = 'eip155',
   Bitcoin = 'bip122'

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -3,3 +3,5 @@ import * as caip2 from './caip2/caip2'
 import * as caip19 from './caip19/caip19'
 
 export { adapters, caip2, caip19 }
+export { CAIP2 } from './caip2/caip2'
+export { CAIP19 } from './caip19/caip19'


### PR DESCRIPTION
let's use use `CAIP2` or `CAIP19` as a type in web, which are just strings, but makes the types much more descriptive