### PR TITLE
fix: foxy icon url

### DIFF
--- a/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
@@ -22,7 +22,7 @@ export const getFoxyToken = (): TokenAsset[] => {
     contractType: assetNamespace,
     color: '#CE3885',
     secondaryColor: '#CE3885',
-    icon: 'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/icons/foxy-icon.png',
+    icon: 'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethTokens/icons/foxy-icon.png',
     sendSupport: true,
     receiveSupport: true,
     symbol: 'FOXy'


### PR DESCRIPTION
Update icon url.  This was unable to be tested due to needing to be in main before github hosted it.
This is the correct url