### PR TITLE
fix: cosmos-sdk/MsgWithdrawDelegationReward -> cosmos-sdk/MsgWithdraw…

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -348,7 +348,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
         },
         msg: [
           {
-            type: 'cosmos-sdk/MsgWithdrawDelegationReward',
+            type: 'cosmos-sdk/MsgWithdrawDelegatorReward',
             value: {
               amount: {
                 amount: bnOrZero(0).toString(), // amount here is required to broadcast, but we are withdrawing ALL rewards


### PR DESCRIPTION
…DelegatorReward

This typo currently produces a bug where it is impossible to claim because the Tx type is unknown by `proto-tx-builder`. 