### PR TITLE
fix: portis wallet not showing BTC balance

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -38,6 +38,10 @@
   },
   "devDependencies": {
     "@shapeshiftoss/hdwallet-native": "^1.17.1",
+    "@types/bs58check": "^2.1.0",
     "@types/multicoin-address-validator": "^0.5.0"
+  },
+  "peerDependencies": {
+    "bs58check": "^2.0.0"
   }
 }

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,6 +1,5 @@
-import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP32Params, ChainTypes } from '@shapeshiftoss/types'
+import { BIP32Params, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 
 import { ChainAdapterManager } from './ChainAdapterManager'
@@ -49,7 +48,7 @@ const main = async () => {
     const btcAddress = await btcChainAdapter.getAddress({
       wallet,
       bip32Params: btcBip32Params,
-      scriptType: BTCInputScriptType.SpendWitness
+      accountType: UtxoAccountType.SegwitNative
     })
     console.log('btcAddress:', btcAddress)
 
@@ -57,7 +56,7 @@ const main = async () => {
     console.log('btcAccount:', btcAccount)
 
     await btcChainAdapter.subscribeTxs(
-      { wallet, bip32Params: btcBip32Params, scriptType: BTCInputScriptType.SpendWitness },
+      { wallet, bip32Params: btcBip32Params, accountType: UtxoAccountType.SegwitNative },
       (msg) => console.log(msg),
       (err) => console.log(err)
     )
@@ -67,7 +66,7 @@ const main = async () => {
       value: '400',
       wallet,
       bip32Params: btcBip32Params,
-      chainSpecific: { scriptType: BTCInputScriptType.SpendAddress, satoshiPerByte: '4' }
+      chainSpecific: { accountType: UtxoAccountType.P2pkh, satoshiPerByte: '4' }
     }
 
     try {

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -6,9 +6,9 @@
  * @group unit
  */
 
-import { BTCInputScriptType, HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP32Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { BIP32Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
 import * as bitcoin from './BitcoinChainAdapter'
@@ -283,7 +283,7 @@ describe('BitcoinChainAdapter', () => {
         wallet,
         chainSpecific: {
           opReturnData: 'nm, u',
-          scriptType: BTCInputScriptType.SpendWitness,
+          accountType: UtxoAccountType.SegwitNative,
           satoshiPerByte: '1'
         }
       }
@@ -351,7 +351,7 @@ describe('BitcoinChainAdapter', () => {
         wallet,
         chainSpecific: {
           opReturnData: 'sup fool',
-          scriptType: BTCInputScriptType.SpendWitness,
+          accountType: UtxoAccountType.SegwitNative,
           satoshiPerByte: '1'
         }
       }
@@ -418,11 +418,11 @@ describe('BitcoinChainAdapter', () => {
         isChange: false,
         index: 0
       }
-      const scriptType = BTCInputScriptType.SpendAddress
+
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.P2pkh
       })
       expect(addr).toStrictEqual('1FH6ehAd5ZFXCM1cLGzHxK1s4dGdq1JusM')
     })
@@ -437,11 +437,10 @@ describe('BitcoinChainAdapter', () => {
         index: 1,
         isChange: false
       }
-      const scriptType = BTCInputScriptType.SpendAddress
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.P2pkh
       })
       expect(addr).toStrictEqual('1Jxtem176sCXHnK7QCShoafF5VtWvMa7eq')
     })
@@ -456,11 +455,10 @@ describe('BitcoinChainAdapter', () => {
         index: 0,
         isChange: true
       }
-      const scriptType = BTCInputScriptType.SpendAddress
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.P2pkh
       })
       expect(addr).toStrictEqual('13ZD8S4qR6h4GvkAZ2ht7rpr15TFXYxGCx')
     })
@@ -475,11 +473,10 @@ describe('BitcoinChainAdapter', () => {
         index: 0,
         isChange: false
       }
-      const scriptType = BTCInputScriptType.SpendAddress
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.P2pkh
       })
       expect(addr).toStrictEqual('1K2oFer6nGoXSPspeB5Qvt4htJvw3y31XW')
     })
@@ -494,11 +491,10 @@ describe('BitcoinChainAdapter', () => {
         isChange: false,
         index: 0
       }
-      const scriptType = BTCInputScriptType.SpendWitness
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.SegwitNative
       })
       expect(addr).toStrictEqual('bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa')
     })
@@ -513,11 +509,10 @@ describe('BitcoinChainAdapter', () => {
         index: 1,
         isChange: false
       }
-      const scriptType = BTCInputScriptType.SpendWitness
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.SegwitNative
       })
       expect(addr).toStrictEqual('bc1qpszctuml70ulzf7f0zy5r4sg9nm65qfpgcw0uy')
     })
@@ -532,11 +527,10 @@ describe('BitcoinChainAdapter', () => {
         index: 0,
         isChange: true
       }
-      const scriptType = BTCInputScriptType.SpendWitness
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.SegwitNative
       })
       expect(addr).toStrictEqual('bc1qhazdhyg6ukkvnnlucxamjc3dmkj2zyfte0lqa9')
     })
@@ -551,11 +545,10 @@ describe('BitcoinChainAdapter', () => {
         index: 0,
         isChange: false
       }
-      const scriptType = BTCInputScriptType.SpendWitness
       const addr: string | undefined = await adapter.getAddress({
         bip32Params,
         wallet,
-        scriptType
+        accountType: UtxoAccountType.SegwitNative
       })
       expect(addr).toStrictEqual('bc1qgawuludfvrdxfq0x55k26ydtg2hrx64jp3u6am')
     })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -392,7 +392,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     const { xpub } = await this.getPublicKey(wallet, bip32Params, accountType)
     const account = await this.getAccount(xpub)
     const addresses = (account.chainSpecific.addresses ?? []).map((address) => address.pubkey)
-    const id = `${toRootDerivationPath(bip32Params)}/${scriptType}`
+    const id = `${toRootDerivationPath(bip32Params)}/${accountType}`
 
     await this.providers.ws.subscribeTxs(
       { topic: 'txs', addresses, id },

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,6 +1,5 @@
 import {
   bip32ToAddressNList,
-  BTCInputScriptType,
   BTCOutputAddressType,
   BTCSignTx,
   BTCSignTxInput,
@@ -9,15 +8,26 @@ import {
   PublicKey,
   supportsBTC
 } from '@shapeshiftoss/hdwallet-core'
-import { BIP32Params, chainAdapters, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import {
+  BIP32Params,
+  chainAdapters,
+  ChainTypes,
+  NetworkTypes,
+  UtxoAccountType
+} from '@shapeshiftoss/types'
 import { bitcoin } from '@shapeshiftoss/unchained-client'
 import coinSelect from 'coinselect'
 import WAValidator from 'multicoin-address-validator'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
-import { toPath, toRootDerivationPath } from '../utils/bip32'
-import { toBtcOutputScriptType } from '../utils/utxoUtils'
+import {
+  accountTypeToOutputScriptType,
+  accountTypeToScriptType,
+  convertXpubVersion,
+  toPath,
+  toRootDerivationPath
+} from '../utils'
 
 export interface ChainAdapterArgs {
   providers: {
@@ -51,10 +61,10 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     return ChainTypes.Bitcoin
   }
 
-  private async getPubKey(
+  private async getPublicKey(
     wallet: HDWallet,
     bip32Params: BIP32Params,
-    scriptType: BTCInputScriptType
+    accountType: UtxoAccountType
   ): Promise<PublicKey> {
     const path = toRootDerivationPath(bip32Params)
     const publicKeys = await wallet.getPublicKeys([
@@ -62,10 +72,15 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         coin: this.coinName,
         addressNList: bip32ToAddressNList(path),
         curve: 'secp256k1', // TODO(0xdef1cafe): from constant?
-        scriptType
+        scriptType: accountTypeToScriptType[accountType]
       }
     ])
     if (!publicKeys?.[0]) throw new Error("couldn't get public key")
+
+    if (accountType) {
+      return { xpub: convertXpubVersion(publicKeys[0].xpub, accountType) }
+    }
+
     return publicKeys[0]
   }
 
@@ -137,7 +152,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
         to,
         wallet,
         bip32Params = ChainAdapter.defaultBIP32Params,
-        chainSpecific: { satoshiPerByte, scriptType }
+        chainSpecific: { satoshiPerByte, accountType }
       } = tx
 
       if (!value || !to) {
@@ -145,8 +160,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
       }
 
       const path = toRootDerivationPath(bip32Params)
-      const changeScriptType = toBtcOutputScriptType(scriptType)
-      const pubkey = await this.getPubKey(wallet, bip32Params, scriptType)
+      const pubkey = await this.getPublicKey(wallet, bip32Params, accountType)
       const { data: utxos } = await this.providers.http.getUtxos({
         pubkey: pubkey.xpub
       })
@@ -160,7 +174,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
       const from = await wallet.btcGetAddress({
         addressNList,
         coin: this.coinName,
-        scriptType
+        scriptType: accountTypeToScriptType[accountType]
       })
 
       if (!from) throw new Error('BitcoinChainAdapter: from undefined')
@@ -193,7 +207,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
           addressNList: bip32ToAddressNList(input.path),
           // https://github.com/shapeshift/hdwallet/issues/362
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          scriptType: scriptType as any,
+          scriptType: accountTypeToScriptType[accountType] as any,
           amount: String(input.value),
           vout: input.vout,
           txid: input.txid,
@@ -210,7 +224,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
             addressNList: bip32ToAddressNList(
               `${path}/1/${String(account.chainSpecific.nextChangeAddressIndex)}`
             ),
-            scriptType: changeScriptType,
+            scriptType: accountTypeToOutputScriptType[accountType],
             isChange: true
           }
         } else {
@@ -327,7 +341,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
   async getAddress({
     wallet,
     bip32Params = ChainAdapter.defaultBIP32Params,
-    scriptType = BTCInputScriptType.SpendWitness,
+    accountType = UtxoAccountType.SegwitP2sh,
     showOnDevice = false
   }: chainAdapters.bitcoin.GetAddressInput): Promise<string> {
     if (!supportsBTC(wallet)) {
@@ -339,7 +353,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
 
     // If an index is not passed in, we want to use the newest unused change/receive indices
     if (index === undefined) {
-      const { xpub } = await this.getPubKey(wallet, bip32Params, scriptType)
+      const { xpub } = await this.getPublicKey(wallet, bip32Params, accountType)
       const account = await this.getAccount(xpub)
       index = isChange
         ? account.chainSpecific.nextChangeAddressIndex
@@ -351,7 +365,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     const btcAddress = await wallet.btcGetAddress({
       addressNList,
       coin: this.coinName,
-      scriptType,
+      scriptType: accountTypeToScriptType[accountType],
       showDisplay: Boolean(showOnDevice)
     })
     if (!btcAddress) throw new Error('BitcoinChainAdapter: no btcAddress available from wallet')
@@ -372,10 +386,10 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Bitcoin> {
     const {
       wallet,
       bip32Params = ChainAdapter.defaultBIP32Params,
-      scriptType = BTCInputScriptType.SpendWitness
+      accountType = UtxoAccountType.SegwitNative
     } = input
 
-    const { xpub } = await this.getPubKey(wallet, bip32Params, scriptType)
+    const { xpub } = await this.getPublicKey(wallet, bip32Params, accountType)
     const account = await this.getAccount(xpub)
     const addresses = (account.chainSpecific.addresses ?? []).map((address) => address.pubkey)
     const id = `${toRootDerivationPath(bip32Params)}/${scriptType}`

--- a/packages/chain-adapters/src/utils/utxoUtils.test.ts
+++ b/packages/chain-adapters/src/utils/utxoUtils.test.ts
@@ -1,0 +1,31 @@
+import { UtxoAccountType } from '@shapeshiftoss/types'
+
+import { convertXpubVersion } from './utxoUtils'
+
+const xpub =
+  'xpub6GPVbpBHJMUEK8BzF4ntoP1mdtpMgXJhNSfRQew9vMLLzHB9JyRfj5C5wmqyoRfRQiRL7V7GJkqKEnDEXn1cTBnodPyBW69ao498pg6stm6'
+const ypub =
+  'ypub6bDkuUrCT31iARP75RaX1U7Gorxod9JCHZBeC3q3JMiE3NzNZdbEM8rDxyoZoLKLpMY8rxhpmRBs84poFURdFRUQVjfc5zy54nCnDGGhnDa'
+const zpub =
+  'zpub6v42D9X7biZC1iaDunN9DZCmyq7FZmHhCfhrySivgN676UobpHknyCWMzBm9oEyGDzewcSJPE5YR1MSMyAqe3fA1N5N2funZLWGRbsRjA1s'
+
+describe('utxoUtils', () => {
+  describe('convertXpubVersion', () => {
+    it.each([
+      [xpub, UtxoAccountType.P2pkh, xpub],
+      [xpub, UtxoAccountType.SegwitP2sh, ypub],
+      [xpub, UtxoAccountType.SegwitNative, zpub],
+      [ypub, UtxoAccountType.P2pkh, xpub],
+      [ypub, UtxoAccountType.SegwitP2sh, ypub],
+      [ypub, UtxoAccountType.SegwitNative, zpub],
+      [zpub, UtxoAccountType.P2pkh, xpub],
+      [zpub, UtxoAccountType.SegwitP2sh, ypub],
+      [zpub, UtxoAccountType.SegwitNative, zpub]
+    ])(
+      'should convert %s to %s',
+      async (input: string, type: UtxoAccountType, expected: string) => {
+        expect(convertXpubVersion(input, type)).toBe(expected)
+      }
+    )
+  })
+})

--- a/packages/chain-adapters/src/utils/utxoUtils.ts
+++ b/packages/chain-adapters/src/utils/utxoUtils.ts
@@ -1,6 +1,7 @@
 import { BTCInputScriptType, BTCOutputScriptType } from '@shapeshiftoss/hdwallet-core'
 import { Asset } from '@shapeshiftoss/types'
 import { BIP32Params, UtxoAccountType } from '@shapeshiftoss/types'
+import { decode, encode } from 'bs58check'
 
 /**
  * Utility function to convert a BTCInputScriptType to the corresponding BTCOutputScriptType
@@ -24,16 +25,17 @@ export const toBtcOutputScriptType = (x: BTCInputScriptType) => {
 
 /**
  * Utility function to get BIP32Params and scriptType for chain-adapter functions (getAddress, buildSendTransaction)
- * @param scriptType
+ * @param accountType
  * @param asset
+ * @param accountNumber
  * @returns object with BIP32Params and scriptType or undefined
  */
 export const utxoAccountParams = (
   asset: Asset,
-  utxoAccountType: UtxoAccountType,
+  accountType: UtxoAccountType,
   accountNumber: number
 ): { bip32Params: BIP32Params; scriptType: BTCInputScriptType } => {
-  switch (utxoAccountType) {
+  switch (accountType) {
     case UtxoAccountType.SegwitNative:
       return {
         scriptType: BTCInputScriptType.SpendWitness,
@@ -64,4 +66,84 @@ export const utxoAccountParams = (
     default:
       throw new TypeError('utxoAccountType')
   }
+}
+
+export const accountTypeToScriptType: Record<UtxoAccountType, BTCInputScriptType> = Object.freeze({
+  [UtxoAccountType.P2pkh]: BTCInputScriptType.SpendAddress,
+  [UtxoAccountType.SegwitP2sh]: BTCInputScriptType.SpendP2SHWitness,
+  [UtxoAccountType.SegwitNative]: BTCInputScriptType.SpendWitness
+})
+
+export const accountTypeToOutputScriptType: Record<
+  UtxoAccountType,
+  BTCOutputScriptType
+> = Object.freeze({
+  [UtxoAccountType.P2pkh]: BTCOutputScriptType.PayToAddress,
+  [UtxoAccountType.SegwitP2sh]: BTCOutputScriptType.PayToP2SHWitness,
+  [UtxoAccountType.SegwitNative]: BTCOutputScriptType.PayToWitness
+})
+
+export const scriptTypeToAccountType: Record<
+  BTCInputScriptType,
+  UtxoAccountType | undefined
+> = Object.freeze({
+  [BTCInputScriptType.SpendAddress]: UtxoAccountType.P2pkh,
+  [BTCInputScriptType.SpendP2SHWitness]: UtxoAccountType.SegwitP2sh,
+  [BTCInputScriptType.SpendWitness]: UtxoAccountType.SegwitNative,
+  [BTCInputScriptType.SpendMultisig]: undefined,
+  [BTCInputScriptType.Bech32]: undefined,
+  [BTCInputScriptType.CashAddr]: undefined,
+  [BTCInputScriptType.External]: undefined
+})
+
+/*
+ * @see https://github.com/blockkeeper/blockkeeper-frontend-web/issues/38
+ *
+ * ypub and zpub are defined by BIP48 and BIP84 as special version bytes for use in the BIP32
+ * encoding of the keys for their respective account types. Defining custom serialization formats
+ * for different account types has since fallen out of favor (as in BIP86) but getting these bytes
+ * correct is relevant for interoperation with a variety of other software (like Blockbook).
+ *
+ * The only difference compared to xpub is a prefix, but as it is a base58 encoded string with a
+ * checksum, the checksum is also different.
+ *
+ * The easiest way to fix it is to decode from base58check, replace the prefix to
+ * standard xpub or ypub and then to encode back to base58check. Then one can use this xpub
+ * as normal bip32 master key.
+ *
+ * It may make sense to remember the type of the public key as it tells what type of script
+ * is used in the wallet.
+ *
+ */
+enum PublicKeyType {
+  // mainnet
+  xpub = '0488b21e', // xpub
+  ypub = '049d7cb2', // ypub
+  zpub = '04b24746' // zpub
+}
+
+const accountTypeToVersion = {
+  [UtxoAccountType.P2pkh]: Buffer.from(PublicKeyType.xpub, 'hex'),
+  [UtxoAccountType.SegwitP2sh]: Buffer.from(PublicKeyType.ypub, 'hex'),
+  [UtxoAccountType.SegwitNative]: Buffer.from(PublicKeyType.zpub, 'hex')
+}
+
+/**
+ * Convert any public key into an xpub, ypub, or zpub based on account type
+ *
+ * Blockbook generates addresses from a public key based on the version bytes
+ * some wallets always return the public key in "xpub" format, so we need to convert those
+ *
+ * @param {string} xpub - the public key provided by the wallet
+ * @param {UtxoAccountType} accountType - The desired account type to be encoded into the public key
+ */
+export function convertXpubVersion(xpub: string, accountType: UtxoAccountType) {
+  const payload = decode(xpub)
+  const version = payload.slice(0, 4)
+  if (version.compare(accountTypeToVersion[accountType]) !== 0) {
+    // Get the key without the version code at the front
+    const key = payload.slice(4)
+    return encode(Buffer.concat([accountTypeToVersion[accountType], key]))
+  }
+  return xpub
 }

--- a/packages/types/src/chain-adapters/bitcoin.ts
+++ b/packages/types/src/chain-adapters/bitcoin.ts
@@ -1,5 +1,4 @@
-import { BTCInputScriptType } from '@shapeshiftoss/hdwallet-core'
-
+import { UtxoAccountType } from '../base'
 import { GetAddressInputBase } from '.'
 
 export type Account = {
@@ -17,7 +16,7 @@ export type Address = {
 }
 
 export type GetAddressInput = GetAddressInputBase & {
-  scriptType: BTCInputScriptType
+  accountType: UtxoAccountType
 }
 
 export type TransactionSpecific = {
@@ -80,7 +79,7 @@ export type FeeData = {
 
 export type BuildTxInput = {
   opReturnData?: string
-  scriptType: BTCInputScriptType
+  accountType: UtxoAccountType
   satoshiPerByte: string
 }
 

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -1,6 +1,6 @@
-import { BTCInputScriptType, BTCSignTx, ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { BTCSignTx, ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 
-import { BIP32Params, ChainTypes, NetworkTypes, SwapperType } from '../base'
+import { BIP32Params, ChainTypes, NetworkTypes, SwapperType, UtxoAccountType } from '../base'
 import { ChainAndSwapperSpecific, ChainSpecific } from '../utility'
 import * as bitcoin from './bitcoin'
 import * as ethereum from './ethereum'
@@ -98,7 +98,7 @@ export type FeeDataEstimate<T extends ChainTypes> = {
 export type SubscribeTxsInput = {
   wallet: HDWallet
   bip32Params?: BIP32Params
-  scriptType?: BTCInputScriptType
+  accountType?: UtxoAccountType
 }
 
 export type TxFee = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,6 +2926,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bs58check@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58check/-/bs58check-2.1.0.tgz#7d25a8b88fe7a9e315d2647335ee3c43c8fdb0c0"
+  integrity sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fast-text-encoding@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz#7a9e6d8dd2ac1fa70772b500a307c2620cec1fe3"


### PR DESCRIPTION
# This PR contains a breaking change!

* [MAJOR] fix: replace references to "scriptType" with "accountType"
* feat: add "convertXpubVersion" function to convert any public key to an x-, y-, or z-pub

## Description
The purpose of this change is that `scriptType` can be assumed based on the `accountType`, but not the other way around. We should be passing around the `accountType` and then deriving the `scriptType` to use from that.

This fixes portis BTC balances not working because 
1. Portis always returns its public key in "xpub" format, even for Segwit public keys.
2. Blockbook generates addresses from a public key by INFERRING the account type from the public key prefix of `"xpub" | "ypub" | "zpub"`.
3. We now convert every public key we get into an `"xpub" | "ypub" | "zpub"` based on the `accountType` that's provided
