### PR TITLE
chore: update types packages for chain-adapters and market-service

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -37,7 +37,7 @@
     "@shapeshiftoss/caip": "^1.5.1",
     "@shapeshiftoss/hdwallet-core": "^1.18.2",
     "@shapeshiftoss/hdwallet-native": "^1.18.2",
-    "@shapeshiftoss/types": "^1.20.1",
+    "@shapeshiftoss/types": "^1.21.1",
     "@shapeshiftoss/unchained-client": "^5.1.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.1.0",
     "bs58check": "^2.0.0"
@@ -46,7 +46,7 @@
     "@shapeshiftoss/caip": "^1.5.1",
     "@shapeshiftoss/hdwallet-core": "^1.18.2",
     "@shapeshiftoss/hdwallet-native": "^1.18.2",
-    "@shapeshiftoss/types": "^1.20.0",
+    "@shapeshiftoss/types": "^1.21.1",
     "@shapeshiftoss/unchained-client": "^5.1.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.1.0",
     "@types/bs58check": "^2.1.0",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -33,10 +33,10 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^1.4.2",
-    "@shapeshiftoss/types": "^1.13.1"
+    "@shapeshiftoss/types": "^1.21.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^1.4.2",
-    "@shapeshiftoss/types": "^1.13.1"
+    "@shapeshiftoss/types": "^1.21.1"
   }
 }


### PR DESCRIPTION
Update package version of `types` package in `chain-adapters` and `market-service`