### PR TITLE
feat: accept memo in buildSendTransaction

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -85,7 +85,8 @@ export class ChainAdapter
         bip44Params = CosmosSdkBaseAdapter.defaultBIP44Params,
         chainSpecific: { gas, fee },
         sendMax = false,
-        value
+        value,
+        memo = ''
       } = tx
 
       if (!to) throw new Error('CosmosChainAdapter: to is required')
@@ -127,7 +128,7 @@ export class ChainAdapter
           }
         ],
         signatures: [],
-        memo: ''
+        memo
       }
 
       const txToSign: CosmosSignTx = {

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -170,6 +170,7 @@ export type BuildSendTxInput<T extends ChainTypes> = {
   wallet: HDWallet
   bip44Params?: BIP44Params // TODO maybe these shouldnt be optional
   sendMax?: boolean
+  memo?: string
 } & ChainSpecificBuildTxData<T>
 
 type ChainSpecificBuildTxData<T> = ChainSpecific<


### PR DESCRIPTION
See https://github.com/shapeshift/web/issues/651 - this adds support for memo field in `buildSendTransaction`, which is the method we use in web to build a send tx:

https://github.com/shapeshift/web/blob/1c6ba0e79e65d2c6b13c0f34cc1442b58a705d95/src/plugins/cosmos/components/modals/Send/hooks/useFormSend/useFormSend.tsx#L39-L45

Since tendermint/sig already supports creating a signed tx with memo (see https://tendermint.github.io/sig/interfaces/stdtx.html), we don't need any additional work in lib than this to support memos.

<img width="328" alt="image" src="https://user-images.githubusercontent.com/17035424/159484586-82e252c1-a313-4a54-90c6-af097a747b50.png">