### PR TITLE
fix: gas fees erc20

### DIFF
--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -197,7 +197,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
 
     if (!fees) throw new TypeError('ETH Gas Fees should always exist')
 
-    const data = contractData ? contractData : await getErc20Data(to, value, contractAddress)
+    const data = contractData ?? (await getErc20Data(to, value, contractAddress))
 
     const isErc20Send = !!contractAddress
     const { data: gasLimit } = await this.providers.http.estimateGas({

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -186,7 +186,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
   async getFeeData({
     to,
     value,
-    chainSpecific: { contractAddress, from }
+    chainSpecific: { contractAddress, from, contractData }
   }: chainAdapters.GetFeeDataInput<ChainTypes.Ethereum>): Promise<
     chainAdapters.FeeDataEstimate<ChainTypes.Ethereum>
   > {
@@ -197,17 +197,15 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
 
     if (!fees) throw new TypeError('ETH Gas Fees should always exist')
 
-    const data = await getErc20Data(to, value, contractAddress)
+    const data = contractData ? contractData : await getErc20Data(to, value, contractAddress)
 
-    const { data: feeUnits } = await this.providers.http.estimateGas({
+    const isErc20Send = !!contractAddress
+    const { data: gasLimit } = await this.providers.http.estimateGas({
       from,
-      to,
-      value,
+      to: isErc20Send ? contractAddress : to,
+      value: isErc20Send ? '0' : value,
       data
     })
-
-    // PAD LIMIT
-    const gasLimit = new BigNumber(feeUnits).times(2).toString()
 
     return {
       fast: {

--- a/packages/types/src/chain-adapters/ethereum.ts
+++ b/packages/types/src/chain-adapters/ethereum.ts
@@ -53,4 +53,5 @@ export type BuildTxInput = {
 export type GetFeeDataInput = {
   contractAddress?: string
   from: string
+  contractData?: string
 }


### PR DESCRIPTION
- Fee data was incorrect for erc20.
- got rid of 2x padding ridiculousness because fees are now correct
- Add optional contractData field to be used as a generic way for other parts of the app to get fee data (zrxSwapper)