### PR TITLE
fix: fix send max for eth bug

### DIFF
--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -76,8 +76,8 @@ export class ZrxSwapper implements Swapper {
 
   getDefaultPair(): Pick<Asset, 'chain' | 'symbol' | 'name'>[] {
     const ETH = { name: 'Ethereum', chain: ChainTypes.Ethereum, symbol: 'ETH' }
-    const USDC = { name: 'USD Coin', chain: ChainTypes.Ethereum, symbol: 'USDC' }
-    return [ETH, USDC]
+    const FOX = { name: 'Fox', chain: ChainTypes.Ethereum, symbol: 'FOX' }
+    return [ETH, FOX]
   }
 
   async executeQuote(args: ExecQuoteInput<ChainTypes, SwapperType>): Promise<ExecQuoteOutput> {

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -2,9 +2,14 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { chainAdapters } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 
+import { ETH_ESTIMATE_PADDING } from '../utils/constants'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
 import { chainAdapterMockFuncs, setupZrxDeps } from '../utils/test-data/setupZrxDeps'
 import { getSendMaxAmount } from './getSendMaxAmount'
+
+const createPaddedFee = (value: string) => {
+  return new BigNumber(value).times(ETH_ESTIMATE_PADDING).toString()
+}
 
 describe('getSendMaxAmount', () => {
   const { web3Instance, adapterManager } = setupZrxDeps()
@@ -116,6 +121,7 @@ describe('getSendMaxAmount', () => {
   it('should return max ETH balance in wei (balance minus txFee)', async () => {
     const ethBalance = '1000'
     const txFee = '100'
+    const paddedFee = createPaddedFee(txFee)
     const args = {
       quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined }, txData: 'txData' },
       wallet,
@@ -132,13 +138,14 @@ describe('getSendMaxAmount', () => {
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(
-      new BigNumber(ethBalance).minus(txFee).toString()
+      new BigNumber(ethBalance).minus(paddedFee).toString()
     )
   })
 
   it('should return max ETH balance in wei (balance minus txFee) with correct fee data key', async () => {
     const ethBalance = '1000'
     const txFee = '500'
+    const paddedFee = createPaddedFee(txFee)
     const args = {
       quote: { ...quote, sellAsset: { ...quote.sellAsset, tokenId: undefined }, txData: 'txData' },
       wallet,
@@ -156,7 +163,7 @@ describe('getSendMaxAmount', () => {
     })
 
     expect(await getSendMaxAmount(deps, args)).toEqual(
-      new BigNumber(ethBalance).minus(txFee).toString()
+      new BigNumber(ethBalance).minus(paddedFee).toString()
     )
   })
 })

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.test.ts
@@ -2,13 +2,13 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { chainAdapters } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 
-import { ETH_ESTIMATE_PADDING } from '../utils/constants'
+import { ETH_FEE_ESTIMATE_PADDING } from '../utils/constants'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
 import { chainAdapterMockFuncs, setupZrxDeps } from '../utils/test-data/setupZrxDeps'
 import { getSendMaxAmount } from './getSendMaxAmount'
 
 const createPaddedFee = (value: string) => {
-  return new BigNumber(value).times(ETH_ESTIMATE_PADDING).toString()
+  return new BigNumber(value).times(ETH_FEE_ESTIMATE_PADDING).toString()
 }
 
 describe('getSendMaxAmount', () => {

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -1,9 +1,9 @@
 import { chainAdapters, ChainTypes, SendMaxAmountInput } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
-import { ETH_ESTIMATE_PADDING } from '../utils/constants'
 
 import { SwapError } from '../../../api'
 import { bnOrZero } from '../utils/bignumber'
+import { ETH_ESTIMATE_PADDING } from '../utils/constants'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
 
 export async function getSendMaxAmount(

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -63,7 +63,8 @@ export async function getSendMaxAmount(
   const paddedFee = new BigNumber(estimatedFee).times(ETH_FEE_ESTIMATE_PADDING)
   const sendMaxAmount = new BigNumber(balance).minus(paddedFee)
 
-  if (sendMaxAmount.lt(0)) {
+  // gte covers if sendMaxAmount is NaN
+  if (!sendMaxAmount.gte(0)) {
     throw new SwapError('ETH balance is less than estimated fee')
   }
 

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 
 import { SwapError } from '../../../api'
 import { bnOrZero } from '../utils/bignumber'
-import { ETH_ESTIMATE_PADDING } from '../utils/constants'
+import { ETH_FEE_ESTIMATE_PADDING } from '../utils/constants'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
 
 export async function getSendMaxAmount(
@@ -60,7 +60,7 @@ export async function getSendMaxAmount(
 
   // (ryankk) We need to pad the fee for ETH max sends because the fee estimate is based off
   // of a minimum quote value (quote.sellAmount) and not the users full ETH balance.
-  const paddedFee = new BigNumber(estimatedFee).times(ETH_ESTIMATE_PADDING)
+  const paddedFee = new BigNumber(estimatedFee).times(ETH_FEE_ESTIMATE_PADDING)
   const sendMaxAmount = new BigNumber(balance).minus(paddedFee)
 
   if (sendMaxAmount.lt(0)) {

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -1,5 +1,6 @@
 import { chainAdapters, ChainTypes, SendMaxAmountInput } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
+import { ETH_ESTIMATE_PADDING } from '../utils/constants'
 
 import { SwapError } from '../../../api'
 import { bnOrZero } from '../utils/bignumber'
@@ -57,9 +58,9 @@ export async function getSendMaxAmount(
 
   const estimatedFee = feeEstimates[feeEstimateKey].txFee
 
-  //(ryankk) We need to pad the fee because the fee estimate is based off of a smaller trade. We should
-  // look at this post bounty to see if we can be more accurate.
-  const paddedFee = new BigNumber(estimatedFee).times(1.2).toString()
+  // (ryankk) We need to pad the fee for ETH max sends because the fee estimate is based off
+  // of a minimum quote value (quote.sellAmount) and not the users full ETH balance.
+  const paddedFee = new BigNumber(estimatedFee).times(ETH_ESTIMATE_PADDING)
   const sendMaxAmount = new BigNumber(balance).minus(paddedFee)
 
   if (sendMaxAmount.lt(0)) {

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -48,7 +48,7 @@ export async function getSendMaxAmount(
 
   const feeEstimates = await adapter.getFeeData({
     to: quote.depositAddress,
-    value: balance,
+    value: quote.sellAmount,
     chainSpecific: {
       from: ethAddress,
       contractData: quote.txData
@@ -56,7 +56,11 @@ export async function getSendMaxAmount(
   })
 
   const estimatedFee = feeEstimates[feeEstimateKey].txFee
-  const sendMaxAmount = new BigNumber(balance).minus(estimatedFee)
+
+  //(ryankk) We need to pad the fee because the fee estimate is based off of a smaller trade. We should
+  // look at this post bounty to see if we can be more accurate.
+  const paddedFee = new BigNumber(estimatedFee).times(1.2).toString()
+  const sendMaxAmount = new BigNumber(balance).minus(paddedFee)
 
   if (sendMaxAmount.lt(0)) {
     throw new SwapError('ETH balance is less than estimated fee')

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -22,6 +22,11 @@ export async function getSendMaxAmount(
   const ethAddress = await adapter.getAddress({ wallet, bip32Params })
 
   const account = await adapter.getAccount(ethAddress)
+
+  if (!quote.sellAsset) {
+    throw new SwapError('quote.sellAsset is required')
+  }
+
   const tokenId = quote.sellAsset?.tokenId
 
   let balance: string | undefined
@@ -47,14 +52,16 @@ export async function getSendMaxAmount(
     throw new SwapError('quote.txData is required to get correct fee estimate')
   }
 
+
   const feeEstimates = await adapter.getFeeData({
     to: quote.depositAddress,
-    value: quote.sellAmount,
+    value: bnOrZero(quote.sellAmount).toString(),
     chainSpecific: {
       from: ethAddress,
       contractData: quote.txData
     }
   })
+
 
   const estimatedFee = feeEstimates[feeEstimateKey].txFee
 

--- a/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getSendMaxAmount/getSendMaxAmount.ts
@@ -52,7 +52,6 @@ export async function getSendMaxAmount(
     throw new SwapError('quote.txData is required to get correct fee estimate')
   }
 
-
   const feeEstimates = await adapter.getFeeData({
     to: quote.depositAddress,
     value: bnOrZero(quote.sellAmount).toString(),
@@ -61,7 +60,6 @@ export async function getSendMaxAmount(
       contractData: quote.txData
     }
   })
-
 
   const estimatedFee = feeEstimates[feeEstimateKey].txFee
 

--- a/packages/swapper/src/swappers/zrx/utils/constants.ts
+++ b/packages/swapper/src/swappers/zrx/utils/constants.ts
@@ -12,5 +12,6 @@ export const MAX_ZRX_TRADE = '100000000000000000000000000'
 export const DEFAULT_SOURCE = [{ name: '0x', proportion: '1' }]
 export const DEFAULT_SLIPPAGE = '0.03' // 3%
 export const MAX_SLIPPAGE = '0.3' // 30%
+export const ETH_ESTIMATE_PADDING = '1.2' // Padding the fee estimate by 20% to avoid trade errors.
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const APPROVAL_BUY_AMOUNT = '100000000000000000' // A valid buy amount - 0.1 ETH

--- a/packages/swapper/src/swappers/zrx/utils/constants.ts
+++ b/packages/swapper/src/swappers/zrx/utils/constants.ts
@@ -12,6 +12,6 @@ export const MAX_ZRX_TRADE = '100000000000000000000000000'
 export const DEFAULT_SOURCE = [{ name: '0x', proportion: '1' }]
 export const DEFAULT_SLIPPAGE = '0.03' // 3%
 export const MAX_SLIPPAGE = '0.3' // 30%
-export const ETH_ESTIMATE_PADDING = '1.2' // Padding the fee estimate by 20% to avoid trade errors.
+export const ETH_FEE_ESTIMATE_PADDING = '1.2' // Padding the fee estimate by 20% to avoid trade errors.
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const APPROVAL_BUY_AMOUNT = '100000000000000000' // A valid buy amount - 0.1 ETH


### PR DESCRIPTION
- Pads the estimated gas fee for max ETH trades. 
- Changes default trading to ETH/FOX

closes #239 