### PR TITLE
fix: update getSendMaxAmount to pass quote txData to getFeeData

### DIFF
--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -58,7 +58,7 @@ describe('getSendMaxAmount', () => {
     const ethBalance = '100'
     const txFee = '1000'
     const args = {
-      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined }, txData: 'txData' },
       wallet,
       sellAssetAccountId: quote.sellAssetAccountId
     }
@@ -78,6 +78,33 @@ describe('getSendMaxAmount', () => {
 
     await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
       'ETH balance is less than estimated fee'
+    )
+  })
+
+  it('should throw an error if its an ETH swap and quote does not have txData', async () => {
+    const ethBalance = '100'
+    const txFee = '1000'
+    const args = {
+      quote: { ...quote, txData: '', sellAsset: { ...quote.sellAsset, tokenId: undefined } },
+      wallet,
+      sellAssetAccountId: quote.sellAssetAccountId
+    }
+    ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
+      ...chainAdapterMockFuncs,
+      getAccount: jest.fn(() =>
+        Promise.resolve({
+          balance: ethBalance
+        })
+      ),
+      getFeeData: jest.fn(() =>
+        Promise.resolve({
+          [chainAdapters.FeeDataKey.Average]: { txFee }
+        })
+      )
+    })
+
+    await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
+      'quote.txData is required to get correct fee estimate'
     )
   })
 
@@ -104,7 +131,7 @@ describe('getSendMaxAmount', () => {
     const ethBalance = '1000'
     const txFee = '100'
     const args = {
-      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined }, txData: 'txData' },
       wallet,
       sellAssetAccountId: quote.sellAssetAccountId
     }
@@ -131,7 +158,7 @@ describe('getSendMaxAmount', () => {
     const ethBalance = '1000'
     const txFee = '500'
     const args = {
-      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined } },
+      quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined }, txData: 'txData' },
       wallet,
       sellAssetAccountId: quote.sellAssetAccountId,
       feeEstimateKey: chainAdapters.FeeDataKey.Fast

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -24,11 +24,9 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          chainSpecific: { tokens: [{ contract: 'contractAddress', balance }] }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        chainSpecific: { tokens: [{ contract: 'contractAddress', balance }] }
+      })
     })
 
     await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
@@ -44,11 +42,9 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          balance: undefined
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        balance: undefined
+      })
     })
 
     await expect(getSendMaxAmount(deps, args)).rejects.toThrow(`No balance found for ETH`)
@@ -64,16 +60,12 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          balance: ethBalance
-        })
-      ),
-      getFeeData: jest.fn(() =>
-        Promise.resolve({
-          [chainAdapters.FeeDataKey.Average]: { txFee }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        balance: ethBalance
+      }),
+      getFeeData: jest.fn().mockResolvedValue({
+        [chainAdapters.FeeDataKey.Average]: { txFee }
+      })
     })
 
     await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
@@ -91,16 +83,12 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          balance: ethBalance
-        })
-      ),
-      getFeeData: jest.fn(() =>
-        Promise.resolve({
-          [chainAdapters.FeeDataKey.Average]: { txFee }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        balance: ethBalance
+      }),
+      getFeeData: jest.fn().mockResolvedValue({
+        [chainAdapters.FeeDataKey.Average]: { txFee }
+      })
     })
 
     await expect(getSendMaxAmount(deps, args)).rejects.toThrow(
@@ -117,11 +105,9 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          chainSpecific: { tokens: [{ contract: 'contractAddress', balance: erc20Balance }] }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        chainSpecific: { tokens: [{ contract: 'contractAddress', balance: erc20Balance }] }
+      })
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(erc20Balance)
@@ -137,16 +123,12 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          balance: ethBalance
-        })
-      ),
-      getFeeData: jest.fn(() =>
-        Promise.resolve({
-          [chainAdapters.FeeDataKey.Average]: { txFee }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        balance: ethBalance
+      }),
+      getFeeData: jest.fn().mockResolvedValue({
+        [chainAdapters.FeeDataKey.Average]: { txFee }
+      })
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(
@@ -165,16 +147,12 @@ describe('getSendMaxAmount', () => {
     }
     ;(adapterManager.byChain as jest.Mock<unknown>).mockReturnValue({
       ...chainAdapterMockFuncs,
-      getAccount: jest.fn(() =>
-        Promise.resolve({
-          balance: ethBalance
-        })
-      ),
-      getFeeData: jest.fn(() =>
-        Promise.resolve({
-          [chainAdapters.FeeDataKey.Fast]: { txFee }
-        })
-      )
+      getAccount: jest.fn().mockResolvedValue({
+        balance: ethBalance
+      }),
+      getFeeData: jest.fn().mockResolvedValue({
+        [chainAdapters.FeeDataKey.Fast]: { txFee }
+      })
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -42,17 +42,20 @@ export async function getSendMaxAmount(
     return balance
   }
 
+  if (!quote.txData) {
+    throw new SwapError('quote.txData is required to get correct fee estimate')
+  }
+
   const feeEstimates = await adapter.getFeeData({
     to: quote.depositAddress,
     value: balance,
     chainSpecific: {
       from: ethAddress,
-      contractAddress: tokenId
+      contractData: quote.txData
     }
   })
 
   const estimatedFee = feeEstimates[feeEstimateKey].txFee
-
   const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
 
   if (sendMaxAmount.lt(0)) {


### PR DESCRIPTION
- This updates the way `getSendMaxAmount` passes arguments to `getFeeData` based on the changes made in this [PR](https://github.com/shapeshift/lib/pull/223/files)
- closes #226 