### PR TITLE
refactor(caip): add accountid, assetid, chainid types

### DIFF
--- a/packages/caip/src/caip10/caip10.ts
+++ b/packages/caip/src/caip10/caip10.ts
@@ -2,6 +2,8 @@ import { CAIP2, ChainNamespace, isCAIP2 } from './../caip2/caip2'
 
 export type CAIP10 = string
 
+export type AccountId = string
+
 type ToCAIP19Args = {
   caip2: CAIP2
   account: string

--- a/packages/caip/src/caip19/caip19.ts
+++ b/packages/caip/src/caip19/caip19.ts
@@ -5,6 +5,8 @@ import { ChainNamespace, ChainReference, toCAIP2 } from '../caip2/caip2'
 
 export type CAIP19 = string
 
+export type AssetId = string
+
 export enum AssetNamespace {
   CW20 = 'cw20',
   CW721 = 'cw721',

--- a/packages/caip/src/caip2/caip2.ts
+++ b/packages/caip/src/caip2/caip2.ts
@@ -4,6 +4,8 @@ import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 export type CAIP2 = string
 
+export type ChainId = string
+
 export enum ChainNamespace {
   Ethereum = 'eip155',
   Bitcoin = 'bip122',

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -4,6 +4,6 @@ import * as caip10 from './caip10/caip10'
 import * as caip19 from './caip19/caip19'
 
 export { adapters, caip2, caip19, caip10 }
-export { CAIP2 } from './caip2/caip2'
-export { CAIP10 } from './caip10/caip10'
-export { AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'
+export { ChainId, CAIP2 } from './caip2/caip2'
+export { AccountId, CAIP10 } from './caip10/caip10'
+export { AssetId, AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -9,7 +9,7 @@ export type ChainAdapter<T extends ChainTypes> = {
 
   /**
    * @deprecated - use `getChainId()` instead
-    */
+   */
   getCaip2(): ChainId | CAIP2
 
   getChainId(): ChainId | CAIP2

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,4 +1,4 @@
-import { CAIP2 } from '@shapeshiftoss/caip'
+import { CAIP2, ChainId } from '@shapeshiftoss/caip'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 
 export type ChainAdapter<T extends ChainTypes> = {
@@ -7,9 +7,9 @@ export type ChainAdapter<T extends ChainTypes> = {
    */
   getType(): T
 
-  getCaip2(): CAIP2
+  getCaip2(): ChainId | CAIP2
 
-  getChainId(): CAIP2
+  getChainId(): ChainId | CAIP2
   /**
    * Get the balance of an address
    */

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -7,6 +7,9 @@ export type ChainAdapter<T extends ChainTypes> = {
    */
   getType(): T
 
+  /**
+   * @deprecated - use `getChainId()` instead
+    */
   getCaip2(): ChainId | CAIP2
 
   getChainId(): ChainId | CAIP2

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -36,7 +36,7 @@ const transformValidator = (
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
   protected readonly chainId: ChainId | CAIP2
-  protected readonly assetId: AssetId | CAIP19 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
+  protected readonly assetId: AssetId | CAIP19 // This is the caip-19 asset specifier for native token on the chain (ATOM/OSMO/etc)
   protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string
   protected readonly providers: {

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -35,7 +35,7 @@ const transformValidator = (
 })
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
-  protected readonly chainId: ChainId | CAIP19
+  protected readonly chainId: ChainId | CAIP2
   protected readonly assetId: AssetId | CAIP2 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
   protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -66,7 +66,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
     return this.chainId
   }
 
-  getCaip2(): ChainId | CAIP19 {
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -62,7 +62,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
 
   abstract getType(): T
 
-  getChainId(): ChainId | CAIP19 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -1,4 +1,4 @@
-import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { AssetId, CAIP2, CAIP19, ChainId } from '@shapeshiftoss/caip'
 import { CosmosSignTx } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -11,7 +11,7 @@ import { getStatus, getType, toRootDerivationPath } from '../utils'
 export type CosmosChainTypes = ChainTypes.Cosmos | ChainTypes.Osmosis
 
 export interface ChainAdapterArgs {
-  chainId?: CAIP2
+  chainId?: ChainId | CAIP2
   providers: {
     http: unchained.cosmos.V1Api
     ws: unchained.ws.Client<unchained.cosmos.Tx>
@@ -35,9 +35,9 @@ const transformValidator = (
 })
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
-  protected readonly chainId: CAIP2
-  protected readonly assetId: CAIP19 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
-  protected readonly supportedChainIds: CAIP2[]
+  protected readonly chainId: ChainId | CAIP19
+  protected readonly assetId: AssetId | CAIP2 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
+  protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string
   protected readonly providers: {
     http: unchained.cosmos.V1Api
@@ -62,11 +62,11 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
 
   abstract getType(): T
 
-  getChainId(): CAIP2 {
+  getChainId(): ChainId | CAIP19 {
     return this.chainId
   }
 
-  getCaip2(): CAIP2 {
+  getCaip2(): ChainId | CAIP19 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -36,7 +36,7 @@ const transformValidator = (
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
   protected readonly chainId: ChainId | CAIP2
-  protected readonly assetId: AssetId | CAIP19 // This is the caip-19 asset specifier for native token on the chain (ATOM/OSMO/etc)
+  protected readonly assetId: AssetId | CAIP19 // This is the CAIP19/AssetId for native token on the chain (ATOM/OSMO/etc)
   protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string
   protected readonly providers: {

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -36,7 +36,7 @@ const transformValidator = (
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
   protected readonly chainId: ChainId | CAIP2
-  protected readonly assetId: AssetId | CAIP2 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
+  protected readonly assetId: AssetId | CAIP19 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
   protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string
   protected readonly providers: {

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -46,7 +46,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     accountNumber: 0
   }
 
-  private readonly chainId: AssetId | CAIP2 = 'eip155:1'
+  private readonly chainId: ChainId | CAIP2 = 'eip155:1'
 
   constructor(args: ChainAdapterArgs) {
     if (args.chainId) {

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import { AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetId, AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -25,7 +25,7 @@ export interface ChainAdapterArgs {
     http: unchained.ethereum.V1Api
     ws: unchained.ws.Client<unchained.ethereum.ParsedTx>
   }
-  chainId?: CAIP2
+  chainId?: AssetId | CAIP2
 }
 
 async function getErc20Data(to: string, value: string, contractAddress?: string) {
@@ -46,7 +46,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     accountNumber: 0
   }
 
-  private readonly chainId: CAIP2 = 'eip155:1'
+  private readonly chainId: AssetId | CAIP2 = 'eip155:1'
 
   constructor(args: ChainAdapterArgs) {
     if (args.chainId) {
@@ -67,11 +67,11 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return ChainTypes.Ethereum
   }
 
-  getCaip2(): CAIP2 {
+  getCaip2(): AssetId | CAIP2 {
     return this.chainId
   }
 
-  getChainId(): CAIP2 {
+  getChainId(): AssetId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -67,6 +67,9 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return ChainTypes.Ethereum
   }
 
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
   getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -67,7 +67,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return ChainTypes.Ethereum
   }
 
-  getCaip2(): AssetId | CAIP2 {
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -25,7 +25,7 @@ export interface ChainAdapterArgs {
     http: unchained.ethereum.V1Api
     ws: unchained.ws.Client<unchained.ethereum.ParsedTx>
   }
-  chainId?: AssetId | CAIP2
+  chainId?: ChainId | CAIP2
 }
 
 async function getErc20Data(to: string, value: string, contractAddress?: string) {

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -71,7 +71,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return this.chainId
   }
 
-  getChainId(): AssetId | CAIP2 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import { AssetId, AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP2, caip2, caip19, ChainId } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -1,4 +1,4 @@
-import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { AssetId, CAIP2, CAIP19, ChainId } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, HDWallet, PublicKey } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -26,7 +26,7 @@ export interface ChainAdapterArgs {
     ws: unchained.ws.Client<unchained.Tx>
   }
   coinName: string
-  chainId?: CAIP2
+  chainId?: ChainId | CAIP2
 }
 
 /**
@@ -36,10 +36,10 @@ export interface ChainAdapterArgs {
  * `export type UTXOChainTypes = ChainTypes.Bitcoin | ChainTypes.Litecoin`
  */
 export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChainAdapter<T> {
-  protected chainId: CAIP2
-  protected assetId: CAIP19
+  protected chainId: ChainId | CAIP2
+  protected assetId: AssetId | CAIP19
   protected coinName: string
-  protected readonly supportedChainIds: CAIP2[]
+  protected readonly supportedChainIds: ChainId | CAIP2[]
   protected readonly providers: {
     http: unchained.bitcoin.V1Api
     ws: unchained.ws.Client<unchained.Tx>
@@ -82,19 +82,19 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
 
   /* public methods */
 
-  getCaip2(): CAIP2 {
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getCaip19(): CAIP19 {
+  getCaip19(): AssetId | CAIP19 {
     return this.assetId
   }
 
-  getChainId(): CAIP2 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getAssetId(): CAIP19 {
+  getAssetId(): AssetId | CAIP19 {
     return this.assetId
   }
 

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -82,6 +82,9 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
 
   /* public methods */
 
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
   getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -89,6 +89,9 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
     return this.chainId
   }
 
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
   getCaip19(): AssetId | CAIP19 {
     return this.assetId
   }


### PR DESCRIPTION
Export types { AccountId, AssetId, ChainId } to replace { CAIP10, CAIP19, CAIP2 }

This is to be followed with a PR that removes { CAIP10, CAIP19, CAIP2 } once web PR [#1579](https://github.com/shapeshift/web/pull/1579) has been merged.