### PR TITLE
feat: add "byChainId" function to ChainAdapter Manager

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterManager.test.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.test.ts
@@ -42,10 +42,11 @@ describe('ChainAdapterManager', () => {
     })
 
     it('should add a network', () => {
-      expect(
-        // @ts-ignore
-        getCAM().addChain(ChainTypes.Ethereum, () => new ethereum.ChainAdapter())
-      ).toBeUndefined()
+      const cam = new ChainAdapterManager({})
+      expect(cam.getSupportedAdapters()).toHaveLength(0)
+      // @ts-ignore
+      cam.addChain(ChainTypes.Ethereum, () => ({}))
+      expect(cam.getSupportedAdapters()).toHaveLength(1)
     })
   })
 
@@ -76,6 +77,32 @@ describe('ChainAdapterManager', () => {
     it('should return array of adapter classes', () => {
       // @ts-ignore
       expect(getCAM().getSupportedAdapters()).toStrictEqual([expect.any(Function)])
+    })
+  })
+
+  describe('byChainId', () => {
+    it('should find a supported chain adapter', async () => {
+      const cam = new ChainAdapterManager({})
+      // @ts-ignore
+      cam.addChain(ChainTypes.Bitcoin, () => ({
+        getCaip2: async () => 'bip122:000000000019d6689c085ae165831e93'
+      }))
+      // @ts-ignore
+      cam.addChain(ChainTypes.Ethereum, () => ({
+        getCaip2: async () => 'eip155:1'
+      }))
+
+      await expect(cam.byChainId('eip155:1')).resolves.toBeTruthy()
+    })
+
+    it('should throw an error for an invalid ChainId', async () => {
+      const cam = new ChainAdapterManager({})
+      await expect(cam.byChainId('fake:caip2')).rejects.toThrow('invalid')
+    })
+
+    it('should throw an error if there is no supported adapter', async () => {
+      const cam = new ChainAdapterManager({})
+      await expect(cam.byChainId('eip155:1')).rejects.toThrow('not supported')
     })
   })
 })

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,3 +1,5 @@
+import type { CAIP2 } from '@shapeshiftoss/caip'
+import { caip2 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
@@ -53,7 +55,7 @@ export class ChainAdapterManager {
    * import { ChainAdapterManager, UtxoChainAdapter } from 'chain-adapters'
    * const manager = new ChainAdapterManager(client)
    * manager.addChain('bitcoin', () => new UtxoChainAdapter('BTG', client))
-   * @param {ChainTypes} network - Coin/network symbol from Asset query
+   * @param {ChainTypes} chain - Coin/network symbol from Asset query
    * @param {Function} factory - A function that returns a ChainAdapter instance
    */
   addChain<T extends ChainTypes>(chain: T, factory: () => ChainAdapter<ChainTypes>): void {
@@ -90,5 +92,18 @@ export class ChainAdapterManager {
     }
 
     return adapter as ChainAdapter<T>
+  }
+
+  async byChainId(chainId: CAIP2) {
+    // this function acts like a validation function and throws if the check doesn't pass
+    caip2.isCAIP2(chainId)
+
+    for (const [chain] of this.supported) {
+      // byChain calls the factory function so we need to call it to create the instances
+      const adapter = this.byChain(chain)
+      if ((await adapter.getCaip2()) === chainId) return adapter
+    }
+
+    throw new Error(`Chain [${chainId}] is not supported`)
   }
 }


### PR DESCRIPTION
This is a step toward not using the ChainTypes enum by using a CAIP2 string to get the ChainAdapter instance.

`byChainId` takes a `CAIP2` value and returns a ChainAdapter instance or throws an error.

This PR is not associated with an existing issue.