### PR TITLE
feat: add `code` to errors

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -29,6 +29,17 @@ try {
 
 ```
 
+### Error.code
+
+All errors support a `code` property. This property is designed to be used for internationalization
+so that translated text can be displayed based on the `code` rather than on the `message`.
+
+```ts
+import { RateLimitError } from '@shapeshiftoss/errors'
+
+const e = new RateLimitError('Something bad happened', { code: 'ERR_RATE_LIMIT_INFURA' })
+```
+
 ## Types
 
 ```

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -22,9 +22,11 @@
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.snakecase": "^4.1.1"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.6"
+    "@types/lodash.clonedeep": "^4.5.6",
+    "@types/lodash.snakecase": "^4.1.7"
   }
 }

--- a/packages/errors/src/ErrorWithDetails.test.ts
+++ b/packages/errors/src/ErrorWithDetails.test.ts
@@ -68,4 +68,15 @@ describe('ErrorWithDetails', () => {
     expect(e.cause).toBe(cause)
     expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
   })
+
+  it('should support an error code', () => {
+    const e = new ErrorWithDetails('test message')
+    // Default code
+    expect(e.code).toBe('ERR_UNKNOWN')
+    e.code = 'another_error'
+    expect(e.code).toBe('ANOTHER_ERROR')
+
+    const e2 = new ErrorWithDetails('test message', { code: 'ERR_test' })
+    expect(e2.code).toBe('ERR_TEST')
+  })
 })

--- a/packages/errors/src/ErrorWithDetails.ts
+++ b/packages/errors/src/ErrorWithDetails.ts
@@ -1,15 +1,37 @@
 import cloneDeep from 'lodash.clonedeep'
+import snakeCase from 'lodash.snakecase'
 
 import ErrorWithCause from './ErrorWithCause'
 
 export default class ErrorWithDetails<
-  T extends { cause?: unknown; details?: Record<string, unknown> } | undefined = undefined
+  T extends
+    | { cause?: unknown; details?: Record<string, unknown>; code?: string }
+    | undefined = undefined
 > extends ErrorWithCause<T> {
   public details: T extends { details: infer R } ? R : undefined
+  /**
+   * A string representing the error state
+   *
+   * This allows different language translations to be used for a given error
+   * rather than relying on the text the programmer put in the error message
+   */
+  #code?: string
 
   constructor(message?: string, options?: T) {
     super(message, options)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (options?.details) this.details = cloneDeep<any>(options.details)
+    this.code = options?.code
+  }
+
+  get code(): string | undefined {
+    return this.#code
+  }
+
+  /**
+   * Normalize error codes to uppercase + snake_case for consistency
+   */
+  set code(value: string | undefined) {
+    this.#code = snakeCase(value || 'ERR_UNKNOWN').toUpperCase()
   }
 }

--- a/packages/errors/src/createErrorClass.test.ts
+++ b/packages/errors/src/createErrorClass.test.ts
@@ -31,4 +31,10 @@ describe('createErrorClass', () => {
     expect(err.cause.message).toBe('test')
     expect(err.details.prop).toBe(true)
   })
+
+  it('should create a new Error with a default error code based on the error name', () => {
+    const E = createErrorClass('TestError')
+    const err = new E('test')
+    expect(err.code).toBe('ERR_TEST')
+  })
 })

--- a/packages/errors/src/createErrorClass.ts
+++ b/packages/errors/src/createErrorClass.ts
@@ -2,13 +2,18 @@ import ErrorWithDetails from './ErrorWithDetails'
 
 export function createErrorClass<
   T extends Record<string, unknown>,
-  U extends { cause?: unknown; details?: T } = { cause?: unknown; details?: T }
+  U extends { cause?: unknown; details?: T; code?: string } = {
+    cause?: unknown
+    details?: T
+    code?: string
+  }
 >(name: `${string}Error`) {
   const cls = {
     [name]: class<V extends U> extends ErrorWithDetails<V> {
       constructor(message?: string, options?: V) {
         super(message, options)
         this.name = name
+        this.code = options?.code || `ERR_${name.substring(0, name.indexOf('Error'))}`
       }
     }
   }

--- a/packages/errors/src/errors.test.ts
+++ b/packages/errors/src/errors.test.ts
@@ -6,14 +6,14 @@ import { default as UnauthorizedError } from './UnauthorizedError'
 import { default as ValidationError } from './ValidationError'
 
 describe.each`
-  TestError
-  ${ErrorWithDetails}
-  ${ForbiddenError}
-  ${NotFoundError}
-  ${RateLimitError}
-  ${UnauthorizedError}
-  ${ValidationError}
-`('$TestError.name', ({ TestError }) => {
+  TestError            | code
+  ${ErrorWithDetails}  | ${'ERR_UNKNOWN'}
+  ${ForbiddenError}    | ${'ERR_FORBIDDEN'}
+  ${NotFoundError}     | ${'ERR_NOT_FOUND'}
+  ${RateLimitError}    | ${'ERR_RATE_LIMIT'}
+  ${UnauthorizedError} | ${'ERR_UNAUTHORIZED'}
+  ${ValidationError}   | ${'ERR_VALIDATION'}
+`('$TestError.name', ({ TestError, code }) => {
   it('should create an error with no message', () => {
     const e = new TestError()
     expect(e).toBeInstanceOf(TestError)
@@ -60,5 +60,18 @@ describe.each`
     expect(e.message).toBe('test message')
     expect(e.cause).toBe(cause)
     expect(Object.getOwnPropertyNames(e)).toStrictEqual(['stack', 'message', 'name', 'cause'])
+  })
+
+  it(`should have a default error code of ${code}`, () => {
+    const e = new TestError('test message', { code })
+    expect(e.code).toBe(code)
+  })
+
+  it(`should support a custom error code`, () => {
+    const e = new TestError('test message', { code: 'my error' })
+    expect(e.code).toBe('MY_ERROR')
+
+    e.code = 'second-Error'
+    expect(e.code).toBe('SECOND_ERROR')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,15 +3034,17 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash.snakecase@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.snakecase/-/lodash.snakecase-4.1.7.tgz#2a1ca7cbc08b63e7c3708f6291222e69b0d3216d"
+  integrity sha512-nv9M+JJokFyfZ9QmaWVXZu2DfT40K0GictZaA8SwXczp3oCzMkjp7PtvUBQyvdoG9SnlCpoRXZDIVwQRzJbd9A==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.172":
   version "4.14.181"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
   integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
-
-"@types/lodash@^4.14.172":
-  version "4.14.180"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
-  integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
 
 "@types/long@^4.0.1":
   version "4.0.1"
@@ -3064,10 +3066,10 @@
   resolved "https://registry.yarnpkg.com/@types/multicoin-address-validator/-/multicoin-address-validator-0.5.0.tgz#3888ec229c799652972849ae3456de7958f1424f"
   integrity sha512-I0D2PiV0r5u9pmnFqx5F5tbI4v1Xek+KDMCiTIZMyXO3UM6VoFYt9Tpqk7jfOEXBMVjmkX7anYy6E6KZfnAihg==
 
-"@types/node@*":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
-  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+"@types/node@*", "@types/node@>=13.7.0":
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -3078,11 +3080,6 @@
   version "11.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
-
-"@types/node@>=13.7.0":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@types/node@^12.12.6":
   version "12.20.47"
@@ -8408,6 +8405,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
+
 lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
@@ -8670,24 +8672,12 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
-
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.34"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
-  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
-  dependencies:
-    mime-db "1.51.0"
-
-mime-types@^2.1.16, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9000,15 +8990,10 @@ ndjson@^1.5.0:
     split2 "^2.1.0"
     through2 "^2.0.3"
 
-negotiator@0.6.3:
+negotiator@0.6.3, negotiator@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-negotiator@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 neo-async@^2.6.0:
   version "2.6.2"


### PR DESCRIPTION
This feature will allow us to support translations for error messages.

* The `code` property of an error should be a short string that could be used to lookup a translation for what error message should be shown to a user.
* Error codes are normalized to be UPPER_CASE+SNAKE_CASE so we can have some consistency. For example, `ERR_RATE_LIMIT`.
* All errors have a default code that matches the error's name.
