### PR TITLE
fix: foxy rebase logic and types

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -869,8 +869,11 @@ export class FoxyApi {
           try {
             // check transfer events to see if a user triggered a rebase through unstake
             const transferInfo = transferEvents?.filter(
-              (e) => e.blockNumber === event.blockNumber && e.returnValues.from === userAddress
+              (e) =>
+                e.blockNumber === event.blockNumber &&
+                e.returnValues.from.toLowerCase() === userAddress
             )
+            console.log('transferInfo', transferInfo)
             const transferAmount = transferInfo?.[0]?.returnValues?.value ?? 0
             const postRebaseBalanceResult = await foxyContract.methods
               .balanceOf(userAddress)

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -853,8 +853,6 @@ export class FoxyApi {
               .balanceOf(userAddress)
               .call(null, event.blockNumber - 1)
 
-            console.info('preRebaseBalance', preRebaseBalance)
-            console.info('postRebaseBalance', postRebaseBalance)
             return bnOrZero(postRebaseBalance).minus(preRebaseBalance).toString()
           } catch (e) {
             console.error(`Failed to get balance of address ${e}`)
@@ -862,7 +860,7 @@ export class FoxyApi {
           }
         })()
 
-        const timestamp = await (async () => {
+        const blockTime = await (async () => {
           try {
             const block = await this.web3.eth.getBlock(event.blockNumber)
             return bnOrZero(block.timestamp).toNumber()
@@ -871,7 +869,7 @@ export class FoxyApi {
             return 0
           }
         })()
-        return { balanceDiff, timestamp }
+        return { balanceDiff, blockTime }
       })
     )
 

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -34,6 +34,8 @@ import {
   WithdrawInput
 } from './foxy-types'
 
+export * from './foxy-types'
+
 export type ConstructorArgs = {
   adapter: ChainAdapter<ChainTypes>
   providerUrl: string
@@ -842,7 +844,7 @@ export class FoxyApi {
 
     const results = await Promise.allSettled(
       events.map(async (event) => {
-        const balance = await (async () => {
+        const balanceDiff = await (async () => {
           try {
             const postRebaseBalance = await contract.methods
               .balanceOf(userAddress)
@@ -851,10 +853,12 @@ export class FoxyApi {
               .balanceOf(userAddress)
               .call(null, event.blockNumber - 1)
 
-            return bnOrZero(postRebaseBalance).minus(preRebaseBalance)
+            console.info('preRebaseBalance', preRebaseBalance)
+            console.info('postRebaseBalance', postRebaseBalance)
+            return bnOrZero(postRebaseBalance).minus(preRebaseBalance).toString()
           } catch (e) {
             console.error(`Failed to get balance of address ${e}`)
-            return bnOrZero(0)
+            return bnOrZero(0).toString()
           }
         })()
 
@@ -867,7 +871,7 @@ export class FoxyApi {
             return 0
           }
         })()
-        return { balance, timestamp }
+        return { balanceDiff, timestamp }
       })
     )
 

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -119,5 +119,5 @@ export type RebaseEvent = {
 
 export type RebaseHistory = {
   balanceDiff: string
-  timestamp: number
+  blockTime: number
 }

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -118,6 +118,6 @@ export type RebaseEvent = {
 }
 
 export type RebaseHistory = {
-  balance: BigNumber
+  balanceDiff: string
   timestamp: number
 }

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -1,3 +1,4 @@
+import { CAIP19 } from '@shapeshiftoss/caip/src/caip19/caip19'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
@@ -118,6 +119,7 @@ export type RebaseEvent = {
 }
 
 export type RebaseHistory = {
+  assetId: CAIP19
   balanceDiff: string
   blockTime: number
 }

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -54,6 +54,11 @@ const main = async (): Promise<void> => {
   const userAddress = await api.adapter.getAddress({ wallet })
   console.info('current user address ', userAddress)
 
+  await api.getRebaseHistory({
+    tokenContractAddress: foxyContractAddress,
+    userAddress: '0x86c11fBfED5a45eb7f2bD64509928ff6355f1CA0'
+  })
+
   const circulatingSupply = async () => {
     try {
       const supply = await api.tvl({ tokenContractAddress: foxyContractAddress })

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -54,12 +54,6 @@ const main = async (): Promise<void> => {
   const userAddress = await api.adapter.getAddress({ wallet })
   console.info('current user address ', userAddress)
 
-  const rebases = await api.getRebaseHistory({
-    tokenContractAddress: foxyContractAddress,
-    userAddress: '0x86c11fBfED5a45eb7f2bD64509928ff6355f1CA0'
-  })
-  console.info('rebases', rebases)
-
   const circulatingSupply = async () => {
     try {
       const supply = await api.tvl({ tokenContractAddress: foxyContractAddress })

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -54,10 +54,11 @@ const main = async (): Promise<void> => {
   const userAddress = await api.adapter.getAddress({ wallet })
   console.info('current user address ', userAddress)
 
-  await api.getRebaseHistory({
+  const rebases = await api.getRebaseHistory({
     tokenContractAddress: foxyContractAddress,
     userAddress: '0x86c11fBfED5a45eb7f2bD64509928ff6355f1CA0'
   })
+  console.info('rebases', rebases)
 
   const circulatingSupply = async () => {
     try {


### PR DESCRIPTION
this is required to unblock https://github.com/shapeshift/web/pull/1321

* **wip - @toshiSat to complete - handle stake events that trigger a rebase**
* include assetId in rebase history return type
* adjust the return type to be called blockTime in alignment with what web consumes
* adjust rebase balance diffs that are initiated by unstake events to exclude the transfer value