### PR TITLE
feat(caip): banxa chain map

### DIFF
--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -1,7 +1,7 @@
 import entries from 'lodash/entries'
 import toLower from 'lodash/toLower'
 
-import { CAIP2, toCAIP2 } from '../../caip2/caip2'
+import { ChainId, toCAIP2 } from '../../caip2/caip2'
 import { fromCAIP19 } from '../../caip19/caip19'
 
 const CAIP19ToBanxaTickerMap = {
@@ -56,11 +56,11 @@ export const getSupportedBanxaAssets = () =>
  * since some Banxa assets could be on multiple chains and their default
  * chain won't be exactly the same as ours.
  */
-const caip2ToBanxaBlockchainCodeMap: Record<CAIP2, string> = {
+const chainIdToBanxaBlockchainCodeMap: Record<ChainId, string> = {
   'eip155:1': 'ETH',
   'bip122:000000000019d6689c085ae165831e93': 'BTC',
   'cosmos:cosmoshub-4': 'COSMOS'
-}
+} as const
 
 /**
  * Convert a banxa asset identifier to a Banxa chain identifier for use in Banxa HTTP URLs
@@ -73,6 +73,6 @@ export const getBanxaBlockchainFromBanxaAssetTicker = (banxaAssetId: string): st
   if (!assetCAIP19)
     throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${banxaAssetId} is not supported`)
   const { chain, network } = fromCAIP19(assetCAIP19)
-  const caip2 = toCAIP2({ network, chain })
-  return caip2ToBanxaBlockchainCodeMap[caip2]
+  const chainId = toCAIP2({ network, chain })
+  return chainIdToBanxaBlockchainCodeMap[chainId]
 }

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -59,7 +59,8 @@ const caip2ToBanxaBlockchainCodeMap: Record<CAIP2, string> = {
 
 export const getBanxaBlockchainFromBanxaAssetTicker = (asset: string): string => {
   const assetCAIP19 = banxaTickerToCAIP19(asset.toLowerCase())
-  if (!assetCAIP19) return ''
+  if (!assetCAIP19)
+    throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${asset} is not supported`)
   const { chain, network } = fromCAIP19(assetCAIP19)
   const caip2 = toCAIP2({ network, chain })
   return caip2ToBanxaBlockchainCodeMap[caip2]

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -51,16 +51,27 @@ export const getSupportedBanxaAssets = () =>
     ticker
   }))
 
+/**
+ * map CAIP2s to Banxa blockchain codes (ETH, BTC, COSMOS),
+ * since some Banxa assets could be on multiple chains and their default
+ * chain won't be exactly the same as ours.
+ */
 const caip2ToBanxaBlockchainCodeMap: Record<CAIP2, string> = {
   'eip155:1': 'ETH',
   'bip122:000000000019d6689c085ae165831e93': 'BTC',
   'cosmos:cosmoshub-4': 'COSMOS'
 }
 
-export const getBanxaBlockchainFromBanxaAssetTicker = (asset: string): string => {
-  const assetCAIP19 = banxaTickerToCAIP19(asset.toLowerCase())
+/**
+ * Convert a banxa asset identifier to a Banxa chain identifier for use in Banxa HTTP URLs
+ *
+ * @param {string} banxaAssetId - a Banxa asset string referencing a specific asset; e.g., 'atom'
+ * @returns {string} - a Banxa chain identifier; e.g., 'cosmos'
+ */
+export const getBanxaBlockchainFromBanxaAssetTicker = (banxaAssetId: string): string => {
+  const assetCAIP19 = banxaTickerToCAIP19(banxaAssetId.toLowerCase())
   if (!assetCAIP19)
-    throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${asset} is not supported`)
+    throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${banxaAssetId} is not supported`)
   const { chain, network } = fromCAIP19(assetCAIP19)
   const caip2 = toCAIP2({ network, chain })
   return caip2ToBanxaBlockchainCodeMap[caip2]

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -1,5 +1,8 @@
+import { ChainTypes } from '@shapeshiftoss/types'
 import entries from 'lodash/entries'
 import toLower from 'lodash/toLower'
+
+import { fromCAIP19 } from '../../caip19/caip19'
 
 const CAIP19ToBanxaTickerMap = {
   'bip122:000000000019d6689c085ae165831e93/slip44:0': 'btc',
@@ -47,3 +50,17 @@ export const getSupportedBanxaAssets = () =>
     CAIP19,
     ticker
   }))
+
+const caip10TpBanxaBlockchainMap: Record<ChainTypes, string> = {
+  [ChainTypes.Ethereum]: 'ETH',
+  [ChainTypes.Bitcoin]: 'BTC',
+  [ChainTypes.Cosmos]: 'COSMOS',
+  [ChainTypes.Osmosis]: ''
+}
+
+export const getBanxaBlockchainFromBanxaAssetTicker = (asset: string): string => {
+  const assetCAIP19 = banxaTickerToCAIP19(asset.toLowerCase())
+  if (!assetCAIP19) return ''
+  const { chain } = fromCAIP19(assetCAIP19)
+  return caip10TpBanxaBlockchainMap[chain]
+}

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -1,7 +1,7 @@
-import { ChainTypes } from '@shapeshiftoss/types'
 import entries from 'lodash/entries'
 import toLower from 'lodash/toLower'
 
+import { CAIP2, toCAIP2 } from '../../caip2/caip2'
 import { fromCAIP19 } from '../../caip19/caip19'
 
 const CAIP19ToBanxaTickerMap = {
@@ -51,16 +51,16 @@ export const getSupportedBanxaAssets = () =>
     ticker
   }))
 
-const chainTypeToBanxaBlockchainMap: Record<ChainTypes, string> = {
-  [ChainTypes.Ethereum]: 'ETH',
-  [ChainTypes.Bitcoin]: 'BTC',
-  [ChainTypes.Cosmos]: 'COSMOS',
-  [ChainTypes.Osmosis]: ''
+const caip2ToBanxaBlockchainCodeMap: Record<CAIP2, string> = {
+  'eip155:1': 'ETH',
+  'bip122:000000000019d6689c085ae165831e93': 'BTC',
+  'cosmos:cosmoshub-4': 'COSMOS'
 }
 
 export const getBanxaBlockchainFromBanxaAssetTicker = (asset: string): string => {
   const assetCAIP19 = banxaTickerToCAIP19(asset.toLowerCase())
   if (!assetCAIP19) return ''
-  const { chain } = fromCAIP19(assetCAIP19)
-  return chainTypeToBanxaBlockchainMap[chain]
+  const { chain, network } = fromCAIP19(assetCAIP19)
+  const caip2 = toCAIP2({ network, chain })
+  return caip2ToBanxaBlockchainCodeMap[caip2]
 }

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -51,7 +51,7 @@ export const getSupportedBanxaAssets = () =>
     ticker
   }))
 
-const caip10TpBanxaBlockchainMap: Record<ChainTypes, string> = {
+const chainTypeToBanxaBlockchainMap: Record<ChainTypes, string> = {
   [ChainTypes.Ethereum]: 'ETH',
   [ChainTypes.Bitcoin]: 'BTC',
   [ChainTypes.Cosmos]: 'COSMOS',
@@ -62,5 +62,5 @@ export const getBanxaBlockchainFromBanxaAssetTicker = (asset: string): string =>
   const assetCAIP19 = banxaTickerToCAIP19(asset.toLowerCase())
   if (!assetCAIP19) return ''
   const { chain } = fromCAIP19(assetCAIP19)
-  return caip10TpBanxaBlockchainMap[chain]
+  return chainTypeToBanxaBlockchainMap[chain]
 }

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -52,7 +52,7 @@ export const getSupportedBanxaAssets = () =>
   }))
 
 /**
- * map CAIP2s to Banxa blockchain codes (ETH, BTC, COSMOS),
+ * map ChainIds to Banxa blockchain codes (ETH, BTC, COSMOS),
  * since some Banxa assets could be on multiple chains and their default
  * chain won't be exactly the same as ours.
  */


### PR DESCRIPTION
this PR adds the map of converting our chains to the Banxa blockchain name.

web PR: https://github.com/shapeshift/web/pull/1478
this is where this function is used: https://github.com/shapeshift/web/pull/1478/files#diff-d11d8939921408eeb21dd7f5115e6b0ee21aeb464708b178b08c36ba5aecd12eR34
the input for this function is the selectedAssetTicker from Banxa list, this is the list:
https://github.com/shapeshift/lib/blob/b0dd979413f400db08bb360992148d49a4728478/packages/caip/src/adapters/banxa/index.ts#L4-L33

follow-up of: https://github.com/shapeshift/web/issues/1387
