### PR TITLE
feat: cosmos sign and broadcast tx

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -46,7 +46,7 @@
     "@shapeshiftoss/hdwallet-core": "^1.19.0",
     "@shapeshiftoss/hdwallet-native": "^1.19.0",
     "@shapeshiftoss/types": "^2.1.0",
-    "@shapeshiftoss/unchained-client": "^6.0.0",
+    "@shapeshiftoss/unchained-client": "^6.1.1",
     "@types/bs58check": "^2.1.0",
     "@types/multicoin-address-validator": "^0.5.0"
   }

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -211,7 +211,6 @@ const main = async () => {
         txToSign: cosmosUnsignedTx.txToSign
       })
       console.log('broadcastedTx:', broadcastedTx)
-
     } catch (err) {
       console.log('cosmosTx error:', err.message)
     }

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -188,21 +188,30 @@ const main = async () => {
 
     // send cosmos example
     try {
+      const value = '100'
+
+      const feeData = await cosmosChainAdapter.getFeeData({ sendMax: false })
+      const fee = feeData.slow.txFee
+      const gas = feeData.slow.chainSpecific.gasLimit
+
       const cosmosUnsignedTx = await cosmosChainAdapter.buildSendTransaction({
-        to: `0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F`,
-        value: '1',
+        to: 'cosmos1j26n3mjpwx4f7zz65tzq3mygcr74wp7kcwcner',
+        value,
         wallet,
         bip44Params: cosmosBip44Params,
-        chainSpecific: { gas: '0' }
+        chainSpecific: { gas, fee }
       })
-      const cosmosSignedTx = await cosmosChainAdapter.signTransaction({
+
+      if (!cosmosChainAdapter.signAndBroadcastTransaction) return
+
+      console.log('comsos unsigned tx', cosmosUnsignedTx)
+
+      const broadcastedTx = await cosmosChainAdapter.signAndBroadcastTransaction({
         wallet,
         txToSign: cosmosUnsignedTx.txToSign
       })
-      console.log('cosmosSignedTx:', cosmosSignedTx)
+      console.log('broadcastedTx:', broadcastedTx)
 
-      // const cosmosTxID = await cosmosChainAdapter.broadcastTransaction(cosmosSignedTx)
-      // console.log('cosmosTxID:', cosmosTxID)
     } catch (err) {
       console.log('cosmosTx error:', err.message)
     }

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -72,7 +72,8 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
         }),
         chain: this.getType(),
         chainSpecific: {
-          sequence: data.sequence
+          accountNumber: data.accountNumber.toString(),
+          sequence: data.sequence.toString()
         },
         pubkey: data.pubkey
         /* TypeScript can't guarantee the correct type for the chainSpecific field because of the generic return type.

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -154,7 +154,7 @@ export class ChainAdapter
     signTxInput: chainAdapters.SignTxInput<CosmosSignTx>
   ): Promise<string> {
     const signedTx = await this.signTransaction(signTxInput)
-    const { data } = await this.providers.http.sendTx({ sendTxBody: {  hex: signedTx  }})
+    const { data } = await this.providers.http.sendTx({ body: { rawTx: signedTx } })
     return data
   }
 }

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -151,9 +151,10 @@ export class ChainAdapter
   }
 
   async signAndBroadcastTransaction(
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disable no-unused-vars lint rule for unimplemented methods */
     signTxInput: chainAdapters.SignTxInput<CosmosSignTx>
   ): Promise<string> {
-    throw new Error('Method not implemented.')
+    const signedTx = await this.signTransaction(signTxInput)
+    const { data } = await this.providers.http.sendTx({ sendTxBody: {  hex: signedTx  }})
+    return data
   }
 }

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -10,7 +10,7 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapter as IChainAdapter } from '../../api'
 import { ErrorHandler } from '../../error/ErrorHandler'
-import { toPath, bnOrZero } from '../../utils'
+import { bnOrZero, toPath } from '../../utils'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 
 export class ChainAdapter
@@ -144,6 +144,7 @@ export class ChainAdapter
   }
 
   async getFeeData({
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disable no-unused-vars lint rule for unimplemented variable */
     sendMax
   }: Partial<chainAdapters.GetFeeDataInput<ChainTypes.Cosmos>>): Promise<
     chainAdapters.FeeDataEstimate<ChainTypes.Cosmos>

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -10,7 +10,7 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapter as IChainAdapter } from '../../api'
 import { ErrorHandler } from '../../error/ErrorHandler'
-import { toPath, bnOrZero, } from '../../utils'
+import { toPath, bnOrZero } from '../../utils'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 
 export class ChainAdapter
@@ -83,7 +83,7 @@ export class ChainAdapter
         to,
         wallet,
         bip44Params = CosmosSdkBaseAdapter.defaultBIP44Params,
-        chainSpecific: { gas },
+        chainSpecific: { gas, fee },
         sendMax = false,
         value
       } = tx
@@ -105,7 +105,7 @@ export class ChainAdapter
         fee: {
           amount: [
             {
-              amount: bnOrZero(gas).toString(),
+              amount: bnOrZero(fee).toString(),
               denom: 'uatom'
             }
           ],
@@ -157,14 +157,12 @@ export class ChainAdapter
     try {
       if (supportsCosmos(wallet)) {
         const signedTx = await this.signTransaction(signTxInput)
-        console.log({ signedTx, from: 'signAndBroadcastTransaction' })
         const { data } = await this.providers.http.sendTx({ body: { rawTx: signedTx } })
         return data
       } else {
         throw new Error('Wallet does not support Cosmos.')
       }
     } catch (error) {
-      console.dir(error.response.data, { color: true, depth: 4 })
       return ErrorHandler(error)
     }
   }

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -143,11 +143,27 @@ export class ChainAdapter
     }
   }
 
-  async getFeeData(
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disable no-unused-vars lint rule for unimplemented methods */
-    input: Partial<chainAdapters.GetFeeDataInput<ChainTypes.Cosmos>>
-  ): Promise<chainAdapters.FeeDataEstimate<ChainTypes.Cosmos>> {
-    throw new Error('Method not implemented.')
+  async getFeeData({
+    sendMax
+  }: Partial<chainAdapters.GetFeeDataInput<ChainTypes.Cosmos>>): Promise<
+    chainAdapters.FeeDataEstimate<ChainTypes.Cosmos>
+  > {
+    // We currently don't have a way to query validators to get dynamic fees, so they are hard coded.
+    // When we find a strategy to make this more dynamic, we can use 'sendMax' to define max amount.
+    return {
+      [chainAdapters.FeeDataKey.Fast]: {
+        txFee: '5000',
+        chainSpecific: { gasLimit: '250000' }
+      },
+      [chainAdapters.FeeDataKey.Average]: {
+        txFee: '3500',
+        chainSpecific: { gasLimit: '250000' }
+      },
+      [chainAdapters.FeeDataKey.Slow]: {
+        txFee: '2500',
+        chainSpecific: { gasLimit: '250000' }
+      }
+    }
   }
 
   async signAndBroadcastTransaction(

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -80,9 +80,10 @@ export class ChainAdapter
   }
 
   async signAndBroadcastTransaction(
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disable no-unused-vars lint rule for unimplemented methods */
     signTxInput: chainAdapters.SignTxInput<OsmosisSignTx>
   ): Promise<string> {
-    throw new Error('Method not implemented.')
+    const signedTx = await this.signTransaction(signTxInput)
+    const { data } = await this.providers.http.sendTx({ body: { rawTx: signedTx } })
+    return data
   }
 }

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -80,10 +80,9 @@ export class ChainAdapter
   }
 
   async signAndBroadcastTransaction(
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disable no-unused-vars lint rule for unimplemented methods */
     signTxInput: chainAdapters.SignTxInput<OsmosisSignTx>
   ): Promise<string> {
-    const signedTx = await this.signTransaction(signTxInput)
-    const { data } = await this.providers.http.sendTx({ body: { rawTx: signedTx } })
-    return data
+    throw new Error('Method not implemented.')
   }
 }

--- a/packages/types/src/chain-adapters/cosmos.ts
+++ b/packages/types/src/chain-adapters/cosmos.ts
@@ -1,5 +1,6 @@
 export type BuildTxInput = {
   gas: string
+  fee: string
 }
 
 export type Account = {
@@ -8,5 +9,5 @@ export type Account = {
 }
 
 export type FeeData = {
-  value: string
+  gasLimit: string
 }

--- a/packages/types/src/chain-adapters/cosmos.ts
+++ b/packages/types/src/chain-adapters/cosmos.ts
@@ -3,7 +3,8 @@ export type BuildTxInput = {
 }
 
 export type Account = {
-  sequence: number
+  sequence: string
+  accountNumber: string
 }
 
 export type FeeData = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,10 +2756,10 @@
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-"@shapeshiftoss/blockbook@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/blockbook/-/blockbook-6.0.0.tgz#3379416ed15fb52fa997ff26cd219cb483778432"
-  integrity sha512-VTEM3wPWDxDZSDJt88VpZ9yEFnJPYceGNFSaVi//QDpPY5Y0B2BzXHRbuZj1bRLjVmNLjL0BFNvIGcIAA6xKWw==
+"@shapeshiftoss/blockbook@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/blockbook/-/blockbook-6.1.1.tgz#78a7c6c3a1c6a0e9f22fe4c5d5b932d800229ada"
+  integrity sha512-iwnESD9LAvk8QVynDsBxF4IQOU9DD2oyd9jmB/Ve6Jte9Vg6OIQnu5GC3p9H8AxkqVwtd8YyC9aubBUNBNf0/w==
   dependencies:
     axios "^0.26.0"
     express "^4.17.1"
@@ -2853,12 +2853,12 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/unchained-client@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-6.0.0.tgz#237be630f98c7b45331134c2673d55eb67064376"
-  integrity sha512-EkQyuCc6WnbMJJdm+kYA5ct8I69YNx9UhmScyhR+StLbl8Opbspi5ElGi0RhysRUl9F103bPSB3rZIPmCwoJLQ==
+"@shapeshiftoss/unchained-client@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-6.1.1.tgz#b7ec71bd70973b26940935ee467390561349e36b"
+  integrity sha512-JpdPC4x0cHRJZG6o30PFTxTL2jPWsrvZPFIoyQcpPEqcCH+S9Bz1BSrwCZmcBnFqZBVQmJ2KoKmfQB9ll9sprA==
   dependencies:
-    "@shapeshiftoss/blockbook" "^6.0.0"
+    "@shapeshiftoss/blockbook" "^6.1.1"
     "@shapeshiftoss/caip" "^2.0.0"
     "@shapeshiftoss/types" "^2.0.0"
     "@yfi/sdk" "^1.0.30"


### PR DESCRIPTION
- Add `signAndBroadcastTransaction` to cosmos and osmosis chain adapters
- Update `buildSendTransaction` to have dynamic `accountNumber` and `sequence` number
- Update chainAdapter CLI 

- closes #306 