### PR TITLE
chore: remove unused swapper methods

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -33,16 +33,6 @@ export interface Swapper {
   getQuote(input: GetQuoteInput, wallet?: HDWallet): Promise<Quote<ChainTypes, SwapperType>>
 
   /**
-   * Get a list of available assets based on the array of assets you send it
-   */
-  getAvailableAssets(assets: Asset[]): Asset[]
-
-  /**
-   * Get a boolean if the trade pair will work
-   */
-  canTradePair(sellAsset: Asset, buyAsset: Asset): boolean
-
-  /**
    * Get the usd rate from either the assets symbol or tokenId
    */
   getUsdRate(input: Pick<Asset, 'symbol' | 'tokenId'>): Promise<string>

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -35,16 +35,6 @@ export class ThorchainSwapper implements Swapper {
     throw new Error('ThorchainSwapper: getMinMax unimplemented')
   }
 
-  getAvailableAssets(assets: Asset[]): Asset[] {
-    console.info(assets)
-    throw new Error('ThorchainSwapper: getAvailableAssets unimplemented')
-  }
-
-  canTradePair(sellAsset: Asset, buyAsset: Asset): boolean {
-    console.info(sellAsset, buyAsset)
-    throw new Error('ThorchainSwapper: canTradePair unimplemented')
-  }
-
   async executeQuote(): Promise<ExecQuoteOutput> {
     throw new Error('ThorchainSwapper: executeQuote unimplemented')
   }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -10,7 +10,7 @@ import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
 import { getZrxQuote } from './getZrxQuote/getZrxQuote'
 import { getZrxSendMaxAmount } from './getZrxSendMaxAmount/getZrxSendMaxAmount'
 import { getUsdRate } from './utils/helpers/helpers'
-import { BTC, FOX, WETH } from './utils/test-data/assets'
+import { FOX } from './utils/test-data/assets'
 import { setupQuote } from './utils/test-data/setupSwapQuote'
 import { ZrxApprovalNeeded } from './ZrxApprovalNeeded/ZrxApprovalNeeded'
 import { ZrxApproveInfinite } from './ZrxApproveInfinite/ZrxApproveInfinite'
@@ -68,21 +68,6 @@ describe('ZrxSwapper', () => {
     const message = 'test error'
     const error = new ZrxError(message)
     expect(error.message).toBe(`ZrxError:${message}`)
-  })
-  it('getAvailableAssets filters out all non-ethereum assets', () => {
-    const swapper = new ZrxSwapper(zrxSwapperDeps)
-    const availableAssets = swapper.getAvailableAssets([BTC, FOX, WETH])
-    expect(availableAssets).toStrictEqual([FOX, WETH])
-  })
-  it('canTradePair fails on non-eth chains', () => {
-    const swapper = new ZrxSwapper(zrxSwapperDeps)
-    const canTradePair = swapper.canTradePair(BTC, WETH)
-    expect(canTradePair).toBeFalsy()
-  })
-  it('canTradePair succeeds on eth chains', () => {
-    const swapper = new ZrxSwapper(zrxSwapperDeps)
-    const canTradePair = swapper.canTradePair(FOX, WETH)
-    expect(canTradePair).toBeTruthy()
   })
   it('calls ZrxBuildQuoteTx on swapper.buildQuoteTx', async () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -66,15 +66,6 @@ export class ZrxSwapper implements Swapper {
     return getZrxMinMax(input)
   }
 
-  getAvailableAssets(assets: Asset[]): Asset[] {
-    return assets.filter((asset) => asset.chain === ChainTypes.Ethereum)
-  }
-
-  canTradePair(sellAsset: Asset, buyAsset: Asset): boolean {
-    const availableAssets = this.getAvailableAssets([sellAsset, buyAsset])
-    return availableAssets.length === 2
-  }
-
   getDefaultPair(): [CAIP19, CAIP19] {
     const ETH = 'eip155:1/slip44:60'
     const FOX = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'


### PR DESCRIPTION
**NOTE: This is technically a breaking change, however, the methods being removed are not used anywhere in our codebase, so it is a "safer" breaking change.** 

- Remove `canTradePair` and `getAvailableAssets` from Swapper. 
- As a part of the Swapper refactor work, we have created methods that will replace these methods ([PR](https://github.com/shapeshift/lib/pull/526)) that improve on the naming and implementation. As we move away from using `ChainTypes` and move more to strictly using CAIP19s, removing these methods will bring us closer to that goal.