### PR TITLE
fix: speed up invert of generated caip info

### DIFF
--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -8,7 +8,7 @@ const generatedCAIP19ToCoingeckoMap = Object.values(adapters).reduce((acc, cur) 
 })) as Record<string, string>
 
 const invert = <T extends Record<string, string>>(data: T) =>
-  Object.entries(data).reduce((acc, [k, v]) => ({ ...acc, [v]: k }), {})
+  Object.entries(data).reduce((acc, [k, v]) => ((acc[v] = k), acc), {} as Record<string, string>)
 
 const generatedCoingeckoToCAIP19Map: Record<string, string> = invert(generatedCAIP19ToCoingeckoMap)
 


### PR DESCRIPTION
This is, as far as I can tell, the biggest culprit in the Case of the Slow Page Load; the object allocation is high-overhead by itself, but the spread operator also gets transpiled down to use a babel shim that allocates extra temporary arrays of the intermediate objects' properties and loops over them.