### PR TITLE
feat: support improved performance via dynamic imports

### DIFF
--- a/packages/asset-service/src/service/AssetService.test.ts
+++ b/packages/asset-service/src/service/AssetService.test.ts
@@ -50,17 +50,19 @@ describe('AssetService', () => {
   })
 
   describe('byNetwork', () => {
-    it('should throw if not initialized', () => {
+    it('should throw if not initialized', async () => {
       const assetService = new AssetService(assetFileUrl)
       mockedAxios.get.mockResolvedValue({ data: mockBaseAssets })
-      expect(() => assetService.byNetwork(NetworkTypes.MAINNET)).toThrow(Error)
+      await expect(async () => await assetService.byNetwork(NetworkTypes.MAINNET)).rejects.toThrow(
+        Error
+      )
     })
 
     it('should return assets by network', async () => {
       const assetService = new AssetService(assetFileUrl)
       mockedAxios.get.mockResolvedValue({ data: mockBaseAssets })
       await assetService.initialize()
-      const ethAssets = assetService.byNetwork(NetworkTypes.MAINNET)
+      const ethAssets = await assetService.byNetwork(NetworkTypes.MAINNET)
       expect(ethAssets).toEqual(
         Object.values(mockIndexedAssetData).filter((a: Asset) => a.network === NetworkTypes.MAINNET)
       )
@@ -70,20 +72,20 @@ describe('AssetService', () => {
       const assetService = new AssetService(assetFileUrl)
       mockedAxios.get.mockResolvedValue({ data: mockBaseAssets })
       await assetService.initialize()
-      const ethAssets = assetService.byNetwork()
+      const ethAssets = await assetService.byNetwork()
       expect(ethAssets).toEqual(Object.values(mockIndexedAssetData))
     })
   })
 
   describe('byTokenId', () => {
     const tokenId = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
-    it('should throw if not initialized', () => {
+    it('should throw if not initialized', async () => {
       const assetService = new AssetService(assetFileUrl)
       mockedAxios.get.mockResolvedValue({ data: mockBaseAssets })
       const chain = ChainTypes.Ethereum
       const network = NetworkTypes.MAINNET
       const args = { chain, network, tokenId }
-      expect(() => assetService.byTokenId(args)).toThrow(Error)
+      await expect(async () => await assetService.byTokenId(args)).rejects.toThrow(Error)
     })
 
     it('should return base asset for chain given no tokenId', async () => {
@@ -93,7 +95,7 @@ describe('AssetService', () => {
       const chain = ChainTypes.Ethereum
       const network = NetworkTypes.MAINNET
       const args = { chain, network }
-      expect(assetService.byTokenId(args)).toEqual(
+      expect(await assetService.byTokenId(args)).toEqual(
         Object.values(mockIndexedAssetData).find(
           ({ name, network: assetNetwork }: Asset) =>
             name === 'Ethereum' && assetNetwork === NetworkTypes.MAINNET
@@ -108,7 +110,7 @@ describe('AssetService', () => {
       const chain = ChainTypes.Ethereum
       const network = NetworkTypes.ETH_ROPSTEN
       const args = { chain, network, tokenId }
-      expect(assetService.byTokenId(args)).toEqual(
+      expect(await assetService.byTokenId(args)).toEqual(
         Object.values(mockIndexedAssetData).find(
           ({ tokenId: assetTokenId, network: assetNetwork }: Asset) =>
             assetTokenId === tokenId && assetNetwork === NetworkTypes.ETH_ROPSTEN
@@ -123,7 +125,7 @@ describe('AssetService', () => {
       const chain = ChainTypes.Ethereum
       const network = NetworkTypes.MAINNET
       const args = { chain, network, tokenId }
-      expect(assetService.byTokenId(args)).toEqual(
+      expect(await assetService.byTokenId(args)).toEqual(
         Object.values(mockIndexedAssetData).find(
           ({ tokenId: assetTokenId, network: assetNetwork }: Asset) =>
             assetTokenId === tokenId && assetNetwork === NetworkTypes.MAINNET

--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -57,12 +57,14 @@ export class AssetService {
     this.assetFileUrl = assetFileUrl
   }
 
-  get isInitialized(): boolean {
-    return Array.isArray(this.assetData) && Array.isArray(this.flatAssetData)
+  get isInitialized(): Promise<boolean> {
+    return (async () => {
+      return Array.isArray(this.assetData) && Array.isArray(this.flatAssetData)
+    })()
   }
 
-  private checkInitialized() {
-    if (!this.isInitialized) throw new Error('Asset service not initialized')
+  private async checkInitialized() {
+    if (!(await this.isInitialized)) throw new Error('Asset service not initialized')
   }
 
   /**
@@ -89,8 +91,8 @@ export class AssetService {
    * @param network mainnet, testnet, eth ropsten, etc
    * @returns base coins (ETH, BNB, etc...) along with their supported tokens in a flattened list
    */
-  byNetwork(network?: NetworkTypes): Asset[] {
-    this.checkInitialized()
+  async byNetwork(network?: NetworkTypes): Promise<Asset[]> {
+    await this.checkInitialized()
     return network
       ? this.flatAssetData.filter((asset) => asset.network == network)
       : this.flatAssetData
@@ -103,8 +105,8 @@ export class AssetService {
    * @param tokenId token identifier (contract address on eth)
    * @returns First asset found
    */
-  byTokenId({ chain, network, tokenId }: ByTokenIdArgs): Asset {
-    this.checkInitialized()
+  async byTokenId({ chain, network, tokenId }: ByTokenIdArgs): Promise<Asset> {
+    await this.checkInitialized()
     const index = getDataIndexKey(chain, network ?? NetworkTypes.MAINNET, tokenId)
     const result = this.indexedAssetData[index]
     if (!result) {

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.21.2",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",
+    "bn.js": "^5.2.0",
     "coinselect": "^3.1.12",
     "ethers": "^5.4.7",
     "multicoin-address-validator": "^0.5.2",

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,12 +1,17 @@
 import { Contract } from '@ethersproject/contracts'
 import { CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
-import { BIP44Params, chainAdapters, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import {
+  BIP44Params,
+  chainAdapters,
+  ChainTypes,
+  NetworkTypes,
+  numberToHex
+} from '@shapeshiftoss/types'
 import { ethereum } from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 import BigNumber from 'bignumber.js'
 import WAValidator from 'multicoin-address-validator'
-import { numberToHex } from 'web3-utils'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'

--- a/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
@@ -36,7 +36,7 @@ export async function ZrxApprovalNeeded(
 
   const accountNumber = quote.sellAssetAccountId ? Number(quote.sellAssetAccountId) : 0
 
-  const adapter = adapterManager.byChain(sellAsset.chain)
+  const adapter = (await adapterManager).byChain(sellAsset.chain)
   const bip44Params = adapter.buildBIP44Params({ accountNumber })
   const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
 
@@ -69,7 +69,7 @@ export async function ZrxApprovalNeeded(
     throw new SwapError('ZrxApprovalNeeded - tokenId and allowanceTarget are required')
   }
   const allowanceResult = await getERC20Allowance({
-    web3,
+    web3: await web3,
     erc20AllowanceAbi,
     tokenId: quote.sellAsset.tokenId,
     spenderAddress: data.allowanceTarget,

--- a/packages/swapper/src/swappers/zrx/ZrxApproveInfinite/ZrxApproveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxApproveInfinite/ZrxApproveInfinite.ts
@@ -14,7 +14,9 @@ export async function ZrxApproveInfinite(
   { adapterManager, web3 }: ZrxSwapperDeps,
   { quote, wallet }: ApproveInfiniteInput<ChainTypes, SwapperType>
 ) {
-  const adapter: ChainAdapter<ChainTypes.Ethereum> = adapterManager.byChain(ChainTypes.Ethereum)
+  const adapter: ChainAdapter<ChainTypes.Ethereum> = (await adapterManager).byChain(
+    ChainTypes.Ethereum
+  )
   const bip44Params = adapter.buildBIP44Params({
     accountNumber: bnOrZero(quote.sellAssetAccountId).toNumber()
   }) // TODO: Add account number
@@ -58,7 +60,7 @@ export async function ZrxApproveInfinite(
     wallet,
     adapter,
     erc20Abi,
-    web3
+    web3: await web3
   })
 
   return allowanceGrantRequired

--- a/packages/swapper/src/swappers/zrx/ZrxBuildQuoteTx/ZrxBuildQuoteTx.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxBuildQuoteTx/ZrxBuildQuoteTx.ts
@@ -69,7 +69,7 @@ export async function ZrxBuildQuoteTx(
     )
   }
 
-  const adapter = adapterManager.byChain(buyAsset.chain)
+  const adapter = (await adapterManager).byChain(buyAsset.chain)
   const bip44Params = adapter.buildBIP44Params({ accountNumber: Number(buyAssetAccountId) })
   const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
 
@@ -159,7 +159,7 @@ export async function ZrxBuildQuoteTx(
 
     const allowanceRequired = await getAllowanceRequired({
       quote,
-      web3,
+      web3: await web3,
       erc20AllowanceAbi
     })
     quote.allowanceGrantRequired = allowanceRequired.gt(0)

--- a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts
@@ -1,5 +1,10 @@
-import { ChainTypes, ExecQuoteInput, ExecQuoteOutput, SwapperType } from '@shapeshiftoss/types'
-import { numberToHex } from 'web3-utils'
+import {
+  ChainTypes,
+  ExecQuoteInput,
+  ExecQuoteOutput,
+  numberToHex,
+  SwapperType
+} from '@shapeshiftoss/types'
 
 import { SwapError } from '../../../api'
 import { ZrxSwapperDeps } from '../ZrxSwapper'

--- a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts
@@ -39,7 +39,7 @@ export async function ZrxExecuteQuote(
 
   // value is 0 for erc20s
   const value = sellAsset.symbol === 'ETH' ? quote.sellAmount : '0'
-  const adapter = adapterManager.byChain(sellAsset.chain)
+  const adapter = (await adapterManager).byChain(sellAsset.chain)
   const bip44Params = adapter.buildBIP44Params({
     accountNumber: Number(quote.sellAssetAccountId)
   })

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -26,9 +26,10 @@ import { ZrxApprovalNeeded } from './ZrxApprovalNeeded/ZrxApprovalNeeded'
 import { ZrxApproveInfinite } from './ZrxApproveInfinite/ZrxApproveInfinite'
 import { ZrxBuildQuoteTx } from './ZrxBuildQuoteTx/ZrxBuildQuoteTx'
 import { ZrxExecuteQuote } from './ZrxExecuteQuote/ZrxExecuteQuote'
+
 export type ZrxSwapperDeps = {
-  adapterManager: ChainAdapterManager
-  web3: Web3
+  adapterManager: ChainAdapterManager | Promise<ChainAdapterManager>
+  web3: Web3 | Promise<Web3>
 }
 
 export class ZrxError extends Error {

--- a/packages/swapper/src/swappers/zrx/getZrxSendMaxAmount/getZrxSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxSendMaxAmount/getZrxSendMaxAmount.ts
@@ -16,7 +16,7 @@ export async function getZrxSendMaxAmount(
     feeEstimateKey = chainAdapters.FeeDataKey.Average
   }: SendMaxAmountInput
 ): Promise<string> {
-  const adapter = adapterManager.byChain(ChainTypes.Ethereum)
+  const adapter = (await adapterManager).byChain(ChainTypes.Ethereum)
   const bip44Params = adapter.buildBIP44Params({
     accountNumber: bnOrZero(sellAssetAccountId).toNumber()
   })

--- a/packages/swapper/src/swappers/zrx/utils/abi/erc20-abi.ts
+++ b/packages/swapper/src/swappers/zrx/utils/abi/erc20-abi.ts
@@ -1,4 +1,4 @@
-import { AbiItem } from 'web3-utils'
+import { /*type*/ AbiItem } from 'web3-utils' // TODO: import type once linter fixed
 
 export const erc20Abi: Array<AbiItem> = [
   {

--- a/packages/swapper/src/swappers/zrx/utils/abi/erc20Allowance-abi.ts
+++ b/packages/swapper/src/swappers/zrx/utils/abi/erc20Allowance-abi.ts
@@ -1,4 +1,4 @@
-import { AbiItem } from 'web3-utils'
+import { /*type*/ AbiItem } from 'web3-utils' // TODO: import type once linter fixed
 
 export const erc20AllowanceAbi: AbiItem[] = [
   {

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -1,10 +1,17 @@
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { Asset, ChainTypes, Quote, QuoteResponse, SwapperType } from '@shapeshiftoss/types'
+import {
+  Asset,
+  ChainTypes,
+  numberToHex,
+  Quote,
+  QuoteResponse,
+  SwapperType
+} from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
-import { AbiItem, numberToHex } from 'web3-utils'
+import { /*type*/ AbiItem } from 'web3-utils' // TODO: import type once linter fixed
 
 import { SwapError } from '../../../../api'
 import { ZrxError } from '../../ZrxSwapper'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export { chainAdapters }
 
 export * from './base'
 export * from './market'
+export * from './numberToHex'

--- a/packages/types/src/numberToHex.ts
+++ b/packages/types/src/numberToHex.ts
@@ -1,0 +1,92 @@
+import BN from 'bn.js'
+
+function isHexPrefixed(str: string): boolean {
+  if (typeof str !== 'string') {
+    throw new Error(
+      "[is-hex-prefixed] value must be type 'string', is currently type " +
+        typeof str +
+        ', while checking isHexPrefixed.'
+    )
+  }
+
+  return str.slice(0, 2) === '0x'
+}
+
+function stripHexPrefix<T>(str: T): T
+function stripHexPrefix(str: unknown): unknown {
+  if (typeof str !== 'string') {
+    return str
+  }
+
+  return isHexPrefixed(str) ? str.slice(2) : str
+}
+
+function numberToBN(
+  arg: string | number | (BN & Partial<Record<'pop' | 'push' | 'dividedToIntegerBy', unknown>>)
+): BN {
+  if (typeof arg === 'string' || typeof arg === 'number') {
+    var multiplier = new BN(1); // eslint-disable-line
+    const formattedString = String(arg)
+      .toLowerCase()
+      .trim()
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const isHexPrefixed =
+      formattedString.substr(0, 2) === '0x' || formattedString.substr(0, 3) === '-0x'
+    var stringArg = stripHexPrefix(formattedString); // eslint-disable-line
+    if (stringArg.substr(0, 1) === '-') {
+      stringArg = stripHexPrefix(stringArg.slice(1))
+      multiplier = new BN(-1, 10)
+    }
+    stringArg = stringArg === '' ? '0' : stringArg
+
+    if (
+      (!stringArg.match(/^-?[0-9]+$/) && stringArg.match(/^[0-9A-Fa-f]+$/)) ||
+      stringArg.match(/^[a-fA-F]+$/) ||
+      (isHexPrefixed === true && stringArg.match(/^[0-9A-Fa-f]+$/))
+    ) {
+      return new BN(stringArg, 16).mul(multiplier)
+    }
+
+    if ((stringArg.match(/^-?[0-9]+$/) || stringArg === '') && isHexPrefixed === false) {
+      return new BN(stringArg, 10).mul(multiplier)
+    }
+  } else if (typeof arg === 'object' && arg.toString && !arg.pop && !arg.push) {
+    if (arg.toString(10).match(/^-?[0-9]+$/) && (arg.mul || arg.dividedToIntegerBy)) {
+      return new BN(arg.toString(10), 10)
+    }
+  }
+
+  throw new Error(
+    '[number-to-bn] while converting number ' +
+      JSON.stringify(arg) +
+      ' to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported.'
+  )
+}
+
+function isHexStrict(hex: unknown): boolean {
+  return (
+    (typeof hex === 'string' || typeof hex === 'number') &&
+    /^(-)?0x[0-9a-f]*$/i.test(hex.toString())
+  )
+}
+
+function toBN(number: number | string | BN): BN {
+  try {
+    return numberToBN(number)
+  } catch (e) {
+    throw new Error(e + ' Given value: "' + number + '"')
+  }
+}
+
+export function numberToHex(value: string | number | BN): string {
+  if (value === null || value === undefined) return value
+
+  if (!isFinite(Number(value)) && !isHexStrict(value)) {
+    throw new Error(`Given input "${value}" is not a number.`)
+  }
+
+  const number = toBN(value)
+  const result = number.toString(16)
+
+  return number.lt(new BN(0)) ? '-0x' + result.substr(1) : '0x' + result
+}


### PR DESCRIPTION
- Loading web3-utils is a very expensive operation just to get numberToHex. I've copied over (and typed) the implementation more-or-less verbatim -- we might want to use another library or different impl though.
- Initializing AssetService is a CPU-heavy process, but in order to offload it to a worker the API needs to be full-async.
- Once again #181 prevents us from having some nice things.