### PR TITLE
feat(logger): support custom logging output function

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,11 +1,13 @@
 # @shapeshiftoss/logger
 
-Shapeshift's JSON logging library.
+ShapeShift DAO's simple logging library.
 
 ## Installation
 
 ```bash
 yarn add @shapeshiftoss/logger
+# or
+npm i @shapeshiftoss/logger
 ```
 
 ## Initialization
@@ -22,6 +24,23 @@ const logger = new Logger({
   // extra fields to include on each message
   defaultFields: {
       fn: 'defaultFn'
+  }
+})
+```
+
+### Custom logging output function
+By default, the Logger will log a `JSON` string to the `console`.
+
+You can customize this by providing a `logFn` option to the Logger constructor.
+
+```ts
+import { Logger } from '@shapeshiftoss/logger'
+import type { LogLevel, LogData } from '@shapeshiftoss/logger'
+
+const logger = new Logger({
+  name: 'MyAppLogger',
+  logFn: (level: LogLevel, data: LogData) => {
+    myCentralLogger.send(JSON.stringify(data))
   }
 })
 ```
@@ -92,4 +111,13 @@ const child2 = child.child({ namespace: ['MyModule', 'myFunction']})
 child.info({ biz: 'baz' }, 'hello!') 
 // {"fn":"defaultFn","biz":"baz","message":"hello!",
 //   "timestamp":"2021-10-25T17:53:55.909Z","namespace":"Parent:MyModule:myFunction","status":"info"}
+```
+
+## Reserved Properties
+The following property names are reserved. If you want to log out an object that contains these property names, you'll need to nest it inside another object. 
+
+```ts
+  'namespace'
+  'timestamp'
+  'status'
 ```

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -1,4 +1,4 @@
-import { FormattedObject } from './logger.type'
+import { FormattedError, FormattedObject } from './logger.type'
 
 const objectProto = Object.getPrototypeOf(Object())
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -20,19 +20,41 @@ function isError(value: unknown): value is Error {
   )
 }
 
+/**
+ * Support errors with additional properties
+ * @shapeshiftoss/errors implement these additional properties
+ */
+function isErrorWithDetails(value: unknown): value is Error & {
+  code?: string
+  details?: Record<string, unknown>
+  cause: unknown
+} {
+  return isError(value) && 'cause' in value
+}
+
 // this function accepts anything (string, object, array, or error) and
 // returns an object that datadog knows how to ingest
 export default function format(x: unknown): FormattedObject | undefined {
+  // plain strings can only be included if they have a key in the result object
   if (typeof x === 'string') return { message: x }
-  if (isObject(x)) return x
-  if (isError(x))
-    return {
-      error: {
-        message: x.message,
-        stack: x.stack,
-        kind: x.constructor.name
-      }
+  // Create a shallow copy of objects
+  if (isObject(x)) return { ...x }
+  // Specific formatting for errors
+  if (isError(x)) {
+    const error: FormattedError = {
+      message: x.message,
+      // Only keep the first 6 lines of the stack trace
+      stack: x.stack?.split('\n').slice(0, 6).join('\n'),
+      kind: x.constructor.name
     }
+    if (isErrorWithDetails(x)) {
+      error.code = x.code
+      error.details = format(x.details)
+      error.cause = format(x.cause)
+    }
+
+    return { error }
+  }
   if (Array.isArray(x)) {
     throw new Error('Arrays cannot be formatted for logging')
   }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 import Logger from './logger'
 import { LoggerOptions } from './logger.type'
 
-export { LogLevel } from './logger.type'
+export { LogData, LogLevel, LoggerFunction, LoggerOptions, FormattedError } from './logger.type'
 
 export const loggerFactory = (options?: LoggerOptions) => new Logger(options)
 export { default as Logger } from './logger'

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import Logger from './logger'
-import { LogLevel } from './logger.type'
+import { LoggerFunction, LogLevel } from './logger.type'
 
 describe('Logger', () => {
   let dateSpy: jest.SpyInstance
@@ -96,6 +96,13 @@ describe('Logger', () => {
       )
       spy.mockRestore()
     })
+
+    it('should support a custom logger function', () => {
+      const logFn: LoggerFunction = jest.fn()
+      const logger = new Logger({ name: 'test', logFn })
+      logger.info('test')
+      expect(logFn).toHaveBeenCalledWith('info', expect.objectContaining({ status: 'info' }))
+    })
   })
 
   describe('Logger functions', () => {
@@ -159,6 +166,13 @@ describe('Logger', () => {
         logger.trace('parent')
         expect(traceSpy).toHaveBeenCalledWith(expect.stringMatching(/parent/))
         traceSpy.mockRestore()
+      })
+
+      it('should pass through the logFn of the parent', () => {
+        const logFn: LoggerFunction = jest.fn()
+        const parent = new Logger({ name: 'test', logFn })
+        parent.child({ name: 'info' }).info('child')
+        expect(logFn).toHaveBeenCalledWith('info', expect.objectContaining({ status: 'info' }))
       })
 
       it('should include child keys', () => {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,14 @@
 import format from './format'
-import { Arg1, Arg2, Arg3, LoggerOptions, LoggerT, LogLevel } from './logger.type'
+import {
+  Arg1,
+  Arg2,
+  Arg3,
+  LogData,
+  LoggerFunction,
+  LoggerOptions,
+  LoggerT,
+  LogLevel
+} from './logger.type'
 
 const childIgnoredFields = Object.freeze([
   'name',
@@ -21,18 +30,32 @@ const rankedLogLevels = Object.freeze([
 
 const rankedLogLevelStrings = Object.freeze(rankedLogLevels.map(String))
 
+/**
+ * The default logging function to use when none is provided
+ *
+ * This uses `console` to log out a JSON string of the data.
+ */
+const defaultLogFn: LoggerFunction = (level, data) => {
+  // console.trace outputs stack traces so we use debug instead
+  const consoleFn = level === LogLevel.TRACE ? LogLevel.DEBUG : level
+  // eslint-disable-next-line no-console
+  console[consoleFn](JSON.stringify(data))
+}
+
 export default class Logger implements LoggerT {
   private readonly level: number
   private readonly defaultFields?: Record<string, unknown>
   private namespace: string[] = []
+  private readonly logFn: LoggerFunction
 
   constructor(options?: LoggerOptions) {
-    const { level, defaultFields, namespace, name } = options || {}
+    const { level, defaultFields, namespace, name, logFn } = options || {}
     this.level = typeof level === 'string' ? rankedLogLevelStrings.indexOf(level) : 2
     if (this.level < 0 || this.level >= rankedLogLevels.length) {
       throw new Error('Invalid debug logging level')
     }
 
+    this.logFn = logFn || defaultLogFn
     // Add key/values to be included in every log entry
     this.defaultFields = format(defaultFields) ?? {}
     // A child logger will provide the parent's namespace
@@ -50,7 +73,7 @@ export default class Logger implements LoggerT {
   }
 
   child(options?: LoggerOptions & Record<string, unknown>) {
-    const newOptions = { level: rankedLogLevels[this.level], ...options }
+    const newOptions = { level: rankedLogLevels[this.level], logFn: this.logFn, ...options }
     // Keep the parent namespace
     newOptions.namespace = this.namespace.concat(newOptions.namespace || [])
     // Merge the default fields. For conflicts, keep the child logger's value
@@ -78,28 +101,24 @@ export default class Logger implements LoggerT {
     // No-op if logging is disabled
     if (rankedLogLevels.indexOf(level) < this.level || level === LogLevel.NONE) return
 
-    // console.trace outputs stack traces so we use debug instead
-    const consoleFn = level === LogLevel.TRACE ? LogLevel.DEBUG : level
-
     const args = [arg1, arg2, arg3]
     const argsFormatted = args.map(format)
-    const result: Record<string, unknown> = {
+    const result: LogData = {
       ...this.defaultFields,
       ...argsFormatted[0],
       ...argsFormatted[1],
       ...argsFormatted[2],
       timestamp: new Date().toISOString(),
-      namespace: this.namespace.join(':') || undefined,
+      namespace: this.namespace.join(':'),
       status: level
     }
 
     // I'm concerned that this will add unnecessary overhead to all logging calls
     // just to support a small use case. How can we optimize this?
-    const stringArgs = args.filter((a) => typeof a === 'string')
+    const stringArgs = args.filter((a): a is string => typeof a === 'string')
     if (stringArgs.length > 1) result._messages = stringArgs
 
-    // eslint-disable-next-line no-console
-    console[consoleFn](JSON.stringify(result))
+    this.logFn(level, result)
   }
 
   trace(error: Error, metadata: Record<string, unknown>, message: string): void

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -109,7 +109,7 @@ export default class Logger implements LoggerT {
       ...argsFormatted[1],
       ...argsFormatted[2],
       timestamp: new Date().toISOString(),
-      namespace: this.namespace.join(':'),
+      namespace: this.namespace.join(':') || undefined,
       status: level
     }
 

--- a/packages/logger/src/logger.type.ts
+++ b/packages/logger/src/logger.type.ts
@@ -8,16 +8,42 @@ export enum LogLevel {
 }
 
 export interface LoggerOptions {
+  /**
+   * Alias for "namespace"
+   */
   name?: string
+  /**
+   * namespace allows you to keep "breadcrumbs" of where the error is coming from
+   * As you add to the namespace, the log entry will include a colon-separated list
+   */
   namespace?: string | string[]
+  /**
+   * The severity of the log entry ranging from TRACE to ERROR
+   */
   level?: LogLevel | string
+  /**
+   * A set of properties and values to be included in every log entry
+   * @example
+   * { defaultFields: { fn: 'myRunningFunction' } }
+   */
   defaultFields?: Record<string, unknown>
+  /**
+   * A function that accepts a log level and data and returns nothing
+   *
+   * Use this to implement custom logging such as to the console or a
+   * log aggregation service.
+   */
+  logFn?: LoggerFunction
 }
 
 export type Arg1 = Error | Arg2
 export type Arg2 = Record<string, unknown> | Arg3
 export type Arg3 = string
 
+/**
+ * Calls to the logger are strictly typed and arguments must be passed in a specific order
+ * "message" is always last
+ */
 export type LoggerMethod =
   | ((arg1: Arg1, arg2?: Arg2, arg3?: Arg3) => void)
   | ((message: string) => void)
@@ -47,10 +73,32 @@ export interface FormattedError {
   message: string
   stack?: string
   kind: string
+  // Additional properties supported by @shapeshiftoss/errors ErrorWithDetails
+  code?: string
+  details?: Record<string, unknown>
+  cause?: unknown
 }
 
+/**
+ * The structure of the data provided to the LoggerFunction
+ */
 export interface FormattedObject {
   message?: string
   error?: FormattedError
   [k: string]: unknown
 }
+
+export interface LogData extends FormattedObject {
+  _messages?: string[]
+  timestamp: string
+  namespace: string
+  status: LogLevel
+}
+
+/**
+ * A function responsible for processing log data
+ */
+export type LoggerFunction = (
+  level: LogLevel.TRACE | LogLevel.DEBUG | LogLevel.INFO | LogLevel.WARN | LogLevel.ERROR,
+  data: LogData
+) => void

--- a/packages/logger/src/logger.type.ts
+++ b/packages/logger/src/logger.type.ts
@@ -98,7 +98,4 @@ export interface LogData extends FormattedObject {
 /**
  * A function responsible for processing log data
  */
-export type LoggerFunction = (
-  level: LogLevel.TRACE | LogLevel.DEBUG | LogLevel.INFO | LogLevel.WARN | LogLevel.ERROR,
-  data: LogData
-) => void
+export type LoggerFunction = (level: Exclude<LogLevel, LogLevel.NONE>, data: LogData) => void

--- a/packages/logger/src/logger.type.ts
+++ b/packages/logger/src/logger.type.ts
@@ -89,9 +89,13 @@ export interface FormattedObject {
 }
 
 export interface LogData extends FormattedObject {
+  /**
+   * This only exists if more than 1 plain string was passed to the logger
+   * This should only be possible in plain JS or with @ts-ignore
+   */
   _messages?: string[]
+  namespace?: string
   timestamp: string
-  namespace: string
   status: LogLevel
 }
 


### PR DESCRIPTION
* feat(logger): support custom logging ouput function
* feat(logger): support formatting Errors with cause, details, and code
* chore(logger): update README to describe custom output logging functions and add some comments

## Details
You can now pass in `logFn` to the `Logger` constructor to provide a custom log output function. The function is provided with the log level and a `FormattedObject` of data.