### PR TITLE
refactor: add assetid, chainid fields to asset type

### DIFF
--- a/packages/asset-service/src/generateAssetData/baseAssets.ts
+++ b/packages/asset-service/src/generateAssetData/baseAssets.ts
@@ -2,6 +2,8 @@ import { AssetNamespace } from '@shapeshiftoss/caip'
 import { AssetDataSource, BaseAsset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 export const ethereum: BaseAsset = {
+  assetId: 'eip155:1/slip44:60',
+  chainId: 'eip155:1',
   caip19: 'eip155:1/slip44:60',
   caip2: 'eip155:1',
   chain: ChainTypes.Ethereum,
@@ -22,6 +24,8 @@ export const ethereum: BaseAsset = {
 }
 
 export const bitcoin: BaseAsset = {
+  assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  chainId: 'bip122:000000000019d6689c085ae165831e93',
   caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   caip2: 'bip122:000000000019d6689c085ae165831e93',
   chain: ChainTypes.Bitcoin,
@@ -42,6 +46,8 @@ export const bitcoin: BaseAsset = {
 }
 
 export const tBitcoin: BaseAsset = {
+  assetId: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
+  chainId: 'bip122:000000000933ea01ad0ee984209779ba',
   caip19: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
   caip2: 'bip122:000000000933ea01ad0ee984209779ba',
   chain: ChainTypes.Bitcoin,
@@ -62,6 +68,8 @@ export const tBitcoin: BaseAsset = {
 }
 
 export const tEthereum: BaseAsset = {
+  assetId: 'eip155:3/slip44:60',
+  chainId: 'eip155:3',
   caip19: 'eip155:3/slip44:60',
   caip2: 'eip155:3',
   chain: ChainTypes.Ethereum,
@@ -81,6 +89,8 @@ export const tEthereum: BaseAsset = {
   receiveSupport: false,
   tokens: [
     {
+      assetId: 'eip155:3/erc20:0x1da00b6fc705f2ce4c25d7e7add25a3cc045e54a',
+      chainId: 'eip155:3',
       caip19: 'eip155:3/erc20:0x1da00b6fc705f2ce4c25d7e7add25a3cc045e54a',
       caip2: 'eip155:3',
       name: 'Test Token',
@@ -99,6 +109,8 @@ export const tEthereum: BaseAsset = {
 }
 
 export const atom: BaseAsset = {
+  assetId: 'cosmos:cosmoshub-4/slip44:118',
+  chainId: 'cosmos:cosmoshub-4',
   caip19: 'cosmos:cosmoshub-4/slip44:118',
   caip2: 'cosmos:cosmoshub-4',
   chain: ChainTypes.Cosmos,
@@ -119,6 +131,8 @@ export const atom: BaseAsset = {
 }
 
 export const osmosis: BaseAsset = {
+  assetId: 'cosmos:osmosis-1/slip44:118',
+  chainId: 'cosmos:osmosis-1',
   caip19: 'cosmos:osmosis-1/slip44:118',
   caip2: 'cosmos:osmosis-1',
   chain: ChainTypes.Cosmos,

--- a/packages/asset-service/src/generateAssetData/cosmos/getOsmosisAssets.ts
+++ b/packages/asset-service/src/generateAssetData/cosmos/getOsmosisAssets.ts
@@ -57,6 +57,8 @@ export const getOsmosisAssets = async (): Promise<Asset[]> => {
     const getName = (a: OsmoAsset): string => (a.ibc ? `${a.name} on Osmosis` : a.name)
 
     const assetDatum = {
+      assetId: `cosmos:osmosis-1/${assetNamespace}:${assetReference}`,
+      chainId: 'cosmos:osmosis-1',
       caip19: `cosmos:osmosis-1/${assetNamespace}:${assetReference}`,
       caip2: 'cosmos:osmosis-1',
       chain: ChainTypes.Osmosis,

--- a/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
@@ -43,7 +43,7 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
   for (const [i, batch] of tokenBatches.entries()) {
     console.info(`processing batch ${i + 1} of ${tokenBatches.length}`)
     const promises = batch.map(async (token) => {
-      const { chain } = caip19.fromCAIP19(token.caip19)
+      const { chain } = caip19.fromCAIP19(token.assetId)
       const { info } = generateTrustWalletUrl({ chain, tokenId: token.tokenId })
       return axios.head(info) // return promise
     })
@@ -63,14 +63,14 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
             }
           }
           uniqueTokens[key].icon = getRenderedIdenticonBase64(
-            uniqueTokens[key].caip19,
+            uniqueTokens[key].assetId,
             uniqueTokens[key].symbol.substring(0, 3),
             options
           )
         }
         return uniqueTokens[key] // token without modified icon
       } else {
-        const { chain } = caip19.fromCAIP19(uniqueTokens[key].caip19)
+        const { chain } = caip19.fromCAIP19(uniqueTokens[key].assetId)
         const { icon } = generateTrustWalletUrl({ chain, tokenId: uniqueTokens[key].tokenId })
         return { ...uniqueTokens[key], icon }
       }

--- a/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
@@ -8,6 +8,13 @@ export const getFoxyToken = (): TokenAsset[] => {
   const assetReference = '0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3' // FOXy contract address
 
   const result: TokenAsset = {
+    assetId: caip19.toCAIP19({
+      chain,
+      network,
+      assetNamespace,
+      assetReference
+    }),
+    chainId: caip2.toCAIP2({ chain, network }),
     caip19: caip19.toCAIP19({
       chain,
       network,

--- a/packages/asset-service/src/generateAssetData/ethTokens/overrides.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/overrides.ts
@@ -4,6 +4,8 @@ import { AssetDataSource, TokenAsset } from '@shapeshiftoss/types'
 export const tokensToOverride: Array<TokenAsset> = [
   // example overriding FOX token with custom values instead of goingecko
   {
+    assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    chainId: 'eip155:1',
     caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:1',
     name: 'Fox',

--- a/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
@@ -49,6 +49,8 @@ export async function getUniswapTokens(): Promise<TokenAsset[]> {
       return acc
     }
     const result: TokenAsset = {
+      assetId: caip19.toCAIP19({ chain, network, assetNamespace, assetReference }),
+      chainId: caip2.toCAIP2({ chain, network }),
       caip19: caip19.toCAIP19({ chain, network, assetNamespace, assetReference }),
       caip2: caip2.toCAIP2({ chain, network }),
       dataSource: AssetDataSource.CoinGecko,

--- a/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
@@ -21,6 +21,16 @@ export const getYearnVaults = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: vault.symbol,
       tokenId: toLower(vault.address),
+      chainId: caip2.toCAIP2({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET
+      }),
+      assetId: caip19.toCAIP19({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: AssetNamespace.ERC20,
+        assetReference: vault.address
+      }),
       caip2: caip2.toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
@@ -50,6 +60,16 @@ export const getIronBankTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
+      chainId: caip2.toCAIP2({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET
+      }),
+      assetId: caip19.toCAIP19({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: AssetNamespace.ERC20,
+        assetReference: token.address
+      }),
       caip2: caip2.toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
@@ -79,6 +99,16 @@ export const getZapperTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
+      chainId: caip2.toCAIP2({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET
+      }),
+      assetId: caip19.toCAIP19({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: AssetNamespace.ERC20,
+        assetReference: token.address
+      }),
       caip2: caip2.toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
@@ -108,6 +138,16 @@ export const getUnderlyingVaultTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
+      chainId: caip2.toCAIP2({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET
+      }),
+      assetId: caip19.toCAIP19({
+        chain: ChainTypes.Ethereum,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: AssetNamespace.ERC20,
+        assetReference: token.address
+      }),
       caip2: caip2.toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET

--- a/packages/asset-service/src/generateAssetData/utils.test.ts
+++ b/packages/asset-service/src/generateAssetData/utils.test.ts
@@ -5,7 +5,7 @@ import blacklist from './blacklist.json'
 import { filterBlacklistedAssets } from './utils'
 
 // We need to use the non-null assertion because we know this mocks contains the token property
-jest.mock('./blacklist.json', () => [ETHMockedAsset.tokens![0].caip19, BTCMockedAsset.caip19], {
+jest.mock('./blacklist.json', () => [ETHMockedAsset.tokens![0].assetId, BTCMockedAsset.assetId], {
   virtual: true
 })
 
@@ -15,7 +15,7 @@ describe('Utils', () => {
   describe('filterBlacklistedAssets', () => {
     it('should filter BTC from the asset list', () => {
       const filteredAssetList = filterBlacklistedAssets(blacklist, assetList)
-      expect(filteredAssetList[0]).toHaveProperty('caip19', ETHMockedAsset.caip19)
+      expect(filteredAssetList[0]).toHaveProperty('assetId', ETHMockedAsset.assetId)
     })
 
     it('should filter ERC20 from the asset list', () => {
@@ -23,7 +23,7 @@ describe('Utils', () => {
       const ethFiltered = filteredAssetList[0]
       const remainingToken = ETHMockedAsset.tokens![1]
 
-      expect(ethFiltered.tokens![0]).toHaveProperty('caip19', remainingToken.caip19)
+      expect(ethFiltered.tokens![0]).toHaveProperty('assetId', remainingToken.assetId)
     })
   })
 })

--- a/packages/asset-service/src/generateAssetData/utils.ts
+++ b/packages/asset-service/src/generateAssetData/utils.ts
@@ -13,7 +13,7 @@ export const filterBlacklistedAssets = <T extends BaseAsset | TokenAsset>(
       token.tokens = filterBlacklistedAssets(blacklist, token.tokens)
     }
 
-    return !blacklist.includes(token.caip19)
+    return !blacklist.includes(token.assetId)
   })
 
   return filteredAssets

--- a/packages/asset-service/src/service/AssetService.test.ts
+++ b/packages/asset-service/src/service/AssetService.test.ts
@@ -11,6 +11,8 @@ jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
 
 const EthAsset: Asset = {
+  assetId: 'eip155:3/slip44:60',
+  chainId: 'eip155:3',
   caip19: 'eip155:3/slip44:60',
   caip2: 'eip155:3',
   chain: ChainTypes.Ethereum,
@@ -148,7 +150,7 @@ describe('AssetService', () => {
 
     it('should return a string if found', async () => {
       const assetDescriptions = descriptions as Record<string, string>
-      delete assetDescriptions[EthAsset.caip19]
+      delete assetDescriptions[EthAsset.assetId]
 
       const assetService = new AssetService(assetFileUrl)
       const description = { en: 'a blue fox' }
@@ -163,6 +165,8 @@ describe('AssetService', () => {
       mockedAxios.get.mockRejectedValue({ data: null })
       const chain = ChainTypes.Ethereum
       const tokenData: Asset = {
+        assetId: 'eip155:3/erc20:0x1da00b6fc705f2ce4c25d7e7add25a3cc045e54a',
+        chainId: 'eip155:3',
         caip19: 'eip155:3/erc20:0x1da00b6fc705f2ce4c25d7e7add25a3cc045e54a',
         caip2: 'eip155:3',
         chain: ChainTypes.Ethereum,

--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -125,9 +125,9 @@ export class AssetService {
     const descriptions: Record<string, string> = assetsDescriptions
 
     // Return overridden asset description if it exists and add isTrusted for description links
-    if (descriptions[asset.caip19]) {
+    if (descriptions[asset.assetId ?? asset.caip19]) {
       return {
-        description: descriptions[asset.caip19],
+        description: descriptions[asset.assetId ?? asset.caip19],
         isTrusted: true
       }
     }

--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -127,7 +127,7 @@ export class AssetService {
     // Return overridden asset description if it exists and add isTrusted for description links
     if (descriptions[asset.assetId ?? asset.caip19]) {
       return {
-        description: descriptions[asset.assetId ?? asset.caip19],
+        description: descriptions[asset.assetId],
         isTrusted: true
       }
     }

--- a/packages/asset-service/src/service/AssetServiceTestData.ts
+++ b/packages/asset-service/src/service/AssetServiceTestData.ts
@@ -4,8 +4,10 @@ import { Asset, AssetDataSource, BaseAsset, ChainTypes, NetworkTypes } from '@sh
 import { IndexedAssetData } from '..'
 
 export const ETHMockedAsset: BaseAsset = {
+  assetId: 'eip155:1/slip44:60',
   caip19: 'eip155:1/slip44:60',
   caip2: 'eip155:1',
+  chainId: 'eip155:1',
   chain: ChainTypes.Ethereum,
   dataSource: AssetDataSource.CoinGecko,
   network: NetworkTypes.MAINNET,
@@ -23,8 +25,10 @@ export const ETHMockedAsset: BaseAsset = {
   receiveSupport: true,
   tokens: [
     {
+      assetId: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
       caip19: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
       caip2: 'eip155:1',
+      chainId: 'eip155:1',
       name: 'Aave',
       precision: 18,
       tokenId: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
@@ -38,8 +42,10 @@ export const ETHMockedAsset: BaseAsset = {
       symbol: 'AAVE'
     },
     {
+      assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
       caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
       caip2: 'eip155:1',
+      chainId: 'eip155:1',
       name: 'Fox',
       precision: 18,
       tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -56,8 +62,10 @@ export const ETHMockedAsset: BaseAsset = {
 }
 
 export const BTCMockedAsset: BaseAsset = {
+  assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   caip2: 'bip122:000000000019d6689c085ae165831e93',
+  chainId: 'bip122:000000000019d6689c085ae165831e93',
   chain: ChainTypes.Bitcoin,
   dataSource: AssetDataSource.CoinGecko,
   network: NetworkTypes.MAINNET,
@@ -78,8 +86,10 @@ export const BTCMockedAsset: BaseAsset = {
 export const mockBaseAssets: BaseAsset[] = [
   ETHMockedAsset,
   {
+    assetId: 'eip155:3/slip44:60',
     caip19: 'eip155:3/slip44:60',
     caip2: 'eip155:3',
+    chainId: 'eip155:3',
     chain: ChainTypes.Ethereum,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.ETH_ROPSTEN,
@@ -97,8 +107,10 @@ export const mockBaseAssets: BaseAsset[] = [
     receiveSupport: true,
     tokens: [
       {
+        assetId: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
         caip19: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
         caip2: 'eip155:3',
+        chainId: 'eip155:3',
         name: 'Fox',
         precision: 18,
         tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -115,8 +127,10 @@ export const mockBaseAssets: BaseAsset[] = [
   },
   BTCMockedAsset,
   {
+    assetId: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip19: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip2: 'bip122:000000000933ea01ad0ee984209779ba',
+    chainId: 'bip122:000000000933ea01ad0ee984209779ba',
     chain: ChainTypes.Bitcoin,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.TESTNET,
@@ -137,8 +151,10 @@ export const mockBaseAssets: BaseAsset[] = [
 
 export const mockAssets: Asset[] = [
   {
+    assetId: 'eip155:1/slip44:60',
     caip19: 'eip155:1/slip44:60',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     chain: ChainTypes.Ethereum,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.MAINNET,
@@ -156,8 +172,10 @@ export const mockAssets: Asset[] = [
     receiveSupport: true
   },
   {
+    assetId: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
     caip19: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     name: 'Aave',
     precision: 18,
     tokenId: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
@@ -177,8 +195,10 @@ export const mockAssets: Asset[] = [
     explorerAddressLink: 'https://etherscan.io/address/'
   },
   {
+    assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     name: 'Fox',
     precision: 18,
     tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -198,8 +218,10 @@ export const mockAssets: Asset[] = [
     explorerAddressLink: 'https://etherscan.io/address/'
   },
   {
+    assetId: 'eip155:3/slip44:60',
     caip19: 'eip155:3/slip44:60',
     caip2: 'eip155:3',
+    chainId: 'eip155:3',
     chain: ChainTypes.Ethereum,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.ETH_ROPSTEN,
@@ -217,8 +239,10 @@ export const mockAssets: Asset[] = [
     receiveSupport: true
   },
   {
+    assetId: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip19: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:3',
+    chainId: 'eip155:3',
     name: 'Fox',
     precision: 18,
     tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -238,8 +262,10 @@ export const mockAssets: Asset[] = [
     explorerAddressLink: 'https://etherscan.io/address/'
   },
   {
+    assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
     caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
     caip2: 'bip122:000000000019d6689c085ae165831e93',
+    chainId: 'bip122:000000000019d6689c085ae165831e93',
     chain: ChainTypes.Bitcoin,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.MAINNET,
@@ -257,8 +283,10 @@ export const mockAssets: Asset[] = [
     receiveSupport: false
   },
   {
+    assetId: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip19: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip2: 'bip122:000000000933ea01ad0ee984209779ba',
+    chainId: 'bip122:000000000933ea01ad0ee984209779ba',
     chain: ChainTypes.Bitcoin,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.TESTNET,
@@ -279,8 +307,10 @@ export const mockAssets: Asset[] = [
 
 export const mockIndexedAssetData: IndexedAssetData = {
   ethereum_MAINNET: {
+    assetId: 'eip155:1/slip44:60',
     caip19: 'eip155:1/slip44:60',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     chain: ChainTypes.Ethereum,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.MAINNET,
@@ -298,8 +328,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     receiveSupport: true
   },
   ethereum_MAINNET_0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9: {
+    assetId: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
     caip19: 'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     name: 'Aave',
     precision: 18,
     dataSource: AssetDataSource.CoinGecko,
@@ -319,8 +351,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     explorerTxLink: 'https://etherscan.io/tx/'
   },
   ethereum_MAINNET_0xc770eefad204b5180df6a14ee197d99d808ee52d: {
+    assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:1',
+    chainId: 'eip155:1',
     name: 'Fox',
     precision: 18,
     tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -340,8 +374,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     explorerTxLink: 'https://etherscan.io/tx/'
   },
   ethereum_ETH_ROPSTEN: {
+    assetId: 'eip155:3/slip44:60',
     caip19: 'eip155:3/slip44:60',
     caip2: 'eip155:3',
+    chainId: 'eip155:3',
     chain: ChainTypes.Ethereum,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.ETH_ROPSTEN,
@@ -359,8 +395,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     receiveSupport: true
   },
   ethereum_ETH_ROPSTEN_0xc770eefad204b5180df6a14ee197d99d808ee52d: {
+    assetId: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip19: 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:3',
+    chainId: 'eip155:3',
     name: 'Fox',
     precision: 18,
     tokenId: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -380,8 +418,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     explorerAddressLink: 'https://etherscan.io/address/'
   },
   bitcoin_MAINNET: {
+    assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
     caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
     caip2: 'bip122:000000000019d6689c085ae165831e93',
+    chainId: 'bip122:000000000019d6689c085ae165831e93',
     chain: ChainTypes.Bitcoin,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.MAINNET,
@@ -399,8 +439,10 @@ export const mockIndexedAssetData: IndexedAssetData = {
     receiveSupport: false
   },
   bitcoin_TESTNET: {
+    assetId: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip19: 'bip122:000000000933ea01ad0ee984209779ba/slip44:0',
     caip2: 'bip122:000000000933ea01ad0ee984209779ba',
+    chainId: 'bip122:000000000933ea01ad0ee984209779ba',
     chain: ChainTypes.Bitcoin,
     dataSource: AssetDataSource.CoinGecko,
     network: NetworkTypes.TESTNET,

--- a/packages/caip/src/caip10/caip10.ts
+++ b/packages/caip/src/caip10/caip10.ts
@@ -2,6 +2,8 @@ import { CAIP2, ChainNamespace, isCAIP2 } from './../caip2/caip2'
 
 export type CAIP10 = string
 
+export type AccountId = string
+
 type ToCAIP19Args = {
   caip2: CAIP2
   account: string

--- a/packages/caip/src/caip19/caip19.ts
+++ b/packages/caip/src/caip19/caip19.ts
@@ -5,6 +5,8 @@ import { ChainNamespace, ChainReference, toCAIP2 } from '../caip2/caip2'
 
 export type CAIP19 = string
 
+export type AssetId = string
+
 export enum AssetNamespace {
   CW20 = 'cw20',
   CW721 = 'cw721',

--- a/packages/caip/src/caip2/caip2.ts
+++ b/packages/caip/src/caip2/caip2.ts
@@ -4,6 +4,8 @@ import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 export type CAIP2 = string
 
+export type ChainId = string
+
 export enum ChainNamespace {
   Ethereum = 'eip155',
   Bitcoin = 'bip122',

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -4,6 +4,6 @@ import * as caip10 from './caip10/caip10'
 import * as caip19 from './caip19/caip19'
 
 export { adapters, caip2, caip19, caip10 }
-export { CAIP2 } from './caip2/caip2'
-export { CAIP10 } from './caip10/caip10'
-export { AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'
+export { ChainId, CAIP2 } from './caip2/caip2'
+export { AccountId, CAIP10 } from './caip10/caip10'
+export { AssetId, AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,4 +1,4 @@
-import { CAIP2 } from '@shapeshiftoss/caip'
+import { CAIP2, ChainId } from '@shapeshiftoss/caip'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 
 export type ChainAdapter<T extends ChainTypes> = {
@@ -7,9 +7,12 @@ export type ChainAdapter<T extends ChainTypes> = {
    */
   getType(): T
 
-  getCaip2(): CAIP2
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
+  getCaip2(): ChainId | CAIP2
 
-  getChainId(): CAIP2
+  getChainId(): ChainId | CAIP2
   /**
    * Get the balance of an address
    */

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -1,4 +1,4 @@
-import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { AssetId, CAIP2, CAIP19, ChainId } from '@shapeshiftoss/caip'
 import { CosmosSignTx } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -11,7 +11,7 @@ import { getStatus, getType, toRootDerivationPath } from '../utils'
 export type CosmosChainTypes = ChainTypes.Cosmos | ChainTypes.Osmosis
 
 export interface ChainAdapterArgs {
-  chainId?: CAIP2
+  chainId?: ChainId | CAIP2
   providers: {
     http: unchained.cosmos.V1Api
     ws: unchained.ws.Client<unchained.cosmos.Tx>
@@ -35,9 +35,9 @@ const transformValidator = (
 })
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {
-  protected readonly chainId: CAIP2
-  protected readonly assetId: CAIP19 // This is the caip19 for native token on the chain (ATOM/OSMO/etc)
-  protected readonly supportedChainIds: CAIP2[]
+  protected readonly chainId: ChainId | CAIP2
+  protected readonly assetId: AssetId | CAIP19 // This is the CAIP19/AssetId for native token on the chain (ATOM/OSMO/etc)
+  protected readonly supportedChainIds: ChainId[]
   protected readonly coinName: string
   protected readonly providers: {
     http: unchained.cosmos.V1Api
@@ -62,11 +62,11 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
 
   abstract getType(): T
 
-  getChainId(): CAIP2 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getCaip2(): CAIP2 {
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import { AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP2, caip2, caip19, ChainId } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -25,7 +25,7 @@ export interface ChainAdapterArgs {
     http: unchained.ethereum.V1Api
     ws: unchained.ws.Client<unchained.ethereum.ParsedTx>
   }
-  chainId?: CAIP2
+  chainId?: ChainId | CAIP2
 }
 
 async function getErc20Data(to: string, value: string, contractAddress?: string) {
@@ -46,7 +46,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     accountNumber: 0
   }
 
-  private readonly chainId: CAIP2 = 'eip155:1'
+  private readonly chainId: ChainId | CAIP2 = 'eip155:1'
 
   constructor(args: ChainAdapterArgs) {
     if (args.chainId) {
@@ -67,11 +67,14 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return ChainTypes.Ethereum
   }
 
-  getCaip2(): CAIP2 {
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getChainId(): CAIP2 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -1,4 +1,4 @@
-import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { AssetId, CAIP2, CAIP19, ChainId } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, HDWallet, PublicKey } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -26,7 +26,7 @@ export interface ChainAdapterArgs {
     ws: unchained.ws.Client<unchained.Tx>
   }
   coinName: string
-  chainId?: CAIP2
+  chainId?: ChainId | CAIP2
 }
 
 /**
@@ -36,10 +36,10 @@ export interface ChainAdapterArgs {
  * `export type UTXOChainTypes = ChainTypes.Bitcoin | ChainTypes.Litecoin`
  */
 export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChainAdapter<T> {
-  protected chainId: CAIP2
-  protected assetId: CAIP19
+  protected chainId: ChainId | CAIP2
+  protected assetId: AssetId | CAIP19
   protected coinName: string
-  protected readonly supportedChainIds: CAIP2[]
+  protected readonly supportedChainIds: ChainId | CAIP2[]
   protected readonly providers: {
     http: unchained.bitcoin.V1Api
     ws: unchained.ws.Client<unchained.Tx>
@@ -82,19 +82,25 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
 
   /* public methods */
 
-  getCaip2(): CAIP2 {
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
+  getCaip2(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getCaip19(): CAIP19 {
+  /**
+   * @deprecated - use `getChainId()` instead
+   */
+  getCaip19(): AssetId | CAIP19 {
     return this.assetId
   }
 
-  getChainId(): CAIP2 {
+  getChainId(): ChainId | CAIP2 {
     return this.chainId
   }
 
-  getAssetId(): CAIP19 {
+  getAssetId(): AssetId | CAIP19 {
     return this.assetId
   }
 

--- a/packages/swapper/src/swappers/zrx/ZrxBuildQuoteTx/ZrxBuildQuoteTx.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxBuildQuoteTx/ZrxBuildQuoteTx.test.ts
@@ -44,6 +44,8 @@ const mockQuoteResponse = {
   allowanceGrantRequired: true,
   buyAmount: undefined,
   buyAsset: {
+    assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    chainId: 'eip155:1',
     caip19: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     caip2: 'eip155:1',
     chain: 'ethereum',
@@ -80,6 +82,8 @@ const mockQuoteResponse = {
   receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
   sellAmount: '1000000000000000000',
   sellAsset: {
+    assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    chainId: 'eip155:1',
     caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
     caip2: 'eip155:1',
     chain: 'ethereum',

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -87,7 +87,7 @@ describe('ZrxSwapper', () => {
     const ethCAIP19 = 'eip155:1/slip44:60'
     expect(pair).toHaveLength(2)
     expect(pair[0]).toEqual(ethCAIP19)
-    expect(pair[1]).toEqual(FOX.caip19)
+    expect(pair[1]).toEqual(FOX.assetId)
   })
   it('calls getUsdRate on swapper.getUsdRate', async () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)

--- a/packages/swapper/src/swappers/zrx/utils/test-data/assets.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/assets.ts
@@ -2,6 +2,8 @@ import { AssetNamespace } from '@shapeshiftoss/caip'
 import { Asset, AssetDataSource, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 export const BTC: Asset = {
+  assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  chainId: 'bip122:000000000019d6689c085ae165831e93',
   caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   caip2: 'bip122:000000000019d6689c085ae165831e93',
   name: 'bitcoin',
@@ -23,6 +25,8 @@ export const BTC: Asset = {
 }
 
 export const WETH: Asset = {
+  assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  chainId: 'eip155:1',
   caip19: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   caip2: 'eip155:1',
   name: 'WETH',
@@ -45,6 +49,8 @@ export const WETH: Asset = {
 }
 
 export const FOX: Asset = {
+  assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+  chainId: 'eip155:1',
   caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
   caip2: 'eip155:1',
   name: 'FOX',

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -51,8 +51,10 @@ export enum AssetDataSource {
 // asset-service
 
 type AbstractAsset = {
-  caip19: string
+  assetId: string
   caip2: string
+  caip19: string
+  chainId: string
   chain: ChainTypes
   description?: string
   isTrustedDescription?: boolean


### PR DESCRIPTION
Depends on [PR #559](https://github.com/shapeshift/lib/pull/559). Change base branch to rename-caip-specifiers to scope the diff to the changes introduced by this commit only.