### PR TITLE
feat: add isTrusted to description of asset service

### DIFF
--- a/packages/asset-service/src/service/AssetService.test.ts
+++ b/packages/asset-service/src/service/AssetService.test.ts
@@ -145,9 +145,10 @@ describe('AssetService', () => {
     it('should return the overridden description if it exists', async () => {
       const assetService = new AssetService(assetFileUrl)
 
-      await expect(assetService.description({ asset: EthAsset })).resolves.toEqual(
-        'overriden description'
-      )
+      await expect(assetService.description({ asset: EthAsset })).resolves.toEqual({
+        description: 'overriden description',
+        isTrusted: true
+      })
     })
 
     it('should return a string if found', async () => {
@@ -157,7 +158,10 @@ describe('AssetService', () => {
       const assetService = new AssetService(assetFileUrl)
       const description = { en: 'a blue fox' }
       mockedAxios.get.mockResolvedValue({ data: { description } })
-      await expect(assetService.description({ asset: EthAsset })).resolves.toEqual(description.en)
+      await expect(assetService.description({ asset: EthAsset })).resolves.toEqual({
+        description: description.en,
+        isTrusted: false
+      })
     })
 
     it('should throw if not found', async () => {

--- a/packages/asset-service/src/service/AssetService.test.ts
+++ b/packages/asset-service/src/service/AssetService.test.ts
@@ -38,7 +38,7 @@ const EthAsset: Asset = {
 jest.mock(
   './descriptions.json',
   () => ({
-    'eip155:3/slip44:60': 'overriden description'
+    'eip155:3/slip44:60': 'overridden description'
   }),
   { virtual: true }
 )
@@ -146,7 +146,7 @@ describe('AssetService', () => {
       const assetService = new AssetService(assetFileUrl)
 
       await expect(assetService.description({ asset: EthAsset })).resolves.toEqual({
-        description: 'overriden description',
+        description: 'overridden description',
         isTrusted: true
       })
     })
@@ -159,8 +159,7 @@ describe('AssetService', () => {
       const description = { en: 'a blue fox' }
       mockedAxios.get.mockResolvedValue({ data: { description } })
       await expect(assetService.description({ asset: EthAsset })).resolves.toEqual({
-        description: description.en,
-        isTrusted: false
+        description: description.en
       })
     })
 

--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -47,6 +47,11 @@ type ByTokenIdArgs = {
   tokenId?: string
 }
 
+type DescriptionData = {
+  description: string
+  isTrusted: boolean
+}
+
 export class AssetService {
   private assetFileUrl?: string
 
@@ -114,13 +119,24 @@ export class AssetService {
     return result
   }
 
-  async description({ asset }: { asset: Asset }): Promise<string> {
+  async description({ asset }: { asset: Asset }): Promise<DescriptionData> {
     const descriptions: Record<string, string> = assetsDescriptions
 
-    // Return overriden asset description if it exists
-    if (descriptions[asset.caip19]) return descriptions[asset.caip19]
+    // Return overriden asset description if it exists and add isTrusted for description links
+    if (descriptions[asset.caip19]) {
+      return {
+        description: descriptions[asset.caip19],
+        isTrusted: true
+      }
+    }
 
-    if (asset.dataSource !== AssetDataSource.CoinGecko) return ''
+    if (asset.dataSource !== AssetDataSource.CoinGecko) {
+      return {
+        description: '',
+        isTrusted: false
+      }
+    }
+
     const contractUrl =
       typeof asset.tokenId === 'string' ? `/contract/${asset.tokenId?.toLowerCase()}` : ''
     const errorMessage = `AssetService:description: no description availble for ${asset.tokenId} on chain ${asset.chain}`
@@ -134,7 +150,11 @@ export class AssetService {
       const { data } = await axios.get<CoinData>(
         `https://api.coingecko.com/api/v3/coins/${asset.chain}${contractUrl}`
       )
-      return data?.description?.en ?? ''
+
+      return {
+        description: data?.description?.en ?? '',
+        isTrusted: false
+      }
     } catch (e) {
       throw new Error(errorMessage)
     }

--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -47,10 +47,10 @@ type ByTokenIdArgs = {
   tokenId?: string
 }
 
-type DescriptionData = {
+type DescriptionData = Readonly<{
   description: string
-  isTrusted: boolean
-}
+  isTrusted?: boolean
+}>
 
 export class AssetService {
   private assetFileUrl?: string
@@ -122,7 +122,7 @@ export class AssetService {
   async description({ asset }: { asset: Asset }): Promise<DescriptionData> {
     const descriptions: Record<string, string> = assetsDescriptions
 
-    // Return overriden asset description if it exists and add isTrusted for description links
+    // Return overridden asset description if it exists and add isTrusted for description links
     if (descriptions[asset.caip19]) {
       return {
         description: descriptions[asset.caip19],
@@ -131,10 +131,7 @@ export class AssetService {
     }
 
     if (asset.dataSource !== AssetDataSource.CoinGecko) {
-      return {
-        description: '',
-        isTrusted: false
-      }
+      return { description: '' }
     }
 
     const contractUrl =
@@ -151,10 +148,7 @@ export class AssetService {
         `https://api.coingecko.com/api/v3/coins/${asset.chain}${contractUrl}`
       )
 
-      return {
-        description: data?.description?.en ?? '',
-        isTrusted: false
-      }
+      return { description: data?.description?.en ?? '' }
     } catch (e) {
       throw new Error(errorMessage)
     }

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -37,7 +37,7 @@
     "@shapeshiftoss/caip": "^1.5.1",
     "@shapeshiftoss/hdwallet-core": "^1.18.2",
     "@shapeshiftoss/hdwallet-native": "^1.18.2",
-    "@shapeshiftoss/types": "^1.20.1",
+    "@shapeshiftoss/types": "^1.21.1",
     "@shapeshiftoss/unchained-client": "^5.1.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.1.0",
     "bs58check": "^2.0.0"
@@ -46,7 +46,7 @@
     "@shapeshiftoss/caip": "^1.5.1",
     "@shapeshiftoss/hdwallet-core": "^1.18.2",
     "@shapeshiftoss/hdwallet-native": "^1.18.2",
-    "@shapeshiftoss/types": "^1.20.0",
+    "@shapeshiftoss/types": "^1.21.1",
     "@shapeshiftoss/unchained-client": "^5.1.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.1.0",
     "@types/bs58check": "^2.1.0",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -33,10 +33,10 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^1.4.2",
-    "@shapeshiftoss/types": "^1.13.1"
+    "@shapeshiftoss/types": "^1.21.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^1.4.2",
-    "@shapeshiftoss/types": "^1.13.1"
+    "@shapeshiftoss/types": "^1.21.1"
   }
 }

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -51,6 +51,7 @@ type AbstractAsset = {
   caip2: string
   chain: ChainTypes
   description?: string
+  isTrustedDescription?: boolean
   dataSource: AssetDataSource
   network: NetworkTypes
   symbol: string


### PR DESCRIPTION
Add `isTrusted` boolean to asset service description function in order to determine the trusted (hard coded in the `descriptions.json` file) and non trusted (3rd party) descriptions.