### PR TITLE
fix(cosmos): actually validateAddress

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
+    "bech32": "^2.0.0",
     "bignumber.js": "^9.0.1",
     "bitcoinjs-lib": "^5.2.0",
     "coinselect": "^3.1.12",

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -2,7 +2,7 @@ import { AssetNamespace, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
 import { CosmosSignTx } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import * as bech32 from 'bech32'
+import { bech32 } from 'bech32'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -174,13 +174,13 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
     try {
       const { prefix } = bech32.decode(address)
 
-      if (CHAIN_TO_BECH32_PREFIX_MAPPING[chain] === prefix)
-        return {
-          valid: true,
-          result: chainAdapters.ValidAddressResultType.Valid
-        }
-      else {
+      if (CHAIN_TO_BECH32_PREFIX_MAPPING[chain] !== prefix) {
         throw new Error(`Invalid address ${address} for ChainType: ${chain}`)
+      }
+
+      return {
+        valid: true,
+        result: chainAdapters.ValidAddressResultType.Valid
       }
     } catch (err) {
       console.error(err)

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -2,6 +2,7 @@ import { AssetNamespace, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
 import { CosmosSignTx } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import * as bech32 from 'bech32'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -16,6 +17,11 @@ export interface ChainAdapterArgs {
     ws: unchained.ws.Client<unchained.cosmos.Tx>
   }
   coinName: string
+}
+
+const CHAIN_TO_BECH32_PREFIX_MAPPING = {
+  [ChainTypes.Cosmos]: 'cosmos',
+  [ChainTypes.Osmosis]: 'osmo'
 }
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
@@ -164,11 +170,17 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
   ): Promise<string>
 
   async validateAddress(address: string): Promise<chainAdapters.ValidAddressResult> {
+    const chain = this.getType()
     try {
-      await this.providers.http.getAccount({ pubkey: address })
-      return {
-        valid: true,
-        result: chainAdapters.ValidAddressResultType.Valid
+      const { prefix } = bech32.decode(address)
+
+      if (CHAIN_TO_BECH32_PREFIX_MAPPING[chain] === prefix)
+        return {
+          valid: true,
+          result: chainAdapters.ValidAddressResultType.Valid
+        }
+      else {
+        throw new Error(`Invalid address ${address} for ChainType: ${chain}`)
       }
     } catch (err) {
       console.error(err)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,6 +3812,11 @@ bech32@1.1.4, bech32@^1.1.2, bech32@^1.1.3, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
+
 before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"


### PR DESCRIPTION
Currently, `CosmosSdkBaseAdapter` is using `WAValidator`, which doesn't support Cosmos.
This will produce some error if we try to validate some cosmos address:

```
wallet_address_validator.js:17 Uncaught (in promise) Error: Missing validator for currency: cosmos
    at Object.validate (wallet_address_validator.js:17:1)
    at ChainAdapter.validateAddress (CosmosSdkBaseAdapter.js:107:1)
```
This PR uses the V1Account endpoint, which has a middleware using the `IsValidAddress` function:
 https://github.com/shapeshift/unchained/blob/1701f95c24a5e26edffa83f1e31da2f27a764778/go/pkg/cosmos/middleware.go#L19
 
By trying that request to `V1Account`, and catching on error status, we effectively have address validation implemented here, without needing to implement a whole new endpoint in unchained. 