### PR TITLE
feat: utxo chain adapter refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Bug fixes and features should always come with tests, when applicable. Test file
 To run the test suite:
 
 ```bash
+# build all dependent packages
+yarn build
+
 # Runs the full test suite
 yarn test
 
@@ -66,4 +69,4 @@ One technique that can helpful when writing tests, is to reference the coverage 
 
 ## Contributing
 
-Please see the [Contributing Guidlines](CONTRIBUTING.md) document for this repo's specific contributing guidelines.
+Please see the [Contributing Guidelines](CONTRIBUTING.md) document for this repo's specific contributing guidelines.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ info You can now run `yarn link "@shapeshiftoss/types"` in the projects where yo
 ✨  Done in 0.47s.
 ```
 
-Similary you can unlink packages, which can be useful for debugging failing CI runs
+Similarly you can unlink packages, which can be useful for debugging failing CI runs
 ```bash
 ➜ yarn unlink-packages
 yarn run v1.22.15

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -10,6 +10,7 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 
+import { ChainAdapterArgs } from '../utxo/UTXOBaseAdapter'
 import * as bitcoin from './BitcoinChainAdapter'
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
@@ -132,7 +133,7 @@ const getNetworkFeesMockedResponse = {
 }
 
 describe('BitcoinChainAdapter', () => {
-  let args: bitcoin.ChainAdapterArgs = {} as any
+  let args: ChainAdapterArgs = {} as any
 
   beforeEach(() => {
     args = {
@@ -215,7 +216,7 @@ describe('BitcoinChainAdapter', () => {
 
       const adapter = new bitcoin.ChainAdapter(args)
       await expect(adapter.getAccount('')).rejects.toThrow(
-        'BitcoinChainAdapter: pubkey parameter is not defined'
+        'UTXOBaseAdapter: pubkey parameter is not defined'
       )
     })
   })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -160,7 +160,9 @@ describe('BitcoinChainAdapter', () => {
     })
     it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
-      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/fromCAIP19: error parsing caip19, chain: (.+), network: undefined/)
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(
+        /fromCAIP19: error parsing caip19, chain: (.+), network: undefined/
+      )
     })
     it('should throw if called with non bitcoin chainId', () => {
       args.chainId = 'eip155:1'
@@ -168,9 +170,7 @@ describe('BitcoinChainAdapter', () => {
     })
     it('should throw if called with no chainId', () => {
       args.chainId = undefined
-      expect(() => new bitcoin.ChainAdapter(args)).toThrow(
-        /chainId required/
-      )
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/chainId required/)
     })
   })
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -141,7 +141,8 @@ describe('BitcoinChainAdapter', () => {
         http: {} as any,
         ws: {} as any
       },
-      coinName: 'Bitcoin'
+      coinName: 'Bitcoin',
+      chainId: 'bip122:000000000019d6689c085ae165831e93'
     }
   })
 
@@ -160,6 +161,12 @@ describe('BitcoinChainAdapter', () => {
     it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
       expect(() => new bitcoin.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
+    })
+    it('should throw if called with no chainId', () => {
+      args.chainId = undefined
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(
+        /The ChainID must be supplied in constructor args/
+      )
     })
   })
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -160,12 +160,16 @@ describe('BitcoinChainAdapter', () => {
     })
     it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'
-      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/The ChainID (.+) is not supported/)
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/fromCAIP19: error parsing caip19, chain: (.+), network: undefined/)
+    })
+    it('should throw if called with non bitcoin chainId', () => {
+      args.chainId = 'eip155:1'
+      expect(() => new bitcoin.ChainAdapter(args)).toThrow(/chainId must be a bitcoin chain type/)
     })
     it('should throw if called with no chainId', () => {
       args.chainId = undefined
       expect(() => new bitcoin.ChainAdapter(args)).toThrow(
-        /The ChainID must be supplied in constructor args/
+        /chainId required/
       )
     })
   })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -15,6 +15,7 @@ import * as bitcoin from './BitcoinChainAdapter'
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 const VALID_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93'
+const VALID_ASSET_ID = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
 
 const getWallet = async (): Promise<HDWallet> => {
   const nativeAdapterArgs: NativeAdapterArgs = {
@@ -147,7 +148,7 @@ describe('BitcoinChainAdapter', () => {
   })
 
   describe('constructor', () => {
-    it('should return chainAdapter with default Bitcoin chainId if called with no chainId', () => {
+    it('should return chainAdapter with Bitcoin chainId', () => {
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual(VALID_CHAIN_ID)
@@ -157,6 +158,13 @@ describe('BitcoinChainAdapter', () => {
       const adapter = new bitcoin.ChainAdapter(args)
       const chainId = adapter.getChainId()
       expect(chainId).toEqual('bip122:000000000933ea01ad0ee984209779ba')
+    })
+    it('should return chainAdapter with Bitcoin caip19 / assetId', () => {
+      const adapter = new bitcoin.ChainAdapter(args)
+      const assetId = adapter.getAssetId()
+      const caip19 = adapter.getCaip19()
+      expect(assetId).toEqual(caip19)
+      expect(assetId).toEqual(VALID_ASSET_ID)
     })
     it('should throw if called with invalid chainId', () => {
       args.chainId = 'INVALID_CHAINID'

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -42,20 +42,14 @@ export class ChainAdapter
 
   constructor(args: ChainAdapterArgs) {
     super(args)
-    if (args.chainId) {
-      try {
-        const { chain } = caip2.fromCAIP2(args.chainId)
-        if (chain !== ChainTypes.Bitcoin) {
-          throw new Error()
-        }
-        this.chainId = args.chainId
-      } catch (e) {
-        throw new Error(`The ChainID ${args.chainId} is not supported`)
-      }
-    } else {
-      throw new Error('The ChainID must be supplied in constructor args')
+    if (!args.chainId) {
+      throw new Error('chainId required')
     }
-
+    const { chain } = caip2.fromCAIP2(args.chainId)
+    if (chain !== ChainTypes.Bitcoin) {
+      throw new Error('chainId must be a bitcoin chain type')
+    }
+    this.chainId = args.chainId
     this.coinName = args.coinName
   }
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -14,7 +14,7 @@ import {
   NetworkTypes,
   UtxoAccountType
 } from '@shapeshiftoss/types'
-import { bitcoin } from '@shapeshiftoss/unchained-client'
+import * as unchained from '@shapeshiftoss/unchained-client'
 import coinSelect from 'coinselect'
 import split from 'coinselect/split'
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -7,7 +7,7 @@ import {
   BTCSignTxOutput,
   supportsBTC
 } from '@shapeshiftoss/hdwallet-core'
-import { chainAdapters, ChainTypes, NetworkTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { BIP44Params, chainAdapters, ChainTypes, NetworkTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import { bitcoin } from '@shapeshiftoss/unchained-client'
 import coinSelect from 'coinselect'
 import split from 'coinselect/split'
@@ -28,6 +28,12 @@ export class ChainAdapter
   extends UTXOBaseAdapter<ChainTypes.Bitcoin>
   implements IChainAdapter<ChainTypes.Bitcoin>
 {
+  public static readonly defaultBIP44Params: BIP44Params = {
+    purpose: 84, // segwit native
+    coinType: 0,
+    accountNumber: 0
+  }
+
   constructor(args: ChainAdapterArgs) {
     super(args)
     if (args.chainId) {
@@ -179,6 +185,10 @@ export class ChainAdapter
     } catch (err) {
       return ErrorHandler(err)
     }
+  }
+
+  buildBIP44Params(params: Partial<BIP44Params>): BIP44Params {
+    return { ...ChainAdapter.defaultBIP44Params, ...params }
   }
 
   async signTransaction(

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -7,7 +7,13 @@ import {
   BTCSignTxOutput,
   supportsBTC
 } from '@shapeshiftoss/hdwallet-core'
-import { BIP44Params, chainAdapters, ChainTypes, NetworkTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import {
+  BIP44Params,
+  chainAdapters,
+  ChainTypes,
+  NetworkTypes,
+  UtxoAccountType
+} from '@shapeshiftoss/types'
 import { bitcoin } from '@shapeshiftoss/unchained-client'
 import coinSelect from 'coinselect'
 import split from 'coinselect/split'
@@ -47,11 +53,10 @@ export class ChainAdapter
         throw new Error(`The ChainID ${args.chainId} is not supported`)
       }
     } else {
-      // use default chain id
-      this.chainId = 'bip122:000000000019d6689c085ae165831e93'
+      throw new Error('The ChainID must be supplied in constructor args')
     }
 
-    this.coinName = args.coinName // TODO fix me
+    this.coinName = args.coinName
   }
 
   getType(): ChainTypes.Bitcoin {

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,4 +1,4 @@
-import { caip2 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, caip2, caip19 } from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   BTCOutputAddressType,
@@ -45,12 +45,18 @@ export class ChainAdapter
     if (!args.chainId) {
       throw new Error('chainId required')
     }
-    const { chain } = caip2.fromCAIP2(args.chainId)
+    const { chain, network } = caip2.fromCAIP2(args.chainId)
     if (chain !== ChainTypes.Bitcoin) {
       throw new Error('chainId must be a bitcoin chain type')
     }
     this.chainId = args.chainId
     this.coinName = args.coinName
+    this.assetId = caip19.toCAIP19({
+      chain,
+      network,
+      assetNamespace: AssetNamespace.Slip44,
+      assetReference: AssetReference.Bitcoin
+    })
   }
 
   getType(): ChainTypes.Bitcoin {

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -15,6 +15,11 @@ import {
 
 export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future to include other UTXOs
 
+/**
+ * Currently, we don't have a generic interact for UTXO providers, but will in the future.
+ * Leaving this as-is for now, but will replace in the future with a more generic UTXO api and client
+ * interface.
+ */
 export interface ChainAdapterArgs {
   providers: {
     http: bitcoin.api.V1Api //?
@@ -38,15 +43,10 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
     ws: bitcoin.ws.Client
   }
 
-  public static readonly defaultBIP44Params: BIP44Params = {
-    purpose: 84, // segwit native
-    coinType: 0,
-    accountNumber: 0
-  }
-
   protected constructor(args: ChainAdapterArgs) {
     this.providers = args.providers
   }
+  
 
   /* Abstract Methods */
 
@@ -62,6 +62,8 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
   abstract getTxHistory(
     input: chainAdapters.TxHistoryInput
   ): Promise<chainAdapters.TxHistoryResponse<T>>
+
+  abstract buildBIP44Params(params: Partial<BIP44Params>): BIP44Params 
 
   abstract buildSendTransaction(
     tx: chainAdapters.BuildSendTxInput<T>
@@ -132,10 +134,6 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
     const isValidAddress = WAValidator.validate(address, this.getType())
     if (isValidAddress) return { valid: true, result: chainAdapters.ValidAddressResultType.Valid }
     return { valid: false, result: chainAdapters.ValidAddressResultType.Invalid }
-  }
-
-  buildBIP44Params(params: Partial<BIP44Params>): BIP44Params {
-    return { ...UTXOBaseAdapter.defaultBIP44Params, ...params }
   }
 
   /* protected / private methods */

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -1,0 +1,169 @@
+import { AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { bip32ToAddressNList, HDWallet, PublicKey } from '@shapeshiftoss/hdwallet-core'
+import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { bitcoin } from '@shapeshiftoss/unchained-client'
+import WAValidator from 'multicoin-address-validator'
+
+import { ChainAdapter as IChainAdapter } from '../api'
+import { ErrorHandler } from '../error/ErrorHandler'
+import {
+  accountTypeToScriptType,
+  bnOrZero,
+  convertXpubVersion,
+  toRootDerivationPath
+} from '../utils'
+
+export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future to include other UTXOs
+
+export interface ChainAdapterArgs {
+  providers: {
+    http: bitcoin.api.V1Api //?
+    ws: bitcoin.ws.Client
+  }
+  coinName: string
+  chainId?: CAIP2
+}
+
+export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChainAdapter<T> {
+  protected chainId: CAIP2
+  protected coinName: string
+  protected readonly providers: {
+    http: bitcoin.api.V1Api
+    ws: bitcoin.ws.Client
+  }
+
+  public static readonly defaultBIP44Params: BIP44Params = {
+    purpose: 84, // segwit native
+    coinType: 0,
+    accountNumber: 0
+  }
+
+  protected constructor(args: ChainAdapterArgs) {
+    this.providers = args.providers
+  }
+  subscribeTxs(
+    input: chainAdapters.SubscribeTxsInput,
+    onMessage: (msg: chainAdapters.SubscribeTxsMessage<T>) => void,
+    onError?: (err: chainAdapters.SubscribeError) => void
+  ): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  unsubscribeTxs(input?: chainAdapters.SubscribeTxsInput): void {
+    throw new Error('Method not implemented.')
+  }
+  closeTxs(): void {
+    throw new Error('Method not implemented.')
+  }
+
+  abstract getType(): T
+
+  getCaip2(): CAIP2 {
+    return this.chainId
+  }
+
+  getChainId(): CAIP2 {
+    return this.chainId
+  }
+
+  async getAccount(pubkey: string): Promise<chainAdapters.Account<T>> {
+    if (!pubkey) {
+      return ErrorHandler('UTXOBaseAdapter: pubkey parameter is not defined')
+    }
+
+    try {
+      const caip = await this.getCaip2()
+      const { chain, network } = caip2.fromCAIP2(caip)
+      const { data } = await this.providers.http.getAccount({ pubkey: pubkey })
+
+      const balance = bnOrZero(data.balance).plus(bnOrZero(data.unconfirmedBalance))
+
+      return {
+        balance: balance.toString(),
+        chain: this.getType(),
+        caip2: caip,
+        caip19: caip19.toCAIP19({
+          chain,
+          network,
+          assetNamespace: AssetNamespace.Slip44,
+          assetReference: AssetReference.Bitcoin
+        }),
+        chainSpecific: {
+          addresses: data.addresses,
+          nextChangeAddressIndex: data.nextChangeAddressIndex,
+          nextReceiveAddressIndex: data.nextReceiveAddressIndex
+        },
+        pubkey: data.pubkey
+      } as chainAdapters.Account<T>
+    } catch (err) {
+      return ErrorHandler(err)
+    }
+  }
+
+  buildBIP44Params(params: Partial<BIP44Params>): BIP44Params {
+    return { ...UTXOBaseAdapter.defaultBIP44Params, ...params }
+  }
+
+  async getTxHistory(
+    input: chainAdapters.TxHistoryInput
+  ): Promise<chainAdapters.TxHistoryResponse<T>> {
+    try {
+      const { data } = await this.providers.http.getTxHistory({
+        pubkey: input.pubkey
+      })
+
+      throw new Error('Method not implemented.')
+    } catch (err) {
+      return ErrorHandler(err)
+    }
+  }
+
+  abstract buildSendTransaction(
+    tx: chainAdapters.BuildSendTxInput<T>
+  ): Promise<{ txToSign: chainAdapters.ChainTxType<T> }>
+
+  abstract getAddress(input: chainAdapters.GetAddressInput): Promise<string>
+
+  abstract getFeeData(
+    input: Partial<chainAdapters.GetFeeDataInput<T>>
+  ): Promise<chainAdapters.FeeDataEstimate<T>>
+
+  abstract signTransaction(
+    signTxInput: chainAdapters.SignTxInput<chainAdapters.ChainTxType<T>>
+  ): Promise<string>
+
+  async broadcastTransaction(hex: string): Promise<string> {
+    const { data } = await this.providers.http.sendTx({
+      sendTxBody: { hex }
+    })
+    return data
+  }
+
+  async validateAddress(address: string): Promise<chainAdapters.ValidAddressResult> {
+    const isValidAddress = WAValidator.validate(address, this.getType())
+    if (isValidAddress) return { valid: true, result: chainAdapters.ValidAddressResultType.Valid }
+    return { valid: false, result: chainAdapters.ValidAddressResultType.Invalid }
+  }
+
+  protected async getPublicKey(
+    wallet: HDWallet,
+    bip44Params: BIP44Params,
+    accountType: UtxoAccountType
+  ): Promise<PublicKey> {
+    const path = toRootDerivationPath(bip44Params)
+    const publicKeys = await wallet.getPublicKeys([
+      {
+        coin: this.coinName,
+        addressNList: bip32ToAddressNList(path),
+        curve: 'secp256k1', // TODO(0xdef1cafe): from constant?
+        scriptType: accountTypeToScriptType[accountType]
+      }
+    ])
+    if (!publicKeys?.[0]) throw new Error("couldn't get public key")
+
+    if (accountType) {
+      return { xpub: convertXpubVersion(publicKeys[0].xpub, accountType) }
+    }
+
+    return publicKeys[0]
+  }
+}

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -17,8 +17,8 @@ export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future 
 
 /**
  * Currently, we don't have a generic interact for UTXO providers, but will in the future.
- * Leaving this as-is for now, but will replace in the future with a more generic UTXO api and client
- * interface.
+ * Leaving this as-is for now, but we will need to test in the future when we have additional
+ * UTXO chains implemented in unchained. 
  */
 export interface ChainAdapterArgs {
   providers: {

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -41,20 +41,14 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
   protected constructor(args: ChainAdapterArgs) {
     this.providers = args.providers
   }
-  subscribeTxs(
+
+  abstract subscribeTxs(
     input: chainAdapters.SubscribeTxsInput,
     onMessage: (msg: chainAdapters.SubscribeTxsMessage<T>) => void,
     onError?: (err: chainAdapters.SubscribeError) => void
-  ): Promise<void> {
-    throw new Error('Method not implemented.')
-  }
-  unsubscribeTxs(input?: chainAdapters.SubscribeTxsInput): void {
-    throw new Error('Method not implemented.')
-  }
-  closeTxs(): void {
-    throw new Error('Method not implemented.')
-  }
-
+  ): Promise<void>
+  abstract unsubscribeTxs(input?: chainAdapters.SubscribeTxsInput): void
+  abstract closeTxs(): void
   abstract getType(): T
 
   getCaip2(): CAIP2 {
@@ -103,19 +97,9 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
     return { ...UTXOBaseAdapter.defaultBIP44Params, ...params }
   }
 
-  async getTxHistory(
+  abstract getTxHistory(
     input: chainAdapters.TxHistoryInput
-  ): Promise<chainAdapters.TxHistoryResponse<T>> {
-    try {
-      const { data } = await this.providers.http.getTxHistory({
-        pubkey: input.pubkey
-      })
-
-      throw new Error('Method not implemented.')
-    } catch (err) {
-      return ErrorHandler(err)
-    }
-  }
+  ): Promise<chainAdapters.TxHistoryResponse<T>>
 
   abstract buildSendTransaction(
     tx: chainAdapters.BuildSendTxInput<T>

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -18,7 +18,7 @@ export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future 
 /**
  * Currently, we don't have a generic interact for UTXO providers, but will in the future.
  * Leaving this as-is for now, but we will need to test in the future when we have additional
- * UTXO chains implemented in unchained. 
+ * UTXO chains implemented in unchained.
  */
 export interface ChainAdapterArgs {
   providers: {
@@ -46,7 +46,6 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
   protected constructor(args: ChainAdapterArgs) {
     this.providers = args.providers
   }
-  
 
   /* Abstract Methods */
 
@@ -63,7 +62,7 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
     input: chainAdapters.TxHistoryInput
   ): Promise<chainAdapters.TxHistoryResponse<T>>
 
-  abstract buildBIP44Params(params: Partial<BIP44Params>): BIP44Params 
+  abstract buildBIP44Params(params: Partial<BIP44Params>): BIP44Params
 
   abstract buildSendTransaction(
     tx: chainAdapters.BuildSendTxInput<T>

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -1,7 +1,7 @@
 import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, HDWallet, PublicKey } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
-import { bitcoin } from '@shapeshiftoss/unchained-client'
+import * as unchained from '@shapeshiftoss/unchained-client'
 import WAValidator from 'multicoin-address-validator'
 
 import { ChainAdapter as IChainAdapter } from '../api'
@@ -22,8 +22,8 @@ export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future 
  */
 export interface ChainAdapterArgs {
   providers: {
-    http: bitcoin.api.V1Api //?
-    ws: bitcoin.ws.Client
+    http: unchained.bitcoin.V1Api
+    ws: unchained.ws.Client<unchained.SequencedTx>
   }
   coinName: string
   chainId?: CAIP2
@@ -40,8 +40,8 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
   protected assetId: CAIP19
   protected coinName: string
   protected readonly providers: {
-    http: bitcoin.api.V1Api
-    ws: bitcoin.ws.Client
+    http: unchained.bitcoin.V1Api
+    ws: unchained.ws.Client<unchained.SequencedTx>
   }
 
   protected constructor(args: ChainAdapterArgs) {


### PR DESCRIPTION
This PR moves much of the BitcoinChainAdapter logic in a UTXOBaseAdapter class that can be re-used for future UTXO's.

It also includes some minor updates to the README

Have a few questions to run down before we merge and will add those as comments momentarily.

Currently, all existing tests pass, but have not done any additional testing past that. 

Closes #125 