### PR TITLE
chore: upgrade axios to 0.26.0

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -25,7 +25,7 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "axios": "^0.24.0",
+    "axios": "^0.26.0",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "@shapeshiftoss/types": "^1.23.0",
     "@yfi/sdk": "^1.0.27",
-    "axios": "^0.24.0"
+    "axios": "^0.26.0"
   }
 }

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -25,7 +25,7 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "axios": "^0.21.2",
+    "axios": "^0.26.0",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",
     "coinselect": "^3.1.12",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.5.1",
     "@yfi/sdk": "^1.0.27",
-    "axios": "^0.21.2",
+    "axios": "^0.26.0",
     "bignumber.js": "^9.0.1",
     "dayjs": "^1.10.6"
   },

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -21,7 +21,7 @@
     "swapcli": "yarn build && node ./dist/swappercli.js"
   },
   "dependencies": {
-    "axios": "^0.21.4",
+    "axios": "^0.26.0",
     "bignumber.js": "^9.0.1",
     "retry-axios": "^2.6.0",
     "web3": "^1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,19 +3436,19 @@ axios@0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^0.21.2, axios@^0.21.4:
+axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+axios@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
   dependencies:
-    follow-redirects "^1.14.4"
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -5981,10 +5981,15 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
-follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
+follow-redirects@^1.10.0, follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+follow-redirects@^1.14.8:
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 foreach@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
chore: upgrade axios to 0.26.0

This is just to keep up on dependencies, especially those that may included security fixes