### PR TITLE
feat: ratelimits on market service adapters

### DIFF
--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.5.1",
     "@yfi/sdk": "^1.0.27",
-    "axios": "^0.21.2",
+    "axios": "^0.25.0",
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.1",
     "dayjs": "^1.10.6"

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -28,6 +28,7 @@
     "@ethersproject/providers": "^5.5.1",
     "@yfi/sdk": "^1.0.27",
     "axios": "^0.21.2",
+    "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.1",
     "dayjs": "^1.10.6"
   },

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -30,7 +30,8 @@
     "axios": "^0.25.0",
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.1",
-    "dayjs": "^1.10.6"
+    "dayjs": "^1.10.6",
+    "p-ratelimit": "^1.0.1"
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^1.4.2",

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -47,18 +47,16 @@ describe('coincap market service', () => {
 
     const apiCalls: number[] = []
 
-    const callApi = async () => {
+    const apiCalled = () => {
       if (apiCalls.length > COINCAP_MAX_RPS) {
         setTimeout(() => {
           apiCalls.length = 0
         }, 1000)
         return 429
       }
-      mockedAxios.get
-        .mockResolvedValueOnce({ data: { data: [eth] } })
-        .mockResolvedValue({ data: { data: [btc] } })
-      const result = await coinMarketService.findAll()
-      return result
+      if (Date.now() - apiCalls[0] > 1000) apiCalls.length = 0
+      apiCalls.push(Date.now())
+      return 200
     }
 
     it('can flatten multiple responses', async () => {
@@ -86,8 +84,12 @@ describe('coincap market service', () => {
     it('does not get rate limited', async () => {
       // using COINCAP_MAX_RPS * 10 here to demonstrate that it does not get ratelimited
       for (let index = 0; index < COINCAP_MAX_RPS * 10; index++) {
-        const result = await callApi()
-        expect(Object.keys(result)[0]).toEqual(adapters.coincapToCAIP19(btc.id))
+        mockedAxios.get
+          .mockResolvedValueOnce({ data: { data: [eth] } })
+          .mockResolvedValue({ data: { data: [btc] } })
+        await coinMarketService.findAll().then(() => {
+          expect(apiCalled).toEqual(200)
+        })
       }
     })
 

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -2,15 +2,14 @@ import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
+import { COINCAP_MAX_RPS } from '../constants'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinCapMarketService } from './coincap'
 import { CoinCapMarketCap } from './coincap-types'
 
 const coinMarketService = new CoinCapMarketService()
 
-// 200 requests per minute or ~3 requests per second as per https://docs.coincap.io/ "Limits" section
-const maxRPS = 8
-const axios = getRatelimitedAxios(maxRPS)
+const axios = getRatelimitedAxios(COINCAP_MAX_RPS)
 
 const mockedAxios = axios as jest.Mocked<RateLimitedAxiosInstance>
 
@@ -69,8 +68,8 @@ describe('coincap market service', () => {
     })
 
     it('does not get rate limited', async () => {
-      // using maxRPS * 10 here to demonstrate that it does not get ratelimited
-      for (let index = 0; index < maxRPS * 10; index++) {
+      // using COINCAP_MAX_RPS * 10 here to demonstrate that it does not get ratelimited
+      for (let index = 0; index < COINCAP_MAX_RPS * 10; index++) {
         mockedAxios.get
           .mockResolvedValueOnce({ data: { data: [eth] } })
           .mockResolvedValue({ data: { data: [btc] } })

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -2,13 +2,13 @@ import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
-import { COINCAP_MAX_RPS } from '../constants'
+import { COINCAP_MAX_RPM } from '../constants'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinCapMarketService } from './coincap'
 import { CoinCapMarketCap } from './coincap-types'
 
 const coinMarketService = new CoinCapMarketService()
-const axios = getRatelimitedAxios(COINCAP_MAX_RPS)
+const axios = getRatelimitedAxios(COINCAP_MAX_RPM)
 
 jest.mock('axios')
 

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -1,15 +1,18 @@
 import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import axios from 'axios'
+import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
+import { COINCAP_MAX_RPS } from '../constants'
+import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinCapMarketService } from './coincap'
 import { CoinCapMarketCap } from './coincap-types'
 
 const coinMarketService = new CoinCapMarketService()
+const axios = getRatelimitedAxios(COINCAP_MAX_RPS)
 
 jest.mock('axios')
 
-const mockedAxios = axios as jest.Mocked<typeof axios>
+const mockedAxios = axios as jest.Mocked<RateLimitedAxiosInstance>
 
 describe('coincap market service', () => {
   describe('getMarketCap', () => {

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -45,6 +45,22 @@ describe('coincap market service', () => {
       explorer: 'https://etherscan.io/'
     }
 
+    const apiCalls: number[] = []
+
+    const callApi = async () => {
+      if (apiCalls.length > COINCAP_MAX_RPS) {
+        setTimeout(() => {
+          apiCalls.length = 0
+        }, 1000)
+        return 429
+      }
+      mockedAxios.get
+        .mockResolvedValueOnce({ data: { data: [eth] } })
+        .mockResolvedValue({ data: { data: [btc] } })
+      const result = await coinMarketService.findAll()
+      return result
+    }
+
     it('can flatten multiple responses', async () => {
       mockedAxios.get
         .mockResolvedValueOnce({ data: { data: [eth] } })
@@ -70,10 +86,7 @@ describe('coincap market service', () => {
     it('does not get rate limited', async () => {
       // using COINCAP_MAX_RPS * 10 here to demonstrate that it does not get ratelimited
       for (let index = 0; index < COINCAP_MAX_RPS * 10; index++) {
-        mockedAxios.get
-          .mockResolvedValueOnce({ data: { data: [eth] } })
-          .mockResolvedValue({ data: { data: [btc] } })
-        const result = await coinMarketService.findAll()
+        const result = await callApi()
         expect(Object.keys(result)[0]).toEqual(adapters.coincapToCAIP19(btc.id))
       }
     })

--- a/packages/market-service/src/coincap/coincap.ts
+++ b/packages/market-service/src/coincap/coincap.ts
@@ -13,13 +13,13 @@ import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
-import { COINCAP_MAX_RPS } from '../constants'
+import { COINCAP_MAX_RPM } from '../constants'
 import { bn, bnOrZero } from '../utils/bignumber'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
 import { CoinCapMarketCap } from './coincap-types'
 
-const axios = getRatelimitedAxios(COINCAP_MAX_RPS)
+const axios = getRatelimitedAxios(COINCAP_MAX_RPM)
 
 export class CoinCapMarketService implements MarketService {
   baseUrl = 'https://api.coincap.io/v2'

--- a/packages/market-service/src/coincap/coincap.ts
+++ b/packages/market-service/src/coincap/coincap.ts
@@ -9,14 +9,17 @@ import {
   MarketDataArgs,
   PriceHistoryArgs
 } from '@shapeshiftoss/types'
-import axios from 'axios'
 import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
 import { bn, bnOrZero } from '../utils/bignumber'
+import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
 import { CoinCapMarketCap } from './coincap-types'
+
+// 200 requests per minute or ~3 requests per second as per https://docs.coincap.io/ "Limits" section
+const axios = getRatelimitedAxios(3)
 
 export class CoinCapMarketService implements MarketService {
   baseUrl = 'https://api.coincap.io/v2'

--- a/packages/market-service/src/coincap/coincap.ts
+++ b/packages/market-service/src/coincap/coincap.ts
@@ -13,13 +13,13 @@ import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
+import { COINCAP_MAX_RPS } from '../constants'
 import { bn, bnOrZero } from '../utils/bignumber'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
 import { CoinCapMarketCap } from './coincap-types'
 
-// 200 requests per minute or ~3 requests per second as per https://docs.coincap.io/ "Limits" section
-const axios = getRatelimitedAxios(3)
+const axios = getRatelimitedAxios(COINCAP_MAX_RPS)
 
 export class CoinCapMarketService implements MarketService {
   baseUrl = 'https://api.coincap.io/v2'

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -2,12 +2,12 @@ import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
-import { COINGECKO_MAX_RPS } from '../constants'
+import { COINGECKO_MAX_RPM } from '../constants'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinGeckoMarketService } from './coingecko'
 import { CoinGeckoMarketCap } from './coingecko-types'
 
-const axios = getRatelimitedAxios(COINGECKO_MAX_RPS)
+const axios = getRatelimitedAxios(COINGECKO_MAX_RPM)
 
 jest.mock('axios')
 

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -1,13 +1,17 @@
 import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import axios from 'axios'
+import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
+import { COINGECKO_MAX_RPS } from '../constants'
+import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinGeckoMarketService } from './coingecko'
 import { CoinGeckoMarketCap } from './coingecko-types'
 
+const axios = getRatelimitedAxios(COINGECKO_MAX_RPS)
+
 jest.mock('axios')
 
-const mockedAxios = axios as jest.Mocked<typeof axios>
+const mockedAxios = axios as jest.Mocked<RateLimitedAxiosInstance>
 
 const coinGeckoMarketService = new CoinGeckoMarketService()
 

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -2,13 +2,12 @@ import { adapters } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { RateLimitedAxiosInstance } from 'axios-rate-limit'
 
+import { COINGECKO_MAX_RPS } from '../constants'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { CoinGeckoMarketService } from './coingecko'
 import { CoinGeckoMarketCap } from './coingecko-types'
 
-// 8 requests per second as per https://www.coingecko.com/en/api_terms section 4.2
-const maxRPS = 8
-const axios = getRatelimitedAxios(maxRPS)
+const axios = getRatelimitedAxios(COINGECKO_MAX_RPS)
 
 const mockedAxios = axios as jest.Mocked<RateLimitedAxiosInstance>
 
@@ -97,8 +96,8 @@ describe('coingecko market service', () => {
     })
 
     it('does not get rate limited', async () => {
-      // using maxRPS * 10 here to demonstrate that it does not get ratelimited
-      for (let index = 0; index < maxRPS * 10; index++) {
+      // using COINGECKO_MAX_RPS * 10 here to demonstrate that it does not get ratelimited
+      for (let index = 0; index < COINGECKO_MAX_RPS * 10; index++) {
         mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
         const result = await coinGeckoMarketService.findAll()
         expect(Object.keys(result)[0]).toEqual(adapters.coingeckoToCAIP19(btc.id))

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -10,12 +10,12 @@ import {
   MarketDataArgs,
   PriceHistoryArgs
 } from '@shapeshiftoss/types'
-import axios from 'axios'
 import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
 import { bn, bnOrZero } from '../utils/bignumber'
+import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
 import { CoinGeckoMarketCap } from './coingecko-types'
 
@@ -33,6 +33,9 @@ type CoinGeckoAssetData = {
     price_change_percentage_24h: number
   }
 }
+
+// 8 requests per second as per https://www.coingecko.com/en/api_terms section 4.2
+const axios = getRatelimitedAxios(8)
 
 export class CoinGeckoMarketService implements MarketService {
   baseUrl = 'https://api.coingecko.com/api/v3'

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -14,6 +14,7 @@ import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
+import { COINGECKO_MAX_RPS } from '../constants'
 import { bn, bnOrZero } from '../utils/bignumber'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
@@ -34,8 +35,7 @@ type CoinGeckoAssetData = {
   }
 }
 
-// 8 requests per second as per https://www.coingecko.com/en/api_terms section 4.2
-const axios = getRatelimitedAxios(8)
+const axios = getRatelimitedAxios(COINGECKO_MAX_RPS)
 
 export class CoinGeckoMarketService implements MarketService {
   baseUrl = 'https://api.coingecko.com/api/v3'

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -14,7 +14,7 @@ import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 
 import { MarketService } from '../api'
-import { COINGECKO_MAX_RPS } from '../constants'
+import { COINGECKO_MAX_RPM } from '../constants'
 import { bn, bnOrZero } from '../utils/bignumber'
 import { getRatelimitedAxios } from '../utils/getRatelimitedAxios'
 import { isValidDate } from '../utils/isValidDate'
@@ -35,7 +35,7 @@ type CoinGeckoAssetData = {
   }
 }
 
-const axios = getRatelimitedAxios(COINGECKO_MAX_RPS)
+const axios = getRatelimitedAxios(COINGECKO_MAX_RPM)
 
 export class CoinGeckoMarketService implements MarketService {
   baseUrl = 'https://api.coingecko.com/api/v3'

--- a/packages/market-service/src/constants.ts
+++ b/packages/market-service/src/constants.ts
@@ -1,0 +1,4 @@
+// 8 requests per second as per https://www.coingecko.com/en/api_terms section 4.2
+export const COINGECKO_MAX_RPS = 8
+// 200 requests per minute or ~3 requests per second as per https://docs.coincap.io/ "Limits" section
+export const COINCAP_MAX_RPS = 3

--- a/packages/market-service/src/constants.ts
+++ b/packages/market-service/src/constants.ts
@@ -1,4 +1,4 @@
-// 8 requests per second as per https://www.coingecko.com/en/api_terms section 4.2
-export const COINGECKO_MAX_RPS = 8
-// 200 requests per minute or ~3 requests per second as per https://docs.coincap.io/ "Limits" section
-export const COINCAP_MAX_RPS = 3
+// 50 requests per minute as per https://www.coingecko.com/en/api/documentation
+export const COINGECKO_MAX_RPS = 50
+// 200 requests per minute as per https://docs.coincap.io/ "Limits" section
+export const COINCAP_MAX_RPS = 200

--- a/packages/market-service/src/constants.ts
+++ b/packages/market-service/src/constants.ts
@@ -1,4 +1,6 @@
 // 50 requests per minute as per https://www.coingecko.com/en/api/documentation
-export const COINGECKO_MAX_RPS = 50
+export const COINGECKO_MAX_RPM = 50
 // 200 requests per minute as per https://docs.coincap.io/ "Limits" section
-export const COINCAP_MAX_RPS = 200
+export const COINCAP_MAX_RPM = 200
+// 500 requests per minute as yearn api has no limits, see https://github.com/shapeshift/lib/pull/368#issuecomment-1039722564
+export const YEARN_MAX_RPM = 500

--- a/packages/market-service/src/utils/getRatelimitedAxios.test.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.test.ts
@@ -4,8 +4,8 @@ import http from 'http'
 import { getRatelimitedAxios } from './getRatelimitedAxios'
 
 const MAX_RPS = 10
-// setting MAX_RPS to 10 and perMilliseconds to 1000 to make it so we send not more than 10 requests every second
-const ratelimitedAxios = getRatelimitedAxios(MAX_RPS, 1000)
+// setting maxRequests to 9 and perMilliseconds to 1000 to make sure we don't send not more than 10 requests every second
+const ratelimitedAxios = getRatelimitedAxios(MAX_RPS - 1, 1000)
 
 // setting this to 1 minute as we need a good amount of time for our tests to run
 jest.setTimeout(60000)

--- a/packages/market-service/src/utils/getRatelimitedAxios.test.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.test.ts
@@ -9,6 +9,8 @@ const ratelimitedAxios = getRatelimitedAxios(MAX_RPS - 1, 1000)
 
 // setting this to 1 minute as we need a good amount of time for our tests to run
 jest.setTimeout(60000)
+// enabling mock timers so we don't slow down CI
+jest.useFakeTimers()
 
 const apiCalls: number[] = []
 

--- a/packages/market-service/src/utils/getRatelimitedAxios.test.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.test.ts
@@ -1,0 +1,60 @@
+import axios from 'axios'
+import http from 'http'
+
+import { getRatelimitedAxios } from './getRatelimitedAxios'
+
+const MAX_RPS = 10
+// setting MAX_RPS to 10 and perMilliseconds to 1000 to make it so we send not more than 10 requests every second
+const ratelimitedAxios = getRatelimitedAxios(MAX_RPS, 1000)
+
+// setting this to 1 minute as we need a good amount of time for our tests to run
+jest.setTimeout(60000)
+
+const apiCalls: number[] = []
+
+const server = http
+  .createServer((_req, res) => {
+    if (apiCalls.length > MAX_RPS) {
+      setTimeout(() => {
+        apiCalls.length = 0
+      }, 1000)
+      res.writeHead(429)
+      return res.end()
+    }
+    if (Date.now() - apiCalls[0] > 1000) apiCalls.length = 0
+    apiCalls.push(Date.now())
+    res.writeHead(200)
+    return res.end()
+  })
+  .listen(8080)
+
+describe('axios rate limit', () => {
+  it('gets rate limited', async () => {
+    // using MAX_RPS * 2 here to demonstrate that it gets ratelimited
+    for (let index = 0; index < MAX_RPS * 2; index++) {
+      try {
+        const resp = await axios.get('http://localhost:8080')
+        expect(resp.status).toEqual(200)
+      } catch (error) {
+        // we need to do this conditionally as axios throws an error on 429
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(error.response.status).toEqual(429)
+      }
+    }
+  })
+
+  it('does not get rate limited', async () => {
+    // making sure our api call history from the previous test is cleared
+    apiCalls.length = 0
+    // using MAX_RPS * 2 here to demonstrate that it does not get ratelimited
+    for (let index = 0; index < MAX_RPS * 2; index++) {
+      const resp = await ratelimitedAxios.get('http://localhost:8080')
+      expect(resp.status).toEqual(200)
+    }
+  })
+})
+
+afterAll(() => {
+  // gracefully shutting down the http server
+  server.close()
+})

--- a/packages/market-service/src/utils/getRatelimitedAxios.test.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.test.ts
@@ -4,22 +4,15 @@ import http from 'http'
 import { getRatelimitedAxios } from './getRatelimitedAxios'
 
 const MAX_RPS = 10
-// setting maxRequests to 9 and perMilliseconds to 1000 to make sure we don't send not more than 10 requests every second
-const ratelimitedAxios = getRatelimitedAxios(MAX_RPS - 1, 1000)
-
-// setting this to 1 minute as we need a good amount of time for our tests to run
-jest.setTimeout(60000)
-// enabling mock timers so we don't slow down CI
-jest.useFakeTimers()
+// setting maxRequests to 10 and perMilliseconds to 1000 to make sure we don't send not more than 10 requests every second
+const ratelimitedAxios = getRatelimitedAxios(MAX_RPS, 1000)
 
 const apiCalls: number[] = []
 
 const server = http
   .createServer((_req, res) => {
     if (apiCalls.length > MAX_RPS) {
-      setTimeout(() => {
-        apiCalls.length = 0
-      }, 1000)
+      apiCalls.length = 0
       res.writeHead(429)
       return res.end()
     }

--- a/packages/market-service/src/utils/getRatelimitedAxios.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import rateLimit from 'axios-rate-limit'
+import axiosRateLimit from 'axios-rate-limit'
 
 // defaulting perMilliseconds to 60000 as both coingecko and coincap provide
 // xxx requests per minute (60000 ms) rate limits
 export const getRatelimitedAxios = (maxRequests: number, perMilliseconds = 60000) => {
-  return rateLimit(axios.create(), { maxRequests, perMilliseconds })
+  return axiosRateLimit(axios, { maxRequests, perMilliseconds })
 }

--- a/packages/market-service/src/utils/getRatelimitedAxios.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import rateLimit from 'axios-rate-limit'
 
-export const getRatelimitedAxios = (rps: number, perMilliseconds = 1000) => {
-  return rateLimit(axios.create(), { maxRequests: rps, perMilliseconds })
+// defaulting perMilliseconds to 60000 as both coingecko and coincap provide
+// xxx requests per minute (60000 ms) rate limits
+export const getRatelimitedAxios = (maxRequests: number, perMilliseconds = 60000) => {
+  return rateLimit(axios.create(), { maxRequests, perMilliseconds })
 }

--- a/packages/market-service/src/utils/getRatelimitedAxios.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.ts
@@ -1,0 +1,6 @@
+import axios from 'axios'
+import rateLimit from 'axios-rate-limit'
+
+export const getRatelimitedAxios = (rps: number) => {
+  return rateLimit(axios.create(), { maxRequests: rps, perMilliseconds: 1000, maxRPS: rps })
+}

--- a/packages/market-service/src/utils/getRatelimitedAxios.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import rateLimit from 'axios-rate-limit'
 
-export const getRatelimitedAxios = (rps: number) => {
-  return rateLimit(axios.create(), { maxRequests: rps, perMilliseconds: 1000, maxRPS: rps })
+export const getRatelimitedAxios = (rps: number, perMilliseconds = 1000) => {
+  return rateLimit(axios.create(), { maxRequests: rps, perMilliseconds })
 }

--- a/packages/market-service/src/utils/getRatelimitedAxios.ts
+++ b/packages/market-service/src/utils/getRatelimitedAxios.ts
@@ -3,6 +3,6 @@ import axiosRateLimit from 'axios-rate-limit'
 
 // defaulting perMilliseconds to 60000 as both coingecko and coincap provide
 // xxx requests per minute (60000 ms) rate limits
-export const getRatelimitedAxios = (maxRequests: number, perMilliseconds = 60000) => {
-  return axiosRateLimit(axios, { maxRequests, perMilliseconds })
+export const getRatelimitedAxios = (maxRequests: number, interval = 60000) => {
+  return axiosRateLimit(axios, { maxRequests, perMilliseconds: interval })
 }

--- a/packages/market-service/src/utils/getYearnRatelimiter.ts
+++ b/packages/market-service/src/utils/getYearnRatelimiter.ts
@@ -1,0 +1,11 @@
+import { pRateLimit } from 'p-ratelimit'
+
+import { YEARN_MAX_RPM } from '../constants'
+
+// defaulting perMilliseconds to 60000 as both coingecko and coincap provide
+export const yearnRatelimiter = (maxRequests = YEARN_MAX_RPM, interval = 60000) => {
+  return pRateLimit({
+    interval,
+    rate: maxRequests
+  })
+}

--- a/packages/market-service/src/utils/getYearnRatelimiter.ts
+++ b/packages/market-service/src/utils/getYearnRatelimiter.ts
@@ -2,7 +2,6 @@ import { pRateLimit } from 'p-ratelimit'
 
 import { YEARN_MAX_RPM } from '../constants'
 
-// defaulting perMilliseconds to 60000 as both coingecko and coincap provide
 export const yearnRatelimiter = (maxRequests = YEARN_MAX_RPM, interval = 60000) => {
   return pRateLimit({
     interval,

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -8,19 +8,13 @@ jest.mock('@yfi/sdk')
 
 const mockedYearnSdk = jest.fn(() => ({
   vaults: {
-    tokens: jest.fn(() => {
-      return mockYearnTokenRestData
-    })
+    tokens: jest.fn(() => Promise.resolve(mockYearnTokenRestData))
   },
   ironBank: {
-    tokens: jest.fn(() => {
-      return mockYearnTokenRestData
-    })
+    tokens: jest.fn(() => Promise.resolve(mockYearnTokenRestData))
   },
   tokens: {
-    supported: jest.fn(() => {
-      return mockYearnTokenRestData
-    })
+    supported: jest.fn(() => Promise.resolve(mockYearnTokenRestData))
   }
 }))()
 

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -41,9 +41,9 @@ export class YearnTokenMarketCapService implements MarketService {
     try {
       const argsToUse = { ...this.defaultGetByMarketCapArgs, ...args }
       const response = await Promise.allSettled([
-        ratelimit(this.yearnSdk.ironBank.tokens),
-        ratelimit(this.yearnSdk.tokens.supported),
-        ratelimit(this.yearnSdk.vaults.tokens)
+        ratelimit(() => this.yearnSdk.ironBank.tokens()),
+        ratelimit(() => this.yearnSdk.tokens.supported()),
+        ratelimit(() => this.yearnSdk.vaults.tokens())
       ])
       const [ironBankResponse, zapperResponse, underlyingTokensResponse] = response
 

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -41,9 +41,9 @@ export class YearnTokenMarketCapService implements MarketService {
     try {
       const argsToUse = { ...this.defaultGetByMarketCapArgs, ...args }
       const response = await Promise.allSettled([
-        ratelimit(() => this.yearnSdk.ironBank.tokens()),
-        ratelimit(() => this.yearnSdk.tokens.supported()),
-        ratelimit(() => this.yearnSdk.vaults.tokens())
+        ratelimit(this.yearnSdk.ironBank.tokens),
+        ratelimit(this.yearnSdk.tokens.supported),
+        ratelimit(this.yearnSdk.vaults.tokens)
       ])
       const [ironBankResponse, zapperResponse, underlyingTokensResponse] = response
 

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -15,12 +15,15 @@ import uniqBy from 'lodash/uniqBy'
 
 import { MarketService } from '../api'
 import { bnOrZero } from '../utils/bignumber'
+import { yearnRatelimiter } from '../utils/getYearnRatelimiter'
 
 type YearnTokenMarketCapServiceArgs = {
   yearnSdk: Yearn<ChainId>
 }
 
 const USDC_PRECISION = 6
+
+const ratelimit = yearnRatelimiter()
 
 export class YearnTokenMarketCapService implements MarketService {
   baseUrl = 'https://api.yearn.finance'
@@ -38,9 +41,9 @@ export class YearnTokenMarketCapService implements MarketService {
     try {
       const argsToUse = { ...this.defaultGetByMarketCapArgs, ...args }
       const response = await Promise.allSettled([
-        this.yearnSdk.ironBank.tokens(),
-        this.yearnSdk.tokens.supported(),
-        this.yearnSdk.vaults.tokens()
+        ratelimit(this.yearnSdk.ironBank.tokens),
+        ratelimit(this.yearnSdk.tokens.supported),
+        ratelimit(this.yearnSdk.vaults.tokens)
       ])
       const [ironBankResponse, zapperResponse, underlyingTokensResponse] = response
 
@@ -86,9 +89,9 @@ export class YearnTokenMarketCapService implements MarketService {
       // the price to web. Doing allSettled so that one rejection does not interfere with the other
       // calls.
       const response = await Promise.allSettled([
-        this.yearnSdk.ironBank.tokens(),
-        this.yearnSdk.tokens.supported(),
-        this.yearnSdk.vaults.tokens()
+        ratelimit(this.yearnSdk.ironBank.tokens),
+        ratelimit(this.yearnSdk.tokens.supported),
+        ratelimit(this.yearnSdk.vaults.tokens)
       ])
       const [ironBankResponse, zapperResponse, underlyingTokensResponse] = response
 

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -8,15 +8,17 @@ jest.mock('@yfi/sdk')
 
 const mockedYearnSdk = jest.fn(() => ({
   vaults: {
-    get: jest.fn((addresses) => {
-      return addresses
-        ? mockYearnVaultRestData.filter((datum) => addresses.includes(datum.address))
-        : mockYearnVaultRestData
-    })
+    get: jest.fn((addresses) =>
+      Promise.resolve(
+        addresses
+          ? mockYearnVaultRestData.filter((datum) => addresses.includes(datum.address))
+          : mockYearnVaultRestData
+      )
+    )
   },
   services: {
     subgraph: {
-      fetchQuery: jest.fn(() => mockYearnGQLData)
+      fetchQuery: jest.fn(() => Promise.resolve(mockYearnGQLData))
     }
   }
 }))()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,6 +3429,11 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios-rate-limit@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz#03241d24c231c47432dab6e8234cfde819253c2e"
+  integrity sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw==
+
 axios@0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,6 +3455,13 @@ axios@^0.24.0:
   dependencies:
     follow-redirects "^1.14.4"
 
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+  dependencies:
+    follow-redirects "^1.14.7"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5990,6 +5997,11 @@ follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+follow-redirects@^1.14.7:
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 foreach@^2.0.5:
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9315,6 +9315,11 @@ p-queue@^6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
+p-ratelimit@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/p-ratelimit/-/p-ratelimit-1.0.1.tgz#a07fb2419f9811feb99fb687f97e00aa0244ac3e"
+  integrity sha512-tKBGoow6aWRH68K2eQx+qc1gSegjd5VLirZYc1Yms9pPFsYQ9TFI6aMn0vJH2vmvzjNpjlWZOFft4aPUen2w0A==
+
 p-reduce@^2.0.0, p-reduce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"


### PR DESCRIPTION
this implements rate limits for coingecko, coincap and yearn market service adapters
closes #367

time spend working on this: 4hours