### PR TITLE
feat: don't log cosmos validation error

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -239,7 +239,6 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
         result: chainAdapters.ValidAddressResultType.Valid
       }
     } catch (err) {
-      console.error(err)
       return { valid: false, result: chainAdapters.ValidAddressResultType.Invalid }
     }
   }


### PR DESCRIPTION
## Description

This removes the console erroring at cosmos validation step, since web will produce an errored state, it currently produces log spew.

## Issue

#487