### PR TITLE
fix: don't use strings in contract calls

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -428,12 +428,10 @@ export class FoxyApi {
     const stakingContract = this.getStakingContract(contractAddress)
     const userChecksum = this.web3.utils.toChecksumAddress(userAddress)
 
-    const data: string = await stakingContract.methods
-      .stake(amountDesired, userAddress)
-      .encodeABI({
-        value: 0,
-        from: userChecksum
-      })
+    const data: string = await stakingContract.methods.stake(amountDesired, userAddress).encodeABI({
+      value: 0,
+      from: userChecksum
+    })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
@@ -609,11 +607,9 @@ export class FoxyApi {
 
     const liquidityReserveContract = this.getLiquidityReserveContract(contractAddress)
 
-    const data: string = liquidityReserveContract.methods
-      .addLiquidity(amountDesired)
-      .encodeABI({
-        from: userAddress
-      })
+    const data: string = liquidityReserveContract.methods.addLiquidity(amountDesired).encodeABI({
+      from: userAddress
+    })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
@@ -656,11 +652,9 @@ export class FoxyApi {
 
     const liquidityReserveContract = this.getLiquidityReserveContract(contractAddress)
 
-    const data: string = liquidityReserveContract.methods
-      .removeLiquidity(amountDesired)
-      .encodeABI({
-        from: userAddress
-      })
+    const data: string = liquidityReserveContract.methods.removeLiquidity(amountDesired).encodeABI({
+      from: userAddress
+    })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -256,7 +256,7 @@ export class FoxyApi {
 
     try {
       const estimatedGas = await liquidityReserveContract.methods
-        .addLiquidity(amountDesired.toString())
+        .addLiquidity(amountDesired)
         .estimateGas({
           from: userAddress
         })
@@ -275,7 +275,7 @@ export class FoxyApi {
 
     try {
       const estimatedGas = await liquidityReserveContract.methods
-        .removeLiquidity(amountDesired.toString())
+        .removeLiquidity(amountDesired)
         .estimateGas({
           from: userAddress
         })
@@ -296,7 +296,7 @@ export class FoxyApi {
 
     try {
       const estimatedGas = isDelayed
-        ? await stakingContract.methods.unstake(amountDesired.toString(), true).estimateGas({
+        ? await stakingContract.methods.unstake(amountDesired, true).estimateGas({
             from: userAddress
           })
         : await stakingContract.methods.instantUnstake(true).estimateGas({
@@ -317,7 +317,7 @@ export class FoxyApi {
 
     try {
       const estimatedGas = await stakingContract.methods
-        .stake(amountDesired.toString(), userAddress)
+        .stake(amountDesired, userAddress)
         .estimateGas({
           from: userAddress
         })
@@ -429,7 +429,7 @@ export class FoxyApi {
     const userChecksum = this.web3.utils.toChecksumAddress(userAddress)
 
     const data: string = await stakingContract.methods
-      .stake(amountDesired.toString(), userAddress)
+      .stake(amountDesired, userAddress)
       .encodeABI({
         value: 0,
         from: userChecksum
@@ -478,7 +478,7 @@ export class FoxyApi {
     if (isDelayed && !amountDesired.gt(0)) throw new Error('Must send valid amount')
 
     const data: string = isDelayed
-      ? stakingContract.methods.unstake(amountDesired.toString(), true).encodeABI({
+      ? stakingContract.methods.unstake(amountDesired, true).encodeABI({
           from: userAddress
         })
       : stakingContract.methods.instantUnstake(true).encodeABI({
@@ -610,7 +610,7 @@ export class FoxyApi {
     const liquidityReserveContract = this.getLiquidityReserveContract(contractAddress)
 
     const data: string = liquidityReserveContract.methods
-      .addLiquidity(amountDesired.toString())
+      .addLiquidity(amountDesired)
       .encodeABI({
         from: userAddress
       })
@@ -657,7 +657,7 @@ export class FoxyApi {
     const liquidityReserveContract = this.getLiquidityReserveContract(contractAddress)
 
     const data: string = liquidityReserveContract.methods
-      .removeLiquidity(amountDesired.toString())
+      .removeLiquidity(amountDesired)
       .encodeABI({
         from: userAddress
       })


### PR DESCRIPTION
Strings were causing 'Invalid BigNumber string' error 