### PR TITLE
feat: add remove function to chain adapters manager

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -76,6 +76,16 @@ export class ChainAdapterManager {
     this.supported.set(chain, factory)
   }
 
+  removeChain<T extends ChainTypes>(chain: T): void {
+    if (!Object.values(ChainTypes).includes(chain)) {
+      throw new Error(`ChainAdapterManager: invalid chain ${chain}`)
+    }
+    if (!this.supported.has(chain)) {
+      throw new Error(`ChainAdapterManager: chain ${chain} not registered`)
+    }
+    this.supported.delete(chain)
+  }
+
   getSupportedChains(): Array<ChainTypes> {
     return Array.from(this.supported.keys())
   }


### PR DESCRIPTION
we have a chainadaptermanager singleton in web and need to access it in and outside react. need the ability to remove chain adapters when we turn off feature flags. we can't replace the singleton, so we need to be able to remove individual chain adapters from the manager. this adds that functionality and unblocks broken feature flag functionality in web.