### PR TITLE
feat: add tokens to returned Validator type

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -29,6 +29,7 @@ const transformValidator = (
 ): chainAdapters.cosmos.Validator => ({
   address: validator.address,
   moniker: validator.moniker,
+  tokens: validator.tokens,
   commission: validator.commission.rate,
   apr: validator.apr
 })

--- a/packages/types/src/chain-adapters/cosmos.ts
+++ b/packages/types/src/chain-adapters/cosmos.ts
@@ -11,6 +11,7 @@ export type Info = {
 export type Validator = {
   address: string
   moniker: string
+  tokens: string
   apr: string
   commission: string
 }


### PR DESCRIPTION
This adds `tokens` to the Validator type in Cosmos.
It is the amount of delegated tokens for that validator (including self-delegation) and will be used for TVL calculation in https://github.com/shapeshift/web/issues/1402.