### PR TITLE
fix: support slip44 for Cosmos in toCAIP2

### DIFF
--- a/packages/caip/src/caip19/caip19.test.ts
+++ b/packages/caip/src/caip19/caip19.test.ts
@@ -33,6 +33,30 @@ describe('caip19', () => {
       expect(result).toEqual('cosmos:cosmoshub-4/slip44:118')
     })
 
+    it('can make Cosmos caip19 identifier on CosmosHub mainnet with slip44 reference', () => {
+      const chain = ChainTypes.Cosmos
+      const network = NetworkTypes.COSMOSHUB_MAINNET
+      const result = toCAIP19({
+        chain,
+        network,
+        assetNamespace: AssetNamespace.Slip44,
+        assetReference: '118'
+      })
+      expect(result).toEqual('cosmos:cosmoshub-4/slip44:118')
+    })
+
+    it('can make Osmosis caip19 identifier on Osmosis mainnet with slip44 reference', () => {
+      const chain = ChainTypes.Osmosis
+      const network = NetworkTypes.OSMOSIS_MAINNET
+      const result = toCAIP19({
+        chain,
+        network,
+        assetNamespace: AssetNamespace.Slip44,
+        assetReference: '118'
+      })
+      expect(result).toEqual('cosmos:osmosis-1/slip44:118')
+    })
+
     it('can return ibc asset caip 19 for osmosis', () => {
       const chain = ChainTypes.Osmosis
       const network = NetworkTypes.OSMOSIS_MAINNET
@@ -83,6 +107,15 @@ describe('caip19', () => {
       const network = NetworkTypes.TESTNET
       expect(() => toCAIP19({ chain, network })).toThrow(
         'toCAIP2: unsupported cosmos network: TESTNET'
+      )
+    })
+
+    it('throws with invalid Cosmos slip44 reference', () => {
+      const chain = ChainTypes.Cosmos
+      const network = NetworkTypes.COSMOSHUB_MAINNET
+      const assetNamespace = AssetNamespace.Slip44
+      expect(() => toCAIP19({ chain, network, assetNamespace, assetReference: 'bad' })).toThrow(
+        'Could not construct CAIP19'
       )
     })
 

--- a/packages/caip/src/caip19/caip19.ts
+++ b/packages/caip/src/caip19/caip19.ts
@@ -32,6 +32,17 @@ type ToCAIP19Args = {
   assetReference?: string
 }
 
+/**
+ * validate that a value is a string slip44 value
+ * @see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+ * @param {string} value - possible slip44 value
+ */
+const isValidSlip44 = (value: string) => {
+  const n = Number(value)
+  // slip44 has a max value of an unsigned 32-bit integer
+  return !isNaN(n) && n >= 0 && n < 4294967296
+}
+
 type ToCAIP19 = (args: ToCAIP19Args) => string
 
 export const toCAIP19: ToCAIP19 = ({
@@ -58,12 +69,13 @@ export const toCAIP19: ToCAIP19 = ({
         case AssetNamespace.IBC:
         case AssetNamespace.NATIVE:
           return `${caip2}/${assetNamespace}:${assetReference}`
-        default: {
-          throw new Error(
-            `Could not construct CAIP19 chain: ${chain}, network: ${network}, assetNamespace: ${assetNamespace}, assetReference: ${assetReference}`
-          )
-        }
+        case AssetNamespace.Slip44:
+          if (isValidSlip44(assetReference)) return `${caip2}/${assetNamespace}:${assetReference}`
       }
+
+      throw new Error(
+        `Could not construct CAIP19 chain: ${chain}, network: ${network}, assetNamespace: ${assetNamespace}, assetReference: ${assetReference}`
+      )
     }
     case ChainTypes.Ethereum: {
       tokenId = tokenId?.toLowerCase()


### PR DESCRIPTION
Currently `toCAIP2` throws an error if you pass in an `assetReference` of `slip44` for Cosmos/Osmosis. The correct CAIP19 for Cosmos is `cosmos:cosmoshub-4/slip44:118`. So if you call `toCAIP19(fromCAIP19(`cosmos:cosmoshub-4/slip44:118`))` it'll throw an error.

This PR fixes that.