### PR TITLE
feat(errors): add new "errors" package

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,40 @@
+# @shapeshiftoss/errors
+
+This package contains named errors and a function to create new named errors
+
+## Installation
+
+It's recommend to add this package to `peerDependencies` to avoid duplicate versions of the package
+which will cause `instanceof` checks to fail.
+
+## Usage
+
+```ts
+import { ValidationError } from '@shapeshiftoss/errors'
+
+throw new ValidationError('txId cannot be null', { details: { name: 'txId', expected: 'not null', actual: 'null' }})
+```
+
+### Create a new named error
+```ts
+import { createErrorClass } from '@shapeshiftoss/errors'
+
+const MyError = createErrorClass<{ myDetails: string }>('MyError')
+
+try {
+  throw new MyError('My cool error', { details: { myDetails: 'string' } })
+} catch (e) {
+  assert.ok(e instanceof MyError)
+}
+
+```
+
+## Types
+
+```
+ForbiddenError - Authorized but not allowed access request resource
+NotFoundError - Can not find requested entity
+RateLimitError - API returned a 429 error
+UnauthorizedError - Trying to access a protected resource
+ValidationError - Invalid data provided
+```

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@shapeshiftoss/errors",
+  "version": "1.0.0",
+  "description": "Common set of typed errors",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "dist",
+    "src": "src"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "dev": "tsc --watch",
+    "test": "jest test",
+    "type-check": "tsc --project ./tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "lodash.clonedeep": "^4.5.0"
+  },
+  "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.6"
+  }
+}

--- a/packages/errors/src/ErrorWithCause.test.ts
+++ b/packages/errors/src/ErrorWithCause.test.ts
@@ -1,0 +1,77 @@
+import ErrorWithCause from './ErrorWithCause'
+
+describe('ErrorWithCause', () => {
+  it('should create an error with no mesasge', () => {
+    const e = new ErrorWithCause()
+    expect(e).toBeInstanceOf(ErrorWithCause)
+    expect(e.message).toBe('')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge', () => {
+    const e = new ErrorWithCause('test message')
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge and a cause', () => {
+    const cause = new TypeError('cause')
+    const e = new ErrorWithCause('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+  })
+
+  it('should support typed cause', () => {
+    const cause = 'String Error'
+    const e = new ErrorWithCause<{ cause: string }>('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    // Check that TypeScript sees e.cause as a string so there's no type error
+    expect(e.cause.toLowerCase()).toBe('string error')
+  })
+
+  it('should error on mismatched typed cause', () => {
+    const cause = 'String Error'
+    // @ts-expect-error
+    const e = new ErrorWithCause<{ cause: Error }>('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    // Check that TypeScript sees e.cause as a string so there's no type error
+    // @ts-expect-error
+    expect(e.cause.toLowerCase()).toBe('string error')
+  })
+
+  it('should ignore unknown properties in options object', () => {
+    const cause = new TypeError('cause')
+    const e = new ErrorWithCause('test message', { cause, details: { arg1: 'foo' } })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
+  })
+})
+
+/*
+
+const b = new ErrorWithCause('test')
+b.cause
+const c = new ErrorWithCause<{ cause: string }>('test', {})
+c.cause
+const d = new ErrorWithCause<{ cause: string }>('test', { cause: 'hi' })
+d.cause
+const e = new ErrorWithCause('test', { cause: 'hi' })
+e.cause
+const f = new ErrorWithCause('test', { details: 'test' })
+f.cause
+
+const foo = new ErrorWithCause<undefined>('bar')
+const foo2 = new ErrorWithCause<string>('bar')
+const foo3 = new ErrorWithCause<string>('bar', {})
+const foo4 = new ErrorWithCause<string>('bar', { cause: undefined })
+const foo5 = new ErrorWithCause<string>('bar', { cause: 'bar' })
+
+const foo6 = new ErrorWithCause('baz')
+const foo7 = new ErrorWithCause('baz', {})
+const foo8 = new ErrorWithCause('baz', { cause: undefined })
+const foo9 = new ErrorWithCause('baz', { cause: 'bar' })
+
+ */

--- a/packages/errors/src/ErrorWithCause.test.ts
+++ b/packages/errors/src/ErrorWithCause.test.ts
@@ -1,20 +1,20 @@
 import ErrorWithCause from './ErrorWithCause'
 
 describe('ErrorWithCause', () => {
-  it('should create an error with no mesasge', () => {
+  it('should create an error with no message', () => {
     const e = new ErrorWithCause()
     expect(e).toBeInstanceOf(ErrorWithCause)
     expect(e.message).toBe('')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge', () => {
+  it('should create an error with a message', () => {
     const e = new ErrorWithCause('test message')
     expect(e.message).toBe('test message')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge and a cause', () => {
+  it('should create an error with a message and a cause', () => {
     const cause = new TypeError('cause')
     const e = new ErrorWithCause('test message', { cause })
     expect(e.message).toBe('test message')
@@ -49,29 +49,3 @@ describe('ErrorWithCause', () => {
     expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
   })
 })
-
-/*
-
-const b = new ErrorWithCause('test')
-b.cause
-const c = new ErrorWithCause<{ cause: string }>('test', {})
-c.cause
-const d = new ErrorWithCause<{ cause: string }>('test', { cause: 'hi' })
-d.cause
-const e = new ErrorWithCause('test', { cause: 'hi' })
-e.cause
-const f = new ErrorWithCause('test', { details: 'test' })
-f.cause
-
-const foo = new ErrorWithCause<undefined>('bar')
-const foo2 = new ErrorWithCause<string>('bar')
-const foo3 = new ErrorWithCause<string>('bar', {})
-const foo4 = new ErrorWithCause<string>('bar', { cause: undefined })
-const foo5 = new ErrorWithCause<string>('bar', { cause: 'bar' })
-
-const foo6 = new ErrorWithCause('baz')
-const foo7 = new ErrorWithCause('baz', {})
-const foo8 = new ErrorWithCause('baz', { cause: undefined })
-const foo9 = new ErrorWithCause('baz', { cause: 'bar' })
-
- */

--- a/packages/errors/src/ErrorWithCause.ts
+++ b/packages/errors/src/ErrorWithCause.ts
@@ -1,0 +1,13 @@
+export default class ErrorWithCause<
+  T extends { cause?: unknown } | undefined = undefined
+> extends Error {
+  readonly cause: T extends { cause: infer R } ? R : undefined
+
+  constructor(message?: string, options?: T) {
+    super(message)
+    this.name = this.constructor.name
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.cause = options?.cause as any
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/packages/errors/src/ErrorWithDetails.test.ts
+++ b/packages/errors/src/ErrorWithDetails.test.ts
@@ -1,0 +1,71 @@
+import ErrorWithDetails from './ErrorWithDetails'
+
+describe('ErrorWithDetails', () => {
+  it('should create an error with no mesasge', () => {
+    const e = new ErrorWithDetails()
+    expect(e).toBeInstanceOf(ErrorWithDetails)
+    expect(e.message).toBe('')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge', () => {
+    const e = new ErrorWithDetails('test message')
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge and a cause', () => {
+    const cause = new TypeError('cause')
+    const e = new ErrorWithDetails('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+  })
+
+  it('should create an error with a mesasge and details', () => {
+    const details = { prop: true }
+    const e = new ErrorWithDetails('test message', { details })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+    expect(e.details).toStrictEqual(details)
+  })
+
+  it('should clone details object', () => {
+    const details = { prop: true, deepProp: { prop2: true } }
+    const e = new ErrorWithDetails('test message', { details })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+    expect(e.details).not.toBe(details)
+    // e.details should be a clone of details to avoid mutation of the original object
+    expect(e.details).toStrictEqual(details)
+    details.deepProp.prop2 = false
+    expect(e.details).not.toStrictEqual(details)
+  })
+
+  it('should support typed cause', () => {
+    const cause = 'String Error'
+    const e = new ErrorWithDetails<{ cause: string }>('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    // Check that TypeScript sees e.cause as a string so there's no type error
+    expect(e.cause.toLowerCase()).toBe('string error')
+  })
+
+  it('should error on mismatched typed cause', () => {
+    const cause = 'String Error'
+    // @ts-expect-error
+    const e = new ErrorWithDetails<{ cause: Error }>('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    // Check that TypeScript sees e.cause as a string so there's no type error
+    // @ts-expect-error
+    expect(e.cause.toLowerCase()).toBe('string error')
+  })
+
+  it('should ignore unknown properties in options object', () => {
+    const cause = new TypeError('cause')
+    const e = new ErrorWithDetails('test message', { cause, stuff: { arg1: 'foo' } })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
+  })
+})

--- a/packages/errors/src/ErrorWithDetails.test.ts
+++ b/packages/errors/src/ErrorWithDetails.test.ts
@@ -1,27 +1,27 @@
 import ErrorWithDetails from './ErrorWithDetails'
 
 describe('ErrorWithDetails', () => {
-  it('should create an error with no mesasge', () => {
+  it('should create an error with no message', () => {
     const e = new ErrorWithDetails()
     expect(e).toBeInstanceOf(ErrorWithDetails)
     expect(e.message).toBe('')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge', () => {
+  it('should create an error with a message', () => {
     const e = new ErrorWithDetails('test message')
     expect(e.message).toBe('test message')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge and a cause', () => {
+  it('should create an error with a message and a cause', () => {
     const cause = new TypeError('cause')
     const e = new ErrorWithDetails('test message', { cause })
     expect(e.message).toBe('test message')
     expect(e.cause).toBe(cause)
   })
 
-  it('should create an error with a mesasge and details', () => {
+  it('should create an error with a message and details', () => {
     const details = { prop: true }
     const e = new ErrorWithDetails('test message', { details })
     expect(e.message).toBe('test message')

--- a/packages/errors/src/ErrorWithDetails.ts
+++ b/packages/errors/src/ErrorWithDetails.ts
@@ -1,0 +1,15 @@
+import cloneDeep from 'lodash.clonedeep'
+
+import ErrorWithCause from './ErrorWithCause'
+
+export default class ErrorWithDetails<
+  T extends { cause?: unknown; details?: Record<string, unknown> } | undefined = undefined
+> extends ErrorWithCause<T> {
+  public details: T extends { details: infer R } ? R : undefined
+
+  constructor(message?: string, options?: T) {
+    super(message, options)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (options?.details) this.details = cloneDeep<any>(options.details)
+  }
+}

--- a/packages/errors/src/ForbiddenError.ts
+++ b/packages/errors/src/ForbiddenError.ts
@@ -1,0 +1,3 @@
+import { createErrorClass } from './createErrorClass'
+
+export default createErrorClass('ForbiddenError')

--- a/packages/errors/src/NotFoundError.ts
+++ b/packages/errors/src/NotFoundError.ts
@@ -1,0 +1,3 @@
+import { createErrorClass } from './createErrorClass'
+
+export default createErrorClass('NotFoundError')

--- a/packages/errors/src/RateLimitError.ts
+++ b/packages/errors/src/RateLimitError.ts
@@ -1,0 +1,3 @@
+import { createErrorClass } from './createErrorClass'
+
+export default createErrorClass('RateLimitError')

--- a/packages/errors/src/UnauthorizedError.ts
+++ b/packages/errors/src/UnauthorizedError.ts
@@ -1,0 +1,3 @@
+import { createErrorClass } from './createErrorClass'
+
+export default createErrorClass('UnauthorizedError')

--- a/packages/errors/src/ValidationError.ts
+++ b/packages/errors/src/ValidationError.ts
@@ -1,0 +1,5 @@
+import { createErrorClass } from './createErrorClass'
+
+type ValidationErrorDetails = { name: string; actual: unknown; expected: unknown }
+
+export default createErrorClass<ValidationErrorDetails>('ValidationError')

--- a/packages/errors/src/createErrorClass.test.ts
+++ b/packages/errors/src/createErrorClass.test.ts
@@ -1,0 +1,34 @@
+import { inspect } from 'util'
+
+import { createErrorClass } from './createErrorClass'
+
+describe('createErrorClass', () => {
+  it('should create a new Error based on ErrorWithDetails', () => {
+    const TestError = createErrorClass('TestError')
+    expect(TestError).toBeInstanceOf(Function)
+    expect(inspect(TestError)).toBe('[class TestError extends ErrorWithDetails]')
+    expect(new TestError('message')).toBeInstanceOf(TestError)
+  })
+
+  it('should create a new Error with typed details', () => {
+    const TestError = createErrorClass<{ prop: boolean }>('TestError')
+    expect(TestError).toBeInstanceOf(Function)
+    expect(new TestError('message', { details: { prop: true } })).toBeInstanceOf(TestError)
+  })
+
+  it('should create a new Error with cause', () => {
+    const TestError = createErrorClass('TestError')
+    const err = new TestError('message', { cause: { prop: true } })
+    expect(err).toBeInstanceOf(TestError)
+    expect(err.cause).toStrictEqual({ prop: true })
+  })
+
+  it('should create a new Error with cause and details', () => {
+    const TestError = createErrorClass<{ prop: true }>('TestError')
+    const err = new TestError('message', { details: { prop: true }, cause: new Error('test') })
+    expect(err).toBeInstanceOf(TestError)
+    expect(err.cause).toBeInstanceOf(Error)
+    expect(err.cause.message).toBe('test')
+    expect(err.details.prop).toBe(true)
+  })
+})

--- a/packages/errors/src/createErrorClass.ts
+++ b/packages/errors/src/createErrorClass.ts
@@ -1,0 +1,17 @@
+import ErrorWithDetails from './ErrorWithDetails'
+
+export function createErrorClass<
+  T extends Record<string, unknown>,
+  U extends { cause?: unknown; details?: T } = { cause?: unknown; details?: T }
+>(name: `${string}Error`) {
+  const cls = {
+    [name]: class<V extends U> extends ErrorWithDetails<V> {
+      constructor(message?: string, options?: V) {
+        super(message, options)
+        this.name = name
+      }
+    }
+  }
+
+  return cls[name]
+}

--- a/packages/errors/src/errors.test.ts
+++ b/packages/errors/src/errors.test.ts
@@ -1,0 +1,64 @@
+import { default as ErrorWithDetails } from './ErrorWithDetails'
+import { default as ForbiddenError } from './ForbiddenError'
+import { default as NotFoundError } from './NotFoundError'
+import { default as RateLimitError } from './RateLimitError'
+import { default as UnauthorizedError } from './UnauthorizedError'
+import { default as ValidationError } from './ValidationError'
+
+describe.each`
+  TestError
+  ${ErrorWithDetails}
+  ${ForbiddenError}
+  ${NotFoundError}
+  ${RateLimitError}
+  ${UnauthorizedError}
+  ${ValidationError}
+`('$TestError.name', ({ TestError }) => {
+  it('should create an error with no mesasge', () => {
+    const e = new TestError()
+    expect(e).toBeInstanceOf(TestError)
+    expect(e.message).toBe('')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge', () => {
+    const e = new TestError('test message')
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+  })
+
+  it('should create an error with a mesasge and a cause', () => {
+    const cause = new TypeError('cause')
+    const e = new TestError('test message', { cause })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+  })
+
+  it('should create an error with a mesasge and details', () => {
+    const details = { prop: true }
+    const e = new TestError('test message', { details })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+    expect(e.details).toStrictEqual(details)
+  })
+
+  it('should clone details object', () => {
+    const details = { prop: true, deepProp: { prop2: true } }
+    const e = new TestError('test message', { details })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBeUndefined()
+    expect(e.details).not.toBe(details)
+    // e.details should be a clone of details to avoid mutation of the original object
+    expect(e.details).toStrictEqual(details)
+    details.deepProp.prop2 = false
+    expect(e.details).not.toStrictEqual(details)
+  })
+
+  it('should ignore unknown properties in options object', () => {
+    const cause = new TypeError('cause')
+    const e = new TestError('test message', { cause, stuff: { arg1: 'foo' } })
+    expect(e.message).toBe('test message')
+    expect(e.cause).toBe(cause)
+    expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
+  })
+})

--- a/packages/errors/src/errors.test.ts
+++ b/packages/errors/src/errors.test.ts
@@ -14,27 +14,27 @@ describe.each`
   ${UnauthorizedError}
   ${ValidationError}
 `('$TestError.name', ({ TestError }) => {
-  it('should create an error with no mesasge', () => {
+  it('should create an error with no message', () => {
     const e = new TestError()
     expect(e).toBeInstanceOf(TestError)
     expect(e.message).toBe('')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge', () => {
+  it('should create an error with a message', () => {
     const e = new TestError('test message')
     expect(e.message).toBe('test message')
     expect(e.cause).toBeUndefined()
   })
 
-  it('should create an error with a mesasge and a cause', () => {
+  it('should create an error with a message and a cause', () => {
     const cause = new TypeError('cause')
     const e = new TestError('test message', { cause })
     expect(e.message).toBe('test message')
     expect(e.cause).toBe(cause)
   })
 
-  it('should create an error with a mesasge and details', () => {
+  it('should create an error with a message and details', () => {
     const details = { prop: true }
     const e = new TestError('test message', { details })
     expect(e.message).toBe('test message')

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,0 +1,8 @@
+export { createErrorClass } from './createErrorClass'
+export { default as ErrorWithCause } from './ErrorWithCause'
+export { default as ErrorWithDetails } from './ErrorWithDetails'
+export { default as ForbiddenError } from './ForbiddenError'
+export { default as NotFoundError } from './NotFoundError'
+export { default as UnauthorizedError } from './UnauthorizedError'
+export { default as ValidationError } from './ValidationError'
+export { default as RateLimitError } from './RateLimitError'

--- a/packages/errors/tsconfig.build.json
+++ b/packages/errors/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "outDir": "./dist"
+  },
+  "watchOptions": {
+    // Use native file system events for files and directories
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    // Poll files for updates more frequently
+    // when they're updated a lot. (use as fallback)
+    "fallbackPolling": "dynamicPriority",
+    // Don't coalesce watch notification
+    "synchronousWatchDirectory": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.181"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
+  integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
+
 "@types/lodash@^4.14.172":
   version "4.14.180"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
@@ -8340,6 +8352,11 @@ lodash.capitalize@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
   integrity sha1-+CbJtOKoUR2E46yinbBeGk87cqk=
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
# Description
This PR creates a new package called `errors`.

`errors` is designed to provide common named errors to make error handling more consistent. For example, in a plugin that talks to a backend API we shouldn't pass through the backend error directly. We should provide a named error and embed the backend error in the `cause` property.

For example:

```ts
try {
  await axios.get('...')
} catch (e) {
  if (e.statusCode === 429) {
    throw new new RateLimitError('Rate limited', { cause: e })
}
```

# Discussion
We could change the errors to not accept a `message` but to create a default message. For example, `ValidationError` could take `{ details: { name: 'property', expected: 'a string', actual: 'null' } }` and generate a `message` of `Property ${name} is expected to be ${expected} but received ${actual}`.
