### PR TITLE
feat: swapper by buyasset

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "bignumber.js": "^9.0.1",
+    "lodash": "^4.17.21",
     "retry-axios": "^2.6.0",
     "web3": "^1.6.1"
   },

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -21,6 +21,10 @@ export type BuyAssetBySellIdInput = {
   buyAssetIds: CAIP19[]
 }
 
+export type SupportedSellAssetsInput = {
+  sellAssetIds: CAIP19[]
+}
+
 export class SwapError extends Error {}
 
 export interface Swapper {

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -85,5 +85,10 @@ export interface Swapper {
   /**
    * Get supported buyAssetId's by sellAssetId
    */
-  buyAssetsBySellId(args: BuyAssetBySellIdInput): CAIP19[]
+  filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): CAIP19[]
+
+  /**
+   * Get supported sell assetIds
+   */
+  filterAssetIdsBySellable(assetIds: CAIP19[]): CAIP19[]
 }

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -16,6 +16,11 @@ import {
   SwapperType
 } from '@shapeshiftoss/types'
 
+export type BuyAssetBySellIdInput = {
+  sellAssetId: CAIP19
+  buyAssetIds: CAIP19[]
+}
+
 export class SwapError extends Error {}
 
 export interface Swapper {
@@ -76,4 +81,9 @@ export interface Swapper {
    * Get max swap balance (minus fees) for sell asset
    */
   getSendMaxAmount(args: SendMaxAmountInput): Promise<string>
+
+  /**
+   * Get supported buyAssetId's by sellAssetId
+   */
+  buyAssetsBySellId(args: BuyAssetBySellIdInput): CAIP19[]
 }

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -142,9 +142,7 @@ describe('SwapperManager', () => {
       const swapper = new SwapperManager()
       swapper.addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
 
-      expect(swapper.getSupportedSellAssets({ sellAssetIds })).toStrictEqual(
-        sellAssetIds.slice(-2)
-      )
+      expect(swapper.getSupportedSellAssets({ sellAssetIds })).toStrictEqual(sellAssetIds.slice(-2))
     })
 
     it('should return unique assetIds', () => {

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -95,4 +95,39 @@ describe('SwapperManager', () => {
       )
     })
   })
+
+  describe('getSupportedBuyAssetsFromSellId', () => {
+    it('should return an array of supported buy assetIds given a sell asset Id', () => {
+      const buyAssetIds = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9', // Aave
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d' // Fox
+      ]
+
+      const sellAssetId = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
+      const swapper = new SwapperManager()
+      swapper.addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
+
+      expect(swapper.getSupportedBuyAssetsFromSellId({ sellAssetId, buyAssetIds })).toStrictEqual(
+        buyAssetIds.slice(-2)
+      )
+    })
+
+    it('should return unique assetIds', () => {
+      const buyAssetIds = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9', // Aave
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d', // Fox
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d' // Fox (duplicate)
+      ]
+
+      const sellAssetId = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
+      const swapper = new SwapperManager()
+      swapper.addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
+
+      expect(swapper.getSupportedBuyAssetsFromSellId({ sellAssetId, buyAssetIds })).toStrictEqual(
+        buyAssetIds.slice(1, 3)
+      )
+    })
+  })
 })

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -130,4 +130,37 @@ describe('SwapperManager', () => {
       )
     })
   })
+
+  describe('getSupportedSellAssets', () => {
+    it('should return an array of supported sell assetIds', () => {
+      const sellAssetIds = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9', // Aave
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d' // Fox
+      ]
+
+      const swapper = new SwapperManager()
+      swapper.addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
+
+      expect(swapper.getSupportedSellAssets({ sellAssetIds })).toStrictEqual(
+        sellAssetIds.slice(-2)
+      )
+    })
+
+    it('should return unique assetIds', () => {
+      const sellAssetIds = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9', // Aave
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d', // Fox
+        'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d' // Fox (duplicate)
+      ]
+
+      const swapper = new SwapperManager()
+      swapper.addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
+
+      expect(swapper.getSupportedSellAssets({ sellAssetIds })).toStrictEqual(
+        sellAssetIds.slice(1, 3)
+      )
+    })
+  })
 })

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -1,6 +1,7 @@
 import { GetQuoteInput, SwapperType } from '@shapeshiftoss/types'
 
 import { Swapper } from '..'
+import { BuyAssetBySellIdInput } from '../api'
 
 export class SwapperError extends Error {
   constructor(message: string) {
@@ -62,5 +63,11 @@ export class SwapperManager {
   async getBestSwapper(quoteParams: GetQuoteInput): Promise<SwapperType> {
     quoteParams // noop to shut up linter
     return SwapperType.Zrx // TODO: implement getBestSwapper
+  }
+
+  getSupportedBuyAssetsFromSellId(args: BuyAssetBySellIdInput) {
+    return Array.from(this.swappers.values()).map((swapper: Swapper) =>
+      swapper.buyAssetsBySellId(args)
+    )
   }
 }

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -1,5 +1,5 @@
-import uniq from 'lodash/uniq'
 import { GetQuoteInput, SwapperType } from '@shapeshiftoss/types'
+import uniq from 'lodash/uniq'
 
 import { Swapper } from '..'
 import { BuyAssetBySellIdInput, SupportedSellAssetsInput } from '../api'

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -2,7 +2,7 @@ import uniq from 'lodash/uniq'
 import { GetQuoteInput, SwapperType } from '@shapeshiftoss/types'
 
 import { Swapper } from '..'
-import { BuyAssetBySellIdInput } from '../api'
+import { BuyAssetBySellIdInput, SupportedSellAssetsInput } from '../api'
 
 export class SwapperError extends Error {
   constructor(message: string) {
@@ -70,6 +70,16 @@ export class SwapperManager {
     return uniq(
       Array.from(this.swappers.values()).flatMap((swapper: Swapper) =>
         swapper.filterBuyAssetsBySellAssetId(args)
+      )
+    )
+  }
+
+  getSupportedSellAssets(args: SupportedSellAssetsInput) {
+    const { sellAssetIds } = args
+
+    return uniq(
+      Array.from(this.swappers.values()).flatMap((swapper: Swapper) =>
+        swapper.filterAssetIdsBySellable(sellAssetIds)
       )
     )
   }

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -1,3 +1,4 @@
+import uniq from 'lodash/uniq'
 import { GetQuoteInput, SwapperType } from '@shapeshiftoss/types'
 
 import { Swapper } from '..'
@@ -66,8 +67,10 @@ export class SwapperManager {
   }
 
   getSupportedBuyAssetsFromSellId(args: BuyAssetBySellIdInput) {
-    return Array.from(this.swappers.values()).map((swapper: Swapper) =>
-      swapper.buyAssetsBySellId(args)
+    return uniq(
+      Array.from(this.swappers.values()).flatMap((swapper: Swapper) =>
+        swapper.filterBuyAssetsBySellAssetId(args)
+      )
     )
   }
 }

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -64,4 +64,12 @@ export class ThorchainSwapper implements Swapper {
   async getSendMaxAmount(): Promise<string> {
     throw new Error('ThorchainSwapper: getSendMaxAmount unimplemented')
   }
+
+  filterBuyAssetsBySellAssetId(): CAIP19[] {
+    throw new Error('ThorchainSwapper: filterBuyAssetsBySellAssetId unimplemented')
+  }
+
+  filterAssetIdsBySellable(): CAIP19[] {
+    throw new Error('ThorchainSwapper: filterAssetIdsBySellable unimplemented')
+  }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -17,7 +17,7 @@ import {
 } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
-import { Swapper, BuyAssetBySellIdInput } from '../../api'
+import { BuyAssetBySellIdInput, Swapper } from '../../api'
 import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
 import { getZrxQuote } from './getZrxQuote/getZrxQuote'
 import { getZrxSendMaxAmount } from './getZrxSendMaxAmount/getZrxSendMaxAmount'

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -99,8 +99,14 @@ export class ZrxSwapper implements Swapper {
     return getZrxSendMaxAmount(this.deps, args)
   }
 
-  byAssetsBySellId(args: BuyAssetBySellIdInput): CAIP19[] {
+  filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): CAIP19[] {
     const { buyAssetIds } = args
+    // TODO: pending changes to caip lib, we may want to import caip2 value instead.
     return buyAssetIds.filter((id) => id.startsWith('eip155:1'))
+  }
+
+  filterAssetIdsBySellable(assetIds: CAIP19[]): CAIP19[] {
+    // reusing logic to avoid potential bugs from changing one and not the other
+    return this.filterBuyAssetsBySellAssetId({ buyAssetIds: assetIds, sellAssetId: '' })
   }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -17,7 +17,7 @@ import {
 } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
-import { Swapper } from '../../api'
+import { Swapper, BuyAssetBySellIdInput } from '../../api'
 import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
 import { getZrxQuote } from './getZrxQuote/getZrxQuote'
 import { getZrxSendMaxAmount } from './getZrxSendMaxAmount/getZrxSendMaxAmount'
@@ -97,5 +97,10 @@ export class ZrxSwapper implements Swapper {
 
   async getSendMaxAmount(args: SendMaxAmountInput): Promise<string> {
     return getZrxSendMaxAmount(this.deps, args)
+  }
+
+  byAssetsBySellId(args: BuyAssetBySellIdInput): CAIP19[] {
+    const { buyAssetIds } = args
+    return buyAssetIds.filter((id) => id.startsWith('eip155:1'))
   }
 }


### PR DESCRIPTION
- Add filtering swapper buy/sell assets by assetId. This functionality is needed to filter trade-able assets when selecting assets to swap.

closes #538 