### PR TITLE
fix: osmosis chart range data

### DIFF
--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -105,12 +105,14 @@ export class OsmosisMarketService implements MarketService {
         start = -8760
         break
       case HistoryTimeframe.ALL:
-        range = 'all'
+        // TODO: currently the 'all' range for v2 is returning 500. Using 1y for the time being.
+        // We need to revisit this at a later date to see if it works in the future
+        range = '1y'
         isV1 = true
         start = 0
         break
       default:
-        range = 'all'
+        range = '1y'
         isV1 = true
         start = 0
     }

--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -127,21 +127,20 @@ export class OsmosisMarketService implements MarketService {
       // return the correct range of data points for each timeframe
       const tapperedData = data.slice(start)
 
-      return tapperedData
-        .reduce<HistoryData[]>((acc, current) => {
-          // convert timestamp from seconds to milliseconds
-          const date = bnOrZero(current.time).times(1000).toNumber()
-          if (!isValidDate(date)) {
-            console.error('Osmosis asset history data has invalid date')
-            return acc
-          }
-          const price = bnOrZero(current.close)
-          acc.push({
-            date,
-            price: price.toNumber()
-          })
+      return tapperedData.reduce<HistoryData[]>((acc, current) => {
+        // convert timestamp from seconds to milliseconds
+        const date = bnOrZero(current.time).times(1000).toNumber()
+        if (!isValidDate(date)) {
+          console.error('Osmosis asset history data has invalid date')
           return acc
-        }, [])
+        }
+        const price = bnOrZero(current.close)
+        acc.push({
+          date,
+          price: price.toNumber()
+        })
+        return acc
+      }, [])
     } catch (e) {
       console.warn(e)
       throw new Error('MarketService(findPriceHistoryByCaip19): error fetching price history')

--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -82,30 +82,30 @@ export class OsmosisMarketService implements MarketService {
       case HistoryTimeframe.HOUR:
         range = '5'
         isV1 = false
-        start = -12
+        start = 12
         break
       case HistoryTimeframe.DAY:
         range = '60'
         isV1 = false
-        start = -24
+        start = 24
         break
       case HistoryTimeframe.WEEK:
         range = '7d'
         isV1 = true
-        start = -168
+        start = bnOrZero(24).times(7).toNumber()
         break
       case HistoryTimeframe.MONTH:
         range = '1mo'
         isV1 = true
-        start = -720
+        start = bnOrZero(24).times(30).toNumber()
         break
       case HistoryTimeframe.YEAR:
         range = '1y'
         isV1 = true
-        start = -8760
+        start = bnOrZero(24).times(365).toNumber()
         break
       case HistoryTimeframe.ALL:
-        // TODO: currently the 'all' range for v2 is returning 500. Using 1y for the time being.
+        // TODO: currently the 'all' range for v2 is returning 500 errors. Using 1y for the time being.
         // We need to revisit this at a later date to see if it works in the future
         range = '1y'
         isV1 = true
@@ -127,7 +127,7 @@ export class OsmosisMarketService implements MarketService {
       const { data } = await axios.get<OsmosisHistoryData[]>(url)
 
       // return the correct range of data points for each timeframe
-      const tapperedData = data.slice(start)
+      const tapperedData = data.slice(-start)
 
       return tapperedData.reduce<HistoryData[]>((acc, current) => {
         // convert timestamp from seconds to milliseconds

--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -77,42 +77,42 @@ export class OsmosisMarketService implements MarketService {
 
     let range
     let isV1
-    let slice
+    let start
     switch (timeframe) {
       case HistoryTimeframe.HOUR:
         range = '5'
         isV1 = false
-        slice = -12
+        start = -12
         break
       case HistoryTimeframe.DAY:
         range = '60'
         isV1 = false
-        slice = -24
+        start = -24
         break
       case HistoryTimeframe.WEEK:
         range = '7d'
         isV1 = true
-        slice = -168
+        start = -168
         break
       case HistoryTimeframe.MONTH:
         range = '1mo'
         isV1 = true
-        slice = -720
+        start = -720
         break
       case HistoryTimeframe.YEAR:
         range = '1y'
         isV1 = true
-        slice = -8760
+        start = -8760
         break
       case HistoryTimeframe.ALL:
         range = 'all'
         isV1 = true
-        slice = 0
+        start = 0
         break
       default:
         range = 'all'
         isV1 = true
-        slice = 0
+        start = 0
     }
 
     try {
@@ -125,7 +125,7 @@ export class OsmosisMarketService implements MarketService {
       const { data } = await axios.get<OsmosisHistoryData[]>(url)
 
       // return the correct range of data points for each timeframe
-      const tapperedData = data.slice(slice)
+      const tapperedData = data.slice(start)
 
       return tapperedData
         .reduce<HistoryData[]>((acc, current) => {

--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -127,9 +127,9 @@ export class OsmosisMarketService implements MarketService {
       const { data } = await axios.get<OsmosisHistoryData[]>(url)
 
       // return the correct range of data points for each timeframe
-      const tapperedData = data.slice(-start)
+      const taperedData = data.slice(-start)
 
-      return tapperedData.reduce<HistoryData[]>((acc, current) => {
+      return taperedData.reduce<HistoryData[]>((acc, current) => {
         // convert timestamp from seconds to milliseconds
         const date = bnOrZero(current.time).times(1000).toNumber()
         if (!isValidDate(date)) {


### PR DESCRIPTION
- The api that is being used for Osmosis market does not have the ability to define a start/end date for price history data. This is a fix that returns the correct data points based on the time interval of each HistoryTimeFrame.