### PR TITLE
fix: fix yearn sdk instantiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "version": "independent"
   },
   "scripts": {
+    "local-ci": "yarn clean && yarn && yarn lint && yarn build && yarn type-check && yarn test",
     "build": "lerna run build --include-dependencies",
     "clean": "rimraf node_modules dist packages/**/dist packages/**/node_modules",
     "dev": "lerna run dev --stream --parallel",

--- a/packages/asset-service/src/generateAssetData/ethTokens/yearnSdk.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/yearnSdk.ts
@@ -3,4 +3,4 @@ import { Yearn } from '@yfi/sdk'
 
 const network = 1 // 1 for mainnet
 const provider = new JsonRpcProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
-export const yearnSdk = new Yearn(network, { provider, disableAllowlist: true })
+export const yearnSdk = new Yearn(network, { provider })

--- a/packages/caip/src/adapters/yearn/utils.ts
+++ b/packages/caip/src/adapters/yearn/utils.ts
@@ -10,7 +10,7 @@ import { AssetNamespace, toCAIP19 } from '../../caip19/caip19'
 
 const network = 1 // 1 for mainnet
 const provider = new JsonRpcProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
-const yearnSdk = new Yearn(network, { provider, disableAllowlist: true })
+const yearnSdk = new Yearn(network, { provider })
 
 export const writeFiles = async (data: Record<string, Record<string, string>>) => {
   const path = './src/adapters/yearn/generated/'

--- a/packages/investor-yearn/src/api/api.ts
+++ b/packages/investor-yearn/src/api/api.ts
@@ -50,7 +50,7 @@ export class YearnVaultApi {
     this.provider = new Web3.providers.HttpProvider(providerUrl)
     this.jsonRpcProvider = new JsonRpcProvider(providerUrl)
     this.web3 = new Web3(this.provider)
-    this.yearnSdk = new Yearn(network, { provider: this.jsonRpcProvider, disableAllowlist: true })
+    this.yearnSdk = new Yearn(network, { provider: this.jsonRpcProvider })
     this.ssRouterContract = new this.web3.eth.Contract(ssRouterAbi, ssRouterContractAddress)
     this.vaults = []
   }

--- a/packages/investor-yearn/src/api/yearn-sdk.ts
+++ b/packages/investor-yearn/src/api/yearn-sdk.ts
@@ -4,4 +4,4 @@ import { Yearn } from '@yfi/sdk'
 // YearnVaultMarketCapService deps
 const network = 1 // 1 for mainnet
 const provider = new JsonRpcProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
-export const yearnSdk = new Yearn(network, { provider, disableAllowlist: true })
+export const yearnSdk = new Yearn(network, { provider })

--- a/packages/market-service/src/market-providers.ts
+++ b/packages/market-service/src/market-providers.ts
@@ -10,7 +10,7 @@ import { YearnVaultMarketCapService } from './yearn/yearn-vaults'
 // YearnVaultMarketCapService deps
 const network = 1 // 1 for mainnet
 const provider = new JsonRpcProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
-const yearnSdk = new Yearn(network, { provider, disableAllowlist: true })
+const yearnSdk = new Yearn(network, { provider })
 
 // Order of this MarketProviders array constitutes the order of provders we will be checking first.
 // More reliable providers should be listed first.

--- a/packages/market-service/src/marketDataCLI.ts
+++ b/packages/market-service/src/marketDataCLI.ts
@@ -21,7 +21,7 @@ const main = async (): Promise<void> => {
   const timeframe = HistoryTimeframe.YEAR
   // const caip19 = 'bip122:000000000019d6689c085ae165831e93/slip44:0' // BTC
   // const provider = new JsonRpcProvider('https://daemon.ethereum.shapeshift.com')
-  // const yearnSdk = new Yearn(1, { provider, disableAllowlist: true })
+  // const yearnSdk = new Yearn(1, { provider })
   // const yearnMarketService = new YearnTokenMarketCapService({ yearnSdk })
   // const osmosisMarketService = new OsmosisMarketService()
   const foxyMarketService = new FoxyMarketService()


### PR DESCRIPTION
`disableAllowList` was removed from the `Yearn()` constructor and is now defaulted - see upstream issue here https://github.com/yearn/yearn-sdk/issues/242

this fixes the build for CI.

