### PR TITLE
test(market-service): spy on console methods to fix log spew in tests

### DIFF
--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -143,6 +143,7 @@ describe('coincap market service', () => {
       await expect(coinMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findByCaip19): error fetching market data')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })
@@ -177,6 +178,7 @@ describe('coincap market service', () => {
       await expect(coinMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })

--- a/packages/market-service/src/coincap/coincap.test.ts
+++ b/packages/market-service/src/coincap/coincap.test.ts
@@ -139,10 +139,11 @@ describe('coincap market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(coinMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findByCaip19): error fetching market data')
       )
+      consoleSpy.mockRestore()
     })
   })
 
@@ -172,10 +173,11 @@ describe('coincap market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(coinMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      consoleSpy.mockRestore()
     })
   })
 })

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -171,6 +171,7 @@ describe('coingecko market service', () => {
       await expect(coinGeckoMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('CoinGeckoMarketService(findByCaip19): error fetching market data')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })
@@ -205,6 +206,7 @@ describe('coingecko market service', () => {
       await expect(coinGeckoMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('CoinGeckoMarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -167,10 +167,11 @@ describe('coingecko market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(coinGeckoMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('CoinGeckoMarketService(findByCaip19): error fetching market data')
       )
+      consoleSpy.mockRestore()
     })
   })
 
@@ -200,10 +201,11 @@ describe('coingecko market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(coinGeckoMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('CoinGeckoMarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      consoleSpy.mockRestore()
     })
   })
 })

--- a/packages/market-service/src/foxy/foxy.test.ts
+++ b/packages/market-service/src/foxy/foxy.test.ts
@@ -20,14 +20,18 @@ describe('foxy market service', () => {
 
     it('can handle api errors', async () => {
       mockedAxios.get.mockRejectedValue({ error: 'foo' })
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       const result = await foxyMarketService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
 
     it('can handle rate limiting', async () => {
       mockedAxios.get.mockResolvedValue({ status: 429 })
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       const result = await foxyMarketService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
   })
 

--- a/packages/market-service/src/foxy/foxy.test.ts
+++ b/packages/market-service/src/foxy/foxy.test.ts
@@ -23,6 +23,7 @@ describe('foxy market service', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       const result = await foxyMarketService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
       consoleSpy.mockRestore()
     })
 
@@ -31,6 +32,7 @@ describe('foxy market service', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       const result = await foxyMarketService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
       consoleSpy.mockRestore()
     })
   })
@@ -51,6 +53,7 @@ describe('foxy market service', () => {
       await expect(foxyMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('FoxyMarketService(findByCaip19): error fetching market data')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })
@@ -85,6 +88,7 @@ describe('foxy market service', () => {
       await expect(foxyMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('FoxyMarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })

--- a/packages/market-service/src/foxy/foxy.test.ts
+++ b/packages/market-service/src/foxy/foxy.test.ts
@@ -43,10 +43,11 @@ describe('foxy market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(foxyMarketService.findByCaip19(args)).rejects.toEqual(
         new Error('FoxyMarketService(findByCaip19): error fetching market data')
       )
+      consoleSpy.mockRestore()
     })
   })
 
@@ -76,10 +77,11 @@ describe('foxy market service', () => {
 
     it('should return null on network error', async () => {
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(foxyMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('FoxyMarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      consoleSpy.mockRestore()
     })
   })
 })

--- a/packages/market-service/src/market-service.test.ts
+++ b/packages/market-service/src/market-service.test.ts
@@ -92,8 +92,10 @@ describe('market service', () => {
     it('can call the next market service if the first fails', async () => {
       // @ts-ignore
       MarketProviders[0].findAll.mockRejectedValueOnce({ error: 'error' })
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       await findAll()
       expect(MarketProviders[1].findAll).toHaveBeenCalledTimes(1)
+      consoleSpy.mockRestore()
     })
     it('errors if no data found', async () => {
       // @ts-ignore
@@ -108,9 +110,11 @@ describe('market service', () => {
       MarketProviders[4].findAll.mockRejectedValueOnce({ error: 'error' })
       // @ts-ignore
       MarketProviders[5].findAll.mockRejectedValueOnce({ error: 'error' })
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       await expect(findAll()).rejects.toEqual(
         new Error('Cannot find market service provider for market data.')
       )
+      consoleSpy.mockRestore()
     })
     it('returns market service data if exists', async () => {
       const result = await findAll()
@@ -119,8 +123,10 @@ describe('market service', () => {
     it('returns next market service data if previous data does not exist', async () => {
       // @ts-ignore
       MarketProviders[0].findAll.mockRejectedValueOnce({ error: 'error' })
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await findAll()
       expect(result).toEqual(mockYearnServiceFindAllData)
+      consoleSpy.mockRestore()
     })
   })
 

--- a/packages/market-service/src/market-service.test.ts
+++ b/packages/market-service/src/market-service.test.ts
@@ -95,6 +95,7 @@ describe('market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       await findAll()
       expect(MarketProviders[1].findAll).toHaveBeenCalledTimes(1)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
     it('errors if no data found', async () => {
@@ -114,6 +115,7 @@ describe('market service', () => {
       await expect(findAll()).rejects.toEqual(
         new Error('Cannot find market service provider for market data.')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(6)
       consoleSpy.mockRestore()
     })
     it('returns market service data if exists', async () => {
@@ -126,6 +128,7 @@ describe('market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await findAll()
       expect(result).toEqual(mockYearnServiceFindAllData)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })

--- a/packages/market-service/src/osmosis/osmosis.test.ts
+++ b/packages/market-service/src/osmosis/osmosis.test.ts
@@ -118,10 +118,11 @@ describe('osmosis market service', () => {
         timeframe: HistoryTimeframe.YEAR
       }
       mockedAxios.get.mockRejectedValue(Error)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(osmosisMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      consoleSpy.mockRestore()
     })
   })
 })

--- a/packages/market-service/src/osmosis/osmosis.test.ts
+++ b/packages/market-service/src/osmosis/osmosis.test.ts
@@ -122,6 +122,7 @@ describe('osmosis market service', () => {
       await expect(osmosisMarketService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('MarketService(findPriceHistoryByCaip19): error fetching price history')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -81,7 +81,6 @@ describe('yearn token market service', () => {
         assetReference: mockYearnTokenRestData[1].address.toLowerCase()
       })
       const [yvBtcKey, yvDaiKey] = Object.keys(result)
-      console.log({ result })
       expect(yvDaiKey).toEqual(yvDaiCaip19)
       expect(yvBtcKey).toEqual(yvBtcCaip19)
     })

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -38,16 +38,20 @@ describe('yearn token market service', () => {
       mockedYearnSdk.vaults.tokens.mockResolvedValueOnce({ error: 'foo' } as never)
       mockedYearnSdk.tokens.supported.mockResolvedValueOnce({ error: 'foo' } as never)
       mockedYearnSdk.ironBank.tokens.mockResolvedValueOnce({ error: 'foo' } as never)
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnTokenMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
 
     it('can handle rate limiting', async () => {
       mockedYearnSdk.vaults.tokens.mockResolvedValueOnce({ status: 429 } as never)
       mockedYearnSdk.tokens.supported.mockResolvedValueOnce({ status: 429 } as never)
       mockedYearnSdk.ironBank.tokens.mockResolvedValueOnce({ status: 429 } as never)
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnTokenMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
 
     it('can use default args', async () => {

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -41,6 +41,7 @@ describe('yearn token market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnTokenMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
 
@@ -51,6 +52,7 @@ describe('yearn token market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnTokenMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
 

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -104,7 +104,6 @@ describe('yearn token market service', () => {
       mockedYearnSdk.vaults.tokens.mockRejectedValueOnce(Error as never)
       mockedYearnSdk.ironBank.tokens.mockRejectedValueOnce(Error as never)
       mockedYearnSdk.tokens.supported.mockRejectedValueOnce(Error as never)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       expect(await yearnTokenMarketCapService.findByCaip19(args)).toEqual(null)
     })
   })

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -48,14 +48,18 @@ describe('yearn market service', () => {
 
     it('can handle api errors', async () => {
       mockedYearnSdk.vaults.get.mockRejectedValueOnce({ error: 'foo' } as never)
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
 
     it('can handle rate limiting', async () => {
       mockedYearnSdk.vaults.get.mockResolvedValueOnce({ status: 429 } as never)
+      const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      consoleSpy.mockRestore()
     })
 
     it('can use default args', async () => {

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -106,10 +106,11 @@ describe('yearn market service', () => {
 
     it('should return null on network error', async () => {
       mockedYearnSdk.vaults.get.mockRejectedValueOnce(Error as never)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(yearnVaultMarketCapService.findByCaip19(args)).rejects.toEqual(
         new Error('YearnMarketService(findByCaip19): error fetching market data')
       )
+      consoleSpy.mockRestore()
     })
   })
 
@@ -132,10 +133,11 @@ describe('yearn market service', () => {
 
     it('should return null on network error', async () => {
       mockedYearnSdk.services.subgraph.fetchQuery.mockRejectedValueOnce(Error as never)
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0)
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0)
       await expect(yearnVaultMarketCapService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('YearnMarketService(getPriceHistory): error fetching price history')
       )
+      consoleSpy.mockRestore()
     })
   })
 })

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -51,6 +51,7 @@ describe('yearn market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
 
@@ -59,6 +60,7 @@ describe('yearn market service', () => {
       const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result).length).toEqual(0)
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
 
@@ -114,6 +116,7 @@ describe('yearn market service', () => {
       await expect(yearnVaultMarketCapService.findByCaip19(args)).rejects.toEqual(
         new Error('YearnMarketService(findByCaip19): error fetching market data')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })
@@ -141,6 +144,7 @@ describe('yearn market service', () => {
       await expect(yearnVaultMarketCapService.findPriceHistoryByCaip19(args)).rejects.toEqual(
         new Error('YearnMarketService(getPriceHistory): error fetching price history')
       )
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       consoleSpy.mockRestore()
     })
   })


### PR DESCRIPTION
Closes #530 

`yarn test` output (with `--coverage=false` to squeeze relevant data into a readable screenshot)

<img width="650" alt="Screen Shot 2022-04-18 at 10 50 25 pm" src="https://user-images.githubusercontent.com/101975263/163813553-df915726-0332-4dcf-9ecd-5c6c7da14940.png">

