### PR TITLE
feat: refactor ChainAdapter.getCaip2() functions to be synchronous & add `getChainId` #381

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterManager.test.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.test.ts
@@ -85,11 +85,11 @@ describe('ChainAdapterManager', () => {
       const cam = new ChainAdapterManager({})
       // @ts-ignore
       cam.addChain(ChainTypes.Bitcoin, () => ({
-        getCaip2: async () => 'bip122:000000000019d6689c085ae165831e93'
+        getCaip2: () => 'bip122:000000000019d6689c085ae165831e93'
       }))
       // @ts-ignore
       cam.addChain(ChainTypes.Ethereum, () => ({
-        getCaip2: async () => 'eip155:1'
+        getCaip2: () => 'eip155:1'
       }))
 
       await expect(cam.byChainId('eip155:1')).resolves.toBeTruthy()

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -13,8 +13,9 @@ export type ChainAdapter<T extends ChainTypes> = {
    */
   getType(): T
 
-  getCaip2(): Promise<CAIP2>
+  getCaip2(): CAIP2
 
+  getChainId(): CAIP2
   /**
    * Get the balance of an address
    */

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -13,6 +13,7 @@ import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapes
 import * as bitcoin from './BitcoinChainAdapter'
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
+const VALID_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93'
 
 const getWallet = async (): Promise<HDWallet> => {
   const nativeAdapterArgs: NativeAdapterArgs = {
@@ -141,6 +142,24 @@ describe('BitcoinChainAdapter', () => {
       },
       coinName: 'Bitcoin'
     }
+  })
+
+  describe('constructor', () => {
+    it('should return chainAdapter with no chainId', () => {
+      const adapter = new bitcoin.ChainAdapter(args)
+      const chainId = adapter.getChainId()
+      expect(chainId).toEqual(VALID_CHAIN_ID)
+    })
+    it('should return chainAdapter with valid chainId', () => {
+      args.chainId = VALID_CHAIN_ID
+      const adapter = new bitcoin.ChainAdapter(args)
+      const chainId = adapter.getChainId()
+      expect(chainId).toEqual(VALID_CHAIN_ID)
+    })
+    it('should return chainAdapter with invalid chainId', () => {
+      args.chainId = 'INVALID_CHAINID'
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
+    })
   })
 
   describe('getType', () => {

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -151,10 +151,10 @@ describe('BitcoinChainAdapter', () => {
       expect(chainId).toEqual(VALID_CHAIN_ID)
     })
     it('should return chainAdapter with valid chainId', () => {
-      args.chainId = VALID_CHAIN_ID
+      args.chainId = 'bip122:000000000019d6689c085ae165831e93'
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
-      expect(chainId).toEqual(VALID_CHAIN_ID)
+      expect(chainId).toEqual('bip122:000000000019d6689c085ae165831e93')
     })
     it('should return chainAdapter with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -145,18 +145,18 @@ describe('BitcoinChainAdapter', () => {
   })
 
   describe('constructor', () => {
-    it('should return chainAdapter with no chainId', () => {
+    it('should return chainAdapter with default Bitcoin chainId if called with no chainId', () => {
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual(VALID_CHAIN_ID)
     })
-    it('should return chainAdapter with valid chainId', () => {
+    it('should return chainAdapter with valid chainId if called with valid chainId', () => {
       args.chainId = 'bip122:000000000019d6689c085ae165831e93'
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual('bip122:000000000019d6689c085ae165831e93')
     })
-    it('should return chainAdapter with invalid chainId', () => {
+    it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
       expect(() => new bitcoin.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
     })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -150,11 +150,11 @@ describe('BitcoinChainAdapter', () => {
       const chainId = adapter.getChainId()
       expect(chainId).toEqual(VALID_CHAIN_ID)
     })
-    it('should return chainAdapter with valid chainId if called with valid chainId', () => {
-      args.chainId = 'bip122:000000000019d6689c085ae165831e93'
+    it('should return chainAdapter with valid chainId if called with valid testnet chainId', () => {
+      args.chainId = 'bip122:000000000933ea01ad0ee984209779ba'
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
-      expect(chainId).toEqual('bip122:000000000019d6689c085ae165831e93')
+      expect(chainId).toEqual('bip122:000000000933ea01ad0ee984209779ba')
     })
     it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -97,10 +97,10 @@ describe('EthereumChainAdapter', () => {
       expect(chainId).toEqual(VALID_CHAIN_ID)
     })
     it('should return chainAdapter with valid chainId', () => {
-      args.chainId = VALID_CHAIN_ID
+      args.chainId = 'eip155:3'
       const adapter = new ethereum.ChainAdapter(args)
       const chainId = adapter.getChainId()
-      expect(chainId).toEqual(VALID_CHAIN_ID)
+      expect(chainId).toEqual('eip155:3')
     })
     it('should return chainAdapter with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
@@ -488,7 +488,6 @@ describe('EthereumChainAdapter', () => {
         }
       })
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(1)
     })
     it('sendmax: true without chainSpecific.erc20ContractAddress should throw if ETH balance is 0', async () => {
       args.providers.http = {
@@ -522,7 +521,6 @@ describe('EthereumChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(2)
     })
     it('sendMax: true without chainSpecific.erc20ContractAddress - should build a tx with full account balance - gas fee', async () => {
       const balance = '2500000'
@@ -570,7 +568,6 @@ describe('EthereumChainAdapter', () => {
         }
       })
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(2)
     })
     it("should build a tx with value: '0' for ERC20 txs without sendMax", async () => {
       args.providers.http = {
@@ -613,7 +610,6 @@ describe('EthereumChainAdapter', () => {
         }
       })
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(1)
     })
     it('sendmax: true with chainSpecific.erc20ContractAddress should build a tx with full account balance - gas fee', async () => {
       args.providers.http = {
@@ -658,7 +654,6 @@ describe('EthereumChainAdapter', () => {
         }
       })
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(2)
     })
 
     it('sendmax: true with chainSpecific.erc20ContractAddress should throw if token balance is 0', async () => {
@@ -694,7 +689,6 @@ describe('EthereumChainAdapter', () => {
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(2)
-      expect(args.providers.http.getInfo).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -91,18 +91,18 @@ describe('EthereumChainAdapter', () => {
   })
 
   describe('constructor', () => {
-    it('should return chainAdapter with no chainId', () => {
+    it('should return chainAdapter with Ethereum mainnet chainId if called with no chainId', () => {
       const adapter = new ethereum.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual(VALID_CHAIN_ID)
     })
-    it('should return chainAdapter with valid chainId', () => {
+    it('should return chainAdapter with valid chainId if called with valid chainId', () => {
       args.chainId = 'eip155:3'
       const adapter = new ethereum.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual('eip155:3')
     })
-    it('should return chainAdapter with invalid chainId', () => {
+    it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
       expect(() => new ethereum.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
     })

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -17,6 +17,7 @@ import * as ethereum from './EthereumChainAdapter'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 const ENS_NAME = 'vitalik.eth'
+const VALID_CHAIN_ID = 'eip155:1'
 
 const getGasFeesMockedResponse = {
   data: {
@@ -88,6 +89,25 @@ describe('EthereumChainAdapter', () => {
       }
     }
   })
+
+  describe('constructor', () => {
+    it('should return chainAdapter with no chainId', () => {
+      const adapter = new ethereum.ChainAdapter(args)
+      const chainId = adapter.getChainId()
+      expect(chainId).toEqual(VALID_CHAIN_ID)
+    })
+    it('should return chainAdapter with valid chainId', () => {
+      args.chainId = VALID_CHAIN_ID
+      const adapter = new ethereum.ChainAdapter(args)
+      const chainId = adapter.getChainId()
+      expect(chainId).toEqual(VALID_CHAIN_ID)
+    })
+    it('should return chainAdapter with invalid chainId', () => {
+      args.chainId = 'INVALID_CHAINID'
+      expect(() => new ethereum.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
+    })
+  })
+
   describe('getBalance', () => {
     it('is unimplemented', () => {
       expect(true).toBeTruthy()

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -25,6 +25,7 @@ export interface ChainAdapterArgs {
     http: ethereum.api.V1Api
     ws: ethereum.ws.Client
   }
+  chainId?: CAIP2
 }
 
 async function getErc20Data(to: string, value: string, contractAddress?: string) {
@@ -45,7 +46,20 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     accountNumber: 0
   }
 
+  private readonly chainId: CAIP2 = 'eip155:1'
+
   constructor(args: ChainAdapterArgs) {
+    if (args.chainId) {
+      try {
+        const { chain } = caip2.fromCAIP2(args.chainId)
+        if (chain !== ChainTypes.Bitcoin) {
+          throw new Error()
+        }
+        this.chainId = args.chainId
+      } catch (e) {
+        throw new Error(`The ChainID ${args.chainId} is not supported`)
+      }
+    }
     this.providers = args.providers
   }
 
@@ -53,28 +67,17 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return ChainTypes.Ethereum
   }
 
-  async getCaip2(): Promise<CAIP2> {
-    try {
-      const { data } = await this.providers.http.getInfo()
+  getCaip2(): CAIP2 {
+    return this.chainId
+  }
 
-      switch (data.network) {
-        case 'mainnet':
-          return caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
-        case 'ropsten':
-          return caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.ETH_ROPSTEN })
-        case 'rinkeby':
-          return caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.ETH_RINKEBY })
-        default:
-          throw new Error(`EthereumChainAdapter: network is not supported: ${data.network}`)
-      }
-    } catch (err) {
-      return ErrorHandler(err)
-    }
+  getChainId(): CAIP2 {
+    return this.chainId
   }
 
   async getAccount(pubkey: string): Promise<chainAdapters.Account<ChainTypes.Ethereum>> {
     try {
-      const caip = await this.getCaip2()
+      const caip = this.getCaip2()
       const { chain, network } = caip2.fromCAIP2(caip)
       const { data } = await this.providers.http.getAccount({ pubkey })
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -52,7 +52,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     if (args.chainId) {
       try {
         const { chain } = caip2.fromCAIP2(args.chainId)
-        if (chain !== ChainTypes.Bitcoin) {
+        if (chain !== ChainTypes.Ethereum) {
           throw new Error()
         }
         this.chainId = args.chainId


### PR DESCRIPTION
- In `api.ts`, change `getCaip2()` to be synchronous and add `getChainId()`
```ts
import { caip2 } from '@shapeshiftoss/caip'
export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
  private readonly chainId = 'bip122:000000000019d6689c085ae165831e93'
  constructor(args: ChainAdapterArgs) {
    if (args.chainId) {
      try {
        const { chain } = caip2.fromCAIP2(args.chainId)
        if (chain !== ChainTypes.Bitcoin) {
          throw new Error()
        }
        this.chainId = args.chainId
      } catch (e) {
        throw new Error(`The ChainID ${args.chainId} is not supported`)
      } 
    }
    this.providers = args.providers
  }

  getCaip2() {
    return this.chainId
  }

  getChainId() {
    return this.chainId
  }
}
```
- Add test cases in `BitcoinChainAdapter.test.ts` and `EthereumChainAdapter.test.ts` to verify
  - Constructor with no `chainId`
  - Constructor with a valid testnet `chainId`
  - Constructor with an invalid `chainId`

closes #381 