### PR TITLE
feat(caip): flatten exports

### DIFF
--- a/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
@@ -1,4 +1,4 @@
-import { caip19 } from '@shapeshiftoss/caip'
+import { fromCAIP19 } from '@shapeshiftoss/caip'
 import { BaseAsset, TokenAsset } from '@shapeshiftoss/types'
 import axios from 'axios'
 import chunk from 'lodash/chunk'
@@ -43,7 +43,7 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
   for (const [i, batch] of tokenBatches.entries()) {
     console.info(`processing batch ${i + 1} of ${tokenBatches.length}`)
     const promises = batch.map(async (token) => {
-      const { chain } = caip19.fromCAIP19(token.assetId)
+      const { chain } = fromCAIP19(token.assetId)
       const { info } = generateTrustWalletUrl({ chain, tokenId: token.tokenId })
       return axios.head(info) // return promise
     })
@@ -70,7 +70,7 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
         }
         return uniqueTokens[key] // token without modified icon
       } else {
-        const { chain } = caip19.fromCAIP19(uniqueTokens[key].assetId)
+        const { chain } = fromCAIP19(uniqueTokens[key].assetId)
         const { icon } = generateTrustWalletUrl({ chain, tokenId: uniqueTokens[key].tokenId })
         return { ...uniqueTokens[key], icon }
       }

--- a/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 
 export const getFoxyToken = (): TokenAsset[] => {
@@ -8,20 +8,20 @@ export const getFoxyToken = (): TokenAsset[] => {
   const assetReference = '0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3' // FOXy contract address
 
   const result: TokenAsset = {
-    assetId: caip19.toCAIP19({
+    assetId: toCAIP19({
       chain,
       network,
       assetNamespace,
       assetReference
     }),
-    chainId: caip2.toCAIP2({ chain, network }),
-    caip19: caip19.toCAIP19({
+    chainId: toCAIP2({ chain, network }),
+    caip19: toCAIP19({
       chain,
       network,
       assetNamespace,
       assetReference
     }),
-    caip2: caip2.toCAIP2({ chain, network }),
+    caip2: toCAIP2({ chain, network }),
     dataSource: AssetDataSource.CoinGecko,
     name: 'FOX Yieldy',
     precision: 18,

--- a/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 import axios from 'axios'
 import lodash from 'lodash'
@@ -49,10 +49,10 @@ export async function getUniswapTokens(): Promise<TokenAsset[]> {
       return acc
     }
     const result: TokenAsset = {
-      assetId: caip19.toCAIP19({ chain, network, assetNamespace, assetReference }),
-      chainId: caip2.toCAIP2({ chain, network }),
-      caip19: caip19.toCAIP19({ chain, network, assetNamespace, assetReference }),
-      caip2: caip2.toCAIP2({ chain, network }),
+      assetId: toCAIP19({ chain, network, assetNamespace, assetReference }),
+      chainId: toCAIP2({ chain, network }),
+      caip19: toCAIP19({ chain, network, assetNamespace, assetReference }),
+      caip2: toCAIP2({ chain, network }),
       dataSource: AssetDataSource.CoinGecko,
       name: token.name,
       precision: token.decimals,

--- a/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 import { Token, Vault } from '@yfi/sdk'
 import toLower from 'lodash/toLower'
@@ -21,21 +21,21 @@ export const getYearnVaults = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: vault.symbol,
       tokenId: toLower(vault.address),
-      chainId: caip2.toCAIP2({
+      chainId: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      assetId: caip19.toCAIP19({
+      assetId: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: vault.address
       }),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -60,21 +60,21 @@ export const getIronBankTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: caip2.toCAIP2({
+      chainId: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      assetId: caip19.toCAIP19({
+      assetId: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: token.address
       }),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -99,21 +99,21 @@ export const getZapperTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: caip2.toCAIP2({
+      chainId: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      assetId: caip19.toCAIP19({
+      assetId: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: token.address
       }),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -138,21 +138,21 @@ export const getUnderlyingVaultTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: caip2.toCAIP2({
+      chainId: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      assetId: caip19.toCAIP19({
+      assetId: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: token.address
       }),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -1,9 +1,10 @@
 import * as adapters from './adapters'
+// TODO: These all go away on the caip breaking change PR
 import * as caip2 from './caip2/caip2'
 import * as caip10 from './caip10/caip10'
 import * as caip19 from './caip19/caip19'
-
 export { adapters, caip2, caip19, caip10 }
-export { ChainId, CAIP2, ChainReference } from './caip2/caip2'
-export { AccountId, CAIP10 } from './caip10/caip10'
-export { AssetId, AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'
+// ENDTODO
+export * from './caip2/caip2'
+export * from './caip10/caip10'
+export * from './caip19/caip19'

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,4 +1,4 @@
-import { CAIP2, caip2 } from '@shapeshiftoss/caip'
+import { CAIP2, isCAIP2 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
@@ -117,7 +117,7 @@ export class ChainAdapterManager {
 
   async byChainId(chainId: CAIP2) {
     // this function acts like a validation function and throws if the check doesn't pass
-    caip2.isCAIP2(chainId)
+    isCAIP2(chainId)
 
     for (const [chain] of this.supported) {
       // byChain calls the factory function so we need to call it to create the instances

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP2, fromCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   BTCOutputAddressType,
@@ -50,12 +50,12 @@ export class ChainAdapter
     } else {
       this.chainId = this.supportedChainIds[0]
     }
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
     if (chain !== ChainTypes.Bitcoin) {
       throw new Error('chainId must be a bitcoin chain type')
     }
     this.coinName = args.coinName
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -1,4 +1,11 @@
-import { AssetNamespace, AssetReference, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
+import {
+  AssetNamespace,
+  AssetReference,
+  CAIP19,
+  ChainReference,
+  fromCAIP2,
+  toCAIP19
+} from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   CosmosSignTx,
@@ -30,9 +37,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
 
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,
@@ -153,7 +160,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -225,7 +232,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -296,7 +303,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -361,7 +368,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -440,7 +447,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, AssetReference, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP19, fromCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, OsmosisSignTx, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 
@@ -23,9 +23,9 @@ export class ChainAdapter
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
 
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, ChainReference, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import axios from 'axios'
@@ -58,9 +58,9 @@ export type ConstructorArgs = {
   providerUrl: string
   foxyAddresses: FoxyAddressesType
   network?:
-    | caip2.ChainReference.EthereumMainnet
-    | caip2.ChainReference.EthereumRinkeby
-    | caip2.ChainReference.EthereumRopsten
+    | ChainReference.EthereumMainnet
+    | ChainReference.EthereumRinkeby
+    | ChainReference.EthereumRopsten
 }
 
 export const transformData = ({ tvl, apy, expired, ...contractData }: FoxyOpportunityInputData) => {
@@ -88,14 +88,14 @@ export class FoxyApi {
   public web3: Web3
   private foxyStakingContracts: Contract[]
   private liquidityReserveContracts: Contract[]
-  private network: caip2.ChainReference
+  private network: ChainReference
   private foxyAddresses: FoxyAddressesType
 
   constructor({
     adapter,
     providerUrl,
     foxyAddresses,
-    network = caip2.ChainReference.EthereumMainnet
+    network = ChainReference.EthereumMainnet
   }: ConstructorArgs) {
     this.adapter = adapter
     this.provider = new Web3.providers.HttpProvider(providerUrl)
@@ -1083,7 +1083,7 @@ export class FoxyApi {
     const assetNamespace = AssetNamespace.ERC20
     const assetReference = tokenContractAddress
     // foxy assetId
-    const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference })
+    const assetId = toCAIP19({ chain, network, assetNamespace, assetReference })
 
     const results = await Promise.allSettled(
       events.map(async (event) => {

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -1,4 +1,4 @@
-import { caip2 } from '@shapeshiftoss/caip'
+import { toCAIP2 } from '@shapeshiftoss/caip'
 import { ChainAdapter, ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
@@ -45,7 +45,7 @@ const main = async (): Promise<void> => {
 
   const api = new FoxyApi({
     adapter: (await adapterManager.byChainId(
-      caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+      toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
     )) as ChainAdapter<ChainTypes.Ethereum>,
     providerUrl: process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
     foxyAddresses

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -1,4 +1,4 @@
-import { adapters, caip19 as AssetId } from '@shapeshiftoss/caip'
+import { adapters, fromCAIP19 } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -19,7 +19,6 @@ import { isValidDate } from '../utils/isValidDate'
 import { rateLimitedAxios } from '../utils/rateLimiters'
 import { CoinGeckoMarketCap } from './coingecko-types'
 
-const { fromCAIP19 } = AssetId
 const axios = rateLimitedAxios(RATE_LIMIT_THRESHOLDS_PER_MINUTE.COINGECKO)
 
 // tons more params here: https://www.coingecko.com/en/api/documentation

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 import { YearnTokenMarketCapService } from './yearn-tokens'
@@ -68,13 +68,13 @@ describe('yearn token market service', () => {
 
     it('can map yearn to caip ids', async () => {
       const result = await yearnTokenMarketCapService.findAll()
-      const yvBtcCaip19 = caip19.toCAIP19({
+      const yvBtcCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: mockYearnTokenRestData[0].address.toLowerCase()
       })
-      const yvDaiCaip19 = caip19.toCAIP19({
+      const yvDaiCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -1,4 +1,4 @@
-import { adapters, AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { adapters, AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -56,7 +56,7 @@ export class YearnTokenMarketCapService implements MarketService {
       const tokens = uniqueTokens.slice(0, argsToUse.count)
 
       return tokens.reduce((acc, token) => {
-        const _caip19: string = caip19.toCAIP19({
+        const _caip19: string = toCAIP19({
           chain: ChainTypes.Ethereum,
           network: NetworkTypes.MAINNET,
           assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes, HistoryTimeframe, NetworkTypes } from '@shapeshiftoss/types'
 
 import { YearnVaultMarketCapService } from './yearn-vaults'
@@ -37,7 +37,7 @@ describe('yearn market service', () => {
       const yvBTCAddress = '0x19D3364A399d251E894aC732651be8B0E4e85001'
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result)[0]).toEqual(
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: NetworkTypes.MAINNET,
           assetNamespace: AssetNamespace.ERC20,
@@ -72,13 +72,13 @@ describe('yearn market service', () => {
 
     it('can map yearn to caip ids', async () => {
       const result = await yearnVaultMarketCapService.findAll()
-      const yvBtcCaip19 = caip19.toCAIP19({
+      const yvBtcCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: mockYearnVaultRestData[0].address.toLowerCase()
       })
-      const yvDaiCaip19 = caip19.toCAIP19({
+      const yvDaiCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-vaults.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.ts
@@ -1,4 +1,4 @@
-import { adapters, AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { adapters, AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -54,7 +54,7 @@ export class YearnVaultMarketCapService implements MarketService {
             : -1
         )
         .reduce((acc, yearnItem) => {
-          const assetId = caip19.toCAIP19({
+          const assetId = toCAIP19({
             chain: ChainTypes.Ethereum,
             network: NetworkTypes.MAINNET,
             assetNamespace: AssetNamespace.ERC20,

--- a/packages/unchained-client/src/bitcoin/parser/index.ts
+++ b/packages/unchained-client/src/bitcoin/parser/index.ts
@@ -1,5 +1,5 @@
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { AssetNamespace, AssetReference, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
 
@@ -21,7 +21,7 @@ export class TransactionParser {
   }
 
   async parse(tx: BlockbookTx, address: string): Promise<ParsedTx> {
-    const caip19Bitcoin = caip19.toCAIP19({
+    const caip19Bitcoin = toCAIP19({
       chain: ChainTypes.Bitcoin,
       network: toNetworkType(this.network),
       assetNamespace: AssetNamespace.Slip44,
@@ -33,8 +33,8 @@ export class TransactionParser {
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
-      caip2: caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
-      chainId: caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
+      caip2: toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
+      chainId: toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: tx.confirmations > 0 ? Status.Confirmed : Status.Pending,
       transfers: [],

--- a/packages/unchained-client/src/cosmos/parser/index.ts
+++ b/packages/unchained-client/src/cosmos/parser/index.ts
@@ -2,9 +2,9 @@ import {
   AssetId,
   AssetNamespace,
   AssetReference,
-  caip2,
-  caip19,
-  ChainId
+  ChainId,
+  fromCAIP2,
+  toCAIP19
 } from '@shapeshiftoss/caip'
 import { BigNumber } from 'bignumber.js'
 
@@ -24,8 +24,8 @@ export class TransactionParser {
   constructor(args: TransactionParserArgs) {
     this.chainId = args.chainId
 
-    this.assetId = caip19.toCAIP19({
-      ...caip2.fromCAIP2(this.chainId),
+    this.assetId = toCAIP19({
+      ...fromCAIP2(this.chainId),
       assetNamespace: AssetNamespace.Slip44,
       assetReference: AssetReference.Cosmos
     })

--- a/packages/unchained-client/src/ethereum/parser/index.ts
+++ b/packages/unchained-client/src/ethereum/parser/index.ts
@@ -1,5 +1,5 @@
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { AssetNamespace, AssetReference, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
@@ -79,8 +79,8 @@ export class TransactionParser {
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
-      caip2: caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
-      chainId: caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
+      caip2: toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
+      chainId: toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: TransactionParser.getStatus(tx),
       trade: contractParserResult?.trade,
@@ -108,7 +108,7 @@ export class TransactionParser {
     address: string,
     internalTxs?: Array<InternalTx>
   ) {
-    const caip19Ethereum = caip19.toCAIP19({
+    const caip19Ethereum = toCAIP19({
       chain: ChainTypes.Ethereum,
       network: toNetworkType(this.network),
       assetNamespace: AssetNamespace.Slip44,
@@ -168,7 +168,7 @@ export class TransactionParser {
       }
 
       const transferArgs = [
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: toNetworkType(this.network),
           assetNamespace: AssetNamespace.ERC20,
@@ -201,7 +201,7 @@ export class TransactionParser {
 
     internalTxs?.forEach((internalTx) => {
       const transferArgs = [
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: toNetworkType(this.network),
           assetNamespace: AssetNamespace.Slip44,

--- a/packages/unchained-client/src/ethereum/parser/uniV2.ts
+++ b/packages/unchained-client/src/ethereum/parser/uniV2.ts
@@ -1,5 +1,5 @@
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { ethers } from 'ethers'
 
@@ -66,7 +66,7 @@ export class Parser implements SubParser {
           const symbol = await contract.symbol()
           const value = decoded.args.amountTokenDesired.toString()
 
-          const assetId = caip19.toCAIP19({
+          const assetId = toCAIP19({
             chain: ChainTypes.Ethereum,
             network: toNetworkType(this.network),
             assetNamespace: AssetNamespace.ERC20,
@@ -93,7 +93,7 @@ export class Parser implements SubParser {
           const symbol = await contract.symbol()
           const value = decoded.args.liquidity.toString()
 
-          const assetId = caip19.toCAIP19({
+          const assetId = toCAIP19({
             chain: ChainTypes.Ethereum,
             network: toNetworkType(this.network),
             assetNamespace: AssetNamespace.ERC20,

--- a/packages/unchained-client/src/ethereum/parser/weth.ts
+++ b/packages/unchained-client/src/ethereum/parser/weth.ts
@@ -1,5 +1,5 @@
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { ethers } from 'ethers'
 
@@ -55,7 +55,7 @@ export class Parser implements SubParser {
     const sendAddress = tx.vin[0].addresses?.[0] ?? ''
     const contract = new ethers.Contract(this.wethContract, ERC20_ABI, this.provider)
 
-    const assetId = caip19.toCAIP19({
+    const assetId = toCAIP19({
       chain: ChainTypes.Ethereum,
       network: toNetworkType(this.network),
       assetNamespace: AssetNamespace.ERC20,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,6 +2843,11 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
+"@shapeshiftoss/types@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-3.1.3.tgz#26b1d626d2b342b107e2ea538b5aedb0bee896ab"
+  integrity sha512-Nhrs8gQelmsFAQQHTEq8TS3wueBKqjBf0pX6VxOiIQyasordSHQT4Di6WQOL1NWhciYptJ2nHPbarmhKOD63Eg==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
This flattens the caip exports instead of exporting each of the namespaces as their own module export. 

Following the release of this, https://github.com/shapeshift/web/pull/1591 should be merged, updating the usages.

- partially tackles #548