### PR TITLE
fix: verify than token address is not empty inside ethTokens

### DIFF
--- a/packages/asset-service/src/generateAssetData/ethTokens/index.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/index.ts
@@ -37,7 +37,7 @@ export async function getTokens(): Promise<TokenAsset[]> {
   const network = NetworkTypes.MAINNET
   const contractType = ContractTypes.ERC20
 
-  const tokens = uniswapTokenData.tokens.map((token) => {
+  const tokens = uniswapTokenData.tokens.flatMap((token) => {
     const overrideToken: TokenAsset | undefined = lodash.find(
       tokensToOverride,
       (override: TokenAsset) => override.tokenId === token.address

--- a/packages/asset-service/src/generateAssetData/ethTokens/index.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/index.ts
@@ -47,6 +47,8 @@ export async function getTokens(): Promise<TokenAsset[]> {
 
     const tokenId = token.address.toLowerCase()
 
+    if (!tokenId) return []
+
     const result: TokenAsset = {
       caip19: caip19.toCAIP19({ chain, network, contractType, tokenId }),
       caip2: caip2.toCAIP2({ chain, network }),


### PR DESCRIPTION
Currently, the CI crash because there is a token with an empty address on coingecko

# How to test?

Verify that the CI is ✅ 