### PR TITLE
[WIP] refactor BitcoinChainAdapter to UTXOChainAdapter

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -2,7 +2,7 @@ import { ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapter } from './api'
-import * as bitcoin from './bitcoin'
+import * as bitcoin from './utxo'
 import * as ethereum from './ethereum'
 
 export type UnchainedUrl = {

--- a/packages/chain-adapters/src/bitcoin/index.ts
+++ b/packages/chain-adapters/src/bitcoin/index.ts
@@ -1,1 +1,0 @@
-export * from './BitcoinChainAdapter'

--- a/packages/chain-adapters/src/utxo/UTXOChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/UTXOChainAdapter.test.ts
@@ -10,7 +10,7 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 
-import * as bitcoin from './BitcoinChainAdapter'
+import * as bitcoin from './UTXOChainAdapter'
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 

--- a/packages/chain-adapters/src/utxo/index.ts
+++ b/packages/chain-adapters/src/utxo/index.ts
@@ -1,0 +1,1 @@
+export * from './UTXOChainAdapter'


### PR DESCRIPTION
### Description
This will refactor the BitcoinChainAdapter to a more generic UTXOChainAdapter and add the required changes to support multiple chains.
### WIP
- [X] getType() should return the UTXO ChainType that is based on the arguments passed into the constructor.
- [X] getCaip2() should return correct caip2 based on the UTXO passed into the constructor
- [X] getAccount() returns a more generic promise type with a correct chain in the return object
- [X] getTxHistory() returns a more generic promise type with a correct chain in the return object
- [ ] Add / modify unit tests for the new generic adapter
- [ ] Search for anywhere we are creating this chain adapter in a hard-coded fashion would need to be updated.