### PR TITLE
fix: incorrect usd rate for multiple assets

### DIFF
--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
@@ -53,6 +53,13 @@ describe('utils', () => {
       )
       const rate = await getUsdRate({ symbol: 'FOX' })
       expect(rate).toBe('0.5')
+      expect(zrxService.get).toHaveBeenCalledWith('/swap/v1/price', {
+        params: {
+          buyToken: 'USDC',
+          buyAmount: '1000000000',
+          sellToken: 'FOX'
+        }
+      });
     })
     it('getUsdRate fails', async () => {
       ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data: {} }))

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
@@ -59,7 +59,7 @@ describe('utils', () => {
           buyAmount: '1000000000',
           sellToken: 'FOX'
         }
-      });
+      })
     })
     it('getUsdRate fails', async () => {
       ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data: {} }))

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -102,7 +102,7 @@ export const getUsdRate = async (input: Pick<Asset, 'symbol' | 'tokenId'>): Prom
     {
       params: {
         buyToken: 'USDC',
-        buyAmount: '1000000', // $1
+        buyAmount: '1000000000', // rate is imprecise for low $ values, hence asking for $1000
         sellToken: tokenId || symbol
       }
     }


### PR DESCRIPTION
Fix for https://github.com/shapeshift/web/issues/568
The rate fetched from 0x api for $1 is imprecise for multiple assets, in practice we notice a more precise rate by fetching rate for $100 / $1000 value.