### PR TITLE
feat(buildSendTransaction): throw on sendMax with 0 balance

### DIFF
--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -169,6 +169,8 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
           if (!erc20Balance) throw new Error('no balance')
           tx.value = erc20Balance
         } else {
+          if (new BigNumber(account.balance).isZero()) throw new Error('no balance')
+
           const fee = new BigNumber(gasPrice).times(gasLimit)
           tx.value = new BigNumber(account.balance).minus(fee).toString()
         }


### PR DESCRIPTION
This was spotted while writing `EthereumChainAdapter` tests in #313.
When building a send tx and using the `sendMax` option, we currently throw on no ERC20 balance, but we don't in case of no native token balance.