### PR TITLE
chore: add effort and sponsor to bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,6 +47,18 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
+  - type: input
+    id: estimate
+    attributes:
+      label: Estimated effort
+      description: "Estimated effort to complete the bounty, in hours or days"
+      placeholder: "Half a day"
+  - type: input
+    id: stakeholder
+    attributes:
+      label: Sponsor / Stakeholder
+      description: "To whom can the bounty hunter go to for questions and support?"
+      placeholder: "github_handle or discord_handle"
   - type: textarea
     id: bounty-hunters
     attributes:


### PR DESCRIPTION
Bring the `lib` bounty template in line with `web` by adding effort and sponsor inputs.

<img width="388" alt="Screen Shot 2022-03-26 at 7 05 08 pm" src="https://user-images.githubusercontent.com/97164662/160230661-bf13ff12-71e1-4b4a-992d-e6f7deba0221.png">
