### PR TITLE
feat: move withdraw type to types package

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -2,14 +2,14 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
 import { ChainReference } from '@shapeshiftoss/caip/dist/caip2/caip2'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
-import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
 import { toLower } from 'lodash'
 import Web3 from 'web3'
 import { HttpProvider, TransactionReceipt } from 'web3-core/types'
 import { Contract } from 'web3-eth-contract'
 
-import { DefiType, erc20Abi, foxyStakingAbi, MAX_ALLOWANCE, WithdrawType } from '../constants'
+import { DefiType, erc20Abi, foxyStakingAbi, MAX_ALLOWANCE } from '../constants'
 import { foxyAbi } from '../constants/foxy-abi'
 import { liquidityReserveAbi } from '../constants/liquidity-reserve-abi'
 import { bnOrZero, buildTxToSign } from '../utils'
@@ -32,7 +32,8 @@ import {
   TxInputWithoutAmountAndWallet,
   TxReceipt,
   WithdrawInfo,
-  WithdrawInput
+  WithdrawInput,
+  WithdrawEstimateGasInput
 } from './foxy-types'
 
 export * from './foxy-types'
@@ -290,7 +291,7 @@ export class FoxyApi {
     }
   }
 
-  async estimateWithdrawGas(input: WithdrawInput): Promise<BigNumber> {
+  async estimateWithdrawGas(input: WithdrawEstimateGasInput): Promise<BigNumber> {
     const { amountDesired, userAddress, contractAddress, type } = input
     this.verifyAddresses([userAddress, contractAddress])
 

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -31,9 +31,9 @@ import {
   TxInputWithoutAmount,
   TxInputWithoutAmountAndWallet,
   TxReceipt,
+  WithdrawEstimateGasInput,
   WithdrawInfo,
-  WithdrawInput,
-  WithdrawEstimateGasInput
+  WithdrawInput
 } from './foxy-types'
 
 export * from './foxy-types'

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -1,9 +1,7 @@
 import { CAIP19 } from '@shapeshiftoss/caip/src/caip19/caip19'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { BIP44Params } from '@shapeshiftoss/types'
+import { BIP44Params, WithdrawType } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
-
-import { WithdrawType } from '../constants'
 
 export type FoxyAddressesType = {
   staking: string
@@ -56,6 +54,8 @@ export type WithdrawInput = Omit<TxInput, 'amountDesired'> & {
   type: WithdrawType
   amountDesired?: BigNumber
 }
+
+export type WithdrawEstimateGasInput = Omit<WithdrawInput, 'wallet'>
 
 export type FoxyOpportunityInputData = {
   tvl: BigNumber

--- a/packages/investor-foxy/src/constants/enums.ts
+++ b/packages/investor-foxy/src/constants/enums.ts
@@ -5,8 +5,3 @@ export enum DefiProvider {
 export enum DefiType {
   TokenStaking = 'token-staking'
 }
-
-export enum WithdrawType {
-  DELAYED,
-  INSTANT
-}

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -1,12 +1,12 @@
 import { caip2 } from '@shapeshiftoss/caip'
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 import readline from 'readline-sync'
 
 import { FoxyApi } from './api'
-import { foxyAddresses, WithdrawType } from './constants'
+import { foxyAddresses } from './constants'
 import { bnOrZero } from './utils'
 
 dotenv.config()

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -30,6 +30,11 @@ export enum NetworkTypes {
   OSMOSIS_TESTNET = 'OSMOSIS_TESTNET'
 }
 
+export enum WithdrawType {
+  DELAYED,
+  INSTANT
+}
+
 export enum UtxoAccountType {
   SegwitNative = 'SegwitNative',
   SegwitP2sh = 'SegwitP2sh',


### PR DESCRIPTION
- Move `Withdrawal Type` to `types` package
- Add `WithdrawEstimateGasInput` for FOXy

NOTE: This PR is a prerequisite for merging of [foxy-withdrawals](https://github.com/shapeshift/web/pull/1330) in web.