### PR TITLE
fix: make accountType optional in BitcoinChainAdapter getAddress

### DIFF
--- a/packages/types/src/chain-adapters/bitcoin.ts
+++ b/packages/types/src/chain-adapters/bitcoin.ts
@@ -16,7 +16,7 @@ export type Address = {
 }
 
 export type GetAddressInput = GetAddressInputBase & {
-  accountType: UtxoAccountType
+  accountType?: UtxoAccountType
 }
 
 export type TransactionSpecific = {


### PR DESCRIPTION
This follows https://github.com/shapeshift/lib/pull/447 - we have a default Segwit Native `accountType`, so it shouldn't be required to explicitly pass it.