### PR TITLE
feat(caip): update caip imports

### DIFF
--- a/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
@@ -1,4 +1,4 @@
-import { caip19 } from '@shapeshiftoss/caip'
+import { fromCAIP19 } from '@shapeshiftoss/caip'
 import { BaseAsset, TokenAsset } from '@shapeshiftoss/types'
 import axios from 'axios'
 import chunk from 'lodash/chunk'
@@ -43,7 +43,7 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
   for (const [i, batch] of tokenBatches.entries()) {
     console.info(`processing batch ${i + 1} of ${tokenBatches.length}`)
     const promises = batch.map(async (token) => {
-      const { chain } = caip19.fromCAIP19(token.caip19)
+      const { chain } = fromCAIP19(token.caip19)
       const { info } = generateTrustWalletUrl({ chain, tokenId: token.tokenId })
       return axios.head(info) // return promise
     })
@@ -70,7 +70,7 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
         }
         return uniqueTokens[key] // token without modified icon
       } else {
-        const { chain } = caip19.fromCAIP19(uniqueTokens[key].caip19)
+        const { chain } = fromCAIP19(uniqueTokens[key].caip19)
         const { icon } = generateTrustWalletUrl({ chain, tokenId: uniqueTokens[key].tokenId })
         return { ...uniqueTokens[key], icon }
       }

--- a/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 
 export const getFoxyToken = (): TokenAsset[] => {
@@ -8,13 +8,13 @@ export const getFoxyToken = (): TokenAsset[] => {
   const assetReference = '0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3' // FOXy contract address
 
   const result: TokenAsset = {
-    caip19: caip19.toCAIP19({
+    caip19: toCAIP19({
       chain,
       network,
       assetNamespace,
       assetReference
     }),
-    caip2: caip2.toCAIP2({ chain, network }),
+    caip2: toCAIP2({ chain, network }),
     dataSource: AssetDataSource.CoinGecko,
     name: 'FOX Yieldy',
     precision: 18,

--- a/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 import axios from 'axios'
 import lodash from 'lodash'
@@ -49,8 +49,8 @@ export async function getUniswapTokens(): Promise<TokenAsset[]> {
       return acc
     }
     const result: TokenAsset = {
-      caip19: caip19.toCAIP19({ chain, network, assetNamespace, assetReference }),
-      caip2: caip2.toCAIP2({ chain, network }),
+      caip19: toCAIP19({ chain, network, assetNamespace, assetReference }),
+      caip2: toCAIP2({ chain, network }),
       dataSource: AssetDataSource.CoinGecko,
       name: token.name,
       precision: token.decimals,

--- a/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
 import { Token, Vault } from '@yfi/sdk'
 import toLower from 'lodash/toLower'
@@ -21,11 +21,11 @@ export const getYearnVaults = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: vault.symbol,
       tokenId: toLower(vault.address),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -50,11 +50,11 @@ export const getIronBankTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -79,11 +79,11 @@ export const getZapperTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
@@ -108,11 +108,11 @@ export const getUnderlyingVaultTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      caip2: caip2.toCAIP2({
+      caip2: toCAIP2({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET
       }),
-      caip19: caip19.toCAIP19({
+      caip19: toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -1,9 +1,4 @@
-import * as adapters from './adapters'
-import * as caip2 from './caip2/caip2'
-import * as caip10 from './caip10/caip10'
-import * as caip19 from './caip19/caip19'
-
-export { adapters, caip2, caip19, caip10 }
-export { ChainId, CAIP2 } from './caip2/caip2'
-export { AccountId, CAIP10 } from './caip10/caip10'
-export { AssetId, AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'
+export * as adapters from './adapters'
+export * from './caip2/caip2'
+export * from './caip10/caip10'
+export * from './caip19/caip19'

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,4 +1,4 @@
-import { CAIP2, caip2 } from '@shapeshiftoss/caip'
+import { CAIP2, isCAIP2 } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
@@ -117,7 +117,7 @@ export class ChainAdapterManager {
 
   async byChainId(chainId: CAIP2) {
     // this function acts like a validation function and throws if the check doesn't pass
-    caip2.isCAIP2(chainId)
+    isCAIP2(chainId)
 
     for (const [chain] of this.supported) {
       // byChain calls the factory function so we need to call it to create the instances

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, AssetReference, CAIP2, caip2, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP2, fromCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   BTCOutputAddressType,
@@ -50,12 +50,12 @@ export class ChainAdapter
     } else {
       this.chainId = this.supportedChainIds[0]
     }
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
     if (chain !== ChainTypes.Bitcoin) {
       throw new Error('chainId must be a bitcoin chain type')
     }
     this.coinName = args.coinName
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -1,4 +1,11 @@
-import { AssetNamespace, AssetReference, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
+import {
+  AssetNamespace,
+  AssetReference,
+  CAIP19,
+  ChainReference,
+  fromCAIP2,
+  toCAIP19
+} from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   CosmosSignTx,
@@ -30,9 +37,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
 
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,
@@ -153,7 +160,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -225,7 +232,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -296,7 +303,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -361,7 +368,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }
@@ -440,7 +447,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
       const txToSign: CosmosSignTx = {
         addressNList,
         tx: utx,
-        chain_id: caip2.ChainReference.CosmosHubMainnet,
+        chain_id: ChainReference.CosmosHubMainnet,
         account_number: account.chainSpecific.accountNumber,
         sequence: account.chainSpecific.sequence
       }

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, AssetReference, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, AssetReference, CAIP19, fromCAIP2, toCAIP19 } from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, OsmosisSignTx, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 
@@ -23,9 +23,9 @@ export class ChainAdapter
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = caip2.fromCAIP2(this.chainId)
+    const { chain, network } = fromCAIP2(this.chainId)
 
-    this.assetId = caip19.toCAIP19({
+    this.assetId = toCAIP19({
       chain,
       network,
       assetNamespace: AssetNamespace.Slip44,

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,5 +1,13 @@
 import { Contract } from '@ethersproject/contracts'
-import { AssetNamespace, AssetReference, CAIP2, caip2, caip19, ChainId } from '@shapeshiftoss/caip'
+import {
+  AssetNamespace,
+  AssetReference,
+  CAIP2,
+  ChainId,
+  fromCAIP2,
+  fromCAIP19,
+  toCAIP19
+} from '@shapeshiftoss/caip'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -51,7 +59,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
   constructor(args: ChainAdapterArgs) {
     if (args.chainId) {
       try {
-        const { chain } = caip2.fromCAIP2(args.chainId)
+        const { chain } = fromCAIP2(args.chainId)
         if (chain !== ChainTypes.Ethereum) {
           throw new Error()
         }
@@ -81,7 +89,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
   async getAccount(pubkey: string): Promise<chainAdapters.Account<ChainTypes.Ethereum>> {
     try {
       const caip = this.getCaip2()
-      const { chain, network } = caip2.fromCAIP2(caip)
+      const { chain, network } = fromCAIP2(caip)
       const { data } = await this.providers.http.getAccount({ pubkey })
 
       const balance = bnOrZero(data.balance).plus(bnOrZero(data.unconfirmedBalance))
@@ -89,7 +97,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
       return {
         balance: balance.toString(),
         caip2: caip,
-        caip19: caip19.toCAIP19({
+        caip19: toCAIP19({
           chain,
           network,
           assetNamespace: AssetNamespace.Slip44,
@@ -100,7 +108,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
           nonce: data.nonce,
           tokens: data.tokens.map((token) => ({
             balance: token.balance,
-            caip19: caip19.toCAIP19({
+            caip19: toCAIP19({
               chain,
               network,
               assetNamespace: getAssetNamespace(token.type),
@@ -164,9 +172,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
         if (isErc20Send) {
           if (!erc20ContractAddress) throw new Error('no token address')
           const erc20Balance = account?.chainSpecific?.tokens?.find((token) => {
-            return (
-              caip19.fromCAIP19(token.caip19).assetReference === erc20ContractAddress.toLowerCase()
-            )
+            return fromCAIP19(token.caip19).assetReference === erc20ContractAddress.toLowerCase()
           })?.balance
           if (!erc20Balance) throw new Error('no balance')
           tx.value = erc20Balance
@@ -262,7 +268,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     if (sendMax && isErc20Send && contractAddress) {
       const account = await this.getAccount(from)
       const erc20Balance = account?.chainSpecific?.tokens?.find((token) => {
-        const { assetReference } = caip19.fromCAIP19(token.caip19)
+        const { assetReference } = fromCAIP19(token.caip19)
         return assetReference === contractAddress.toLowerCase()
       })?.balance
       if (!erc20Balance) throw new Error('no balance')

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainReference } from '@shapeshiftoss/caip/dist/caip2/caip2'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
@@ -1084,7 +1084,7 @@ export class FoxyApi {
     const assetNamespace = AssetNamespace.ERC20
     const assetReference = tokenContractAddress
     // foxy assetId
-    const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference })
+    const assetId = toCAIP19({ chain, network, assetNamespace, assetReference })
 
     const results = await Promise.allSettled(
       events.map(async (event) => {

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -1,4 +1,4 @@
-import { caip2 } from '@shapeshiftoss/caip'
+import { toCAIP2 } from '@shapeshiftoss/caip'
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
@@ -45,7 +45,7 @@ const main = async (): Promise<void> => {
 
   const api = new FoxyApi({
     adapter: await adapterManager.byChainId(
-      caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+      toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
     ),
     providerUrl: process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
     foxyAddresses: foxyAddresses

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
 import { YearnTokenMarketCapService } from './yearn-tokens'
@@ -68,13 +68,13 @@ describe('yearn token market service', () => {
 
     it('can map yearn to caip ids', async () => {
       const result = await yearnTokenMarketCapService.findAll()
-      const yvBtcCaip19 = caip19.toCAIP19({
+      const yvBtcCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: mockYearnTokenRestData[0].address.toLowerCase()
       })
-      const yvDaiCaip19 = caip19.toCAIP19({
+      const yvDaiCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -1,4 +1,4 @@
-import { adapters, AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { adapters, AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -56,7 +56,7 @@ export class YearnTokenMarketCapService implements MarketService {
       const tokens = uniqueTokens.slice(0, argsToUse.count)
 
       return tokens.reduce((acc, token) => {
-        const _caip19: string = caip19.toCAIP19({
+        const _caip19: string = toCAIP19({
           chain: ChainTypes.Ethereum,
           network: NetworkTypes.MAINNET,
           assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -1,4 +1,4 @@
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import { ChainTypes, HistoryTimeframe, NetworkTypes } from '@shapeshiftoss/types'
 
 import { YearnVaultMarketCapService } from './yearn-vaults'
@@ -37,7 +37,7 @@ describe('yearn market service', () => {
       const yvBTCAddress = '0x19D3364A399d251E894aC732651be8B0E4e85001'
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result)[0]).toEqual(
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: NetworkTypes.MAINNET,
           assetNamespace: AssetNamespace.ERC20,
@@ -72,13 +72,13 @@ describe('yearn market service', () => {
 
     it('can map yearn to caip ids', async () => {
       const result = await yearnVaultMarketCapService.findAll()
-      const yvBtcCaip19 = caip19.toCAIP19({
+      const yvBtcCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,
         assetReference: mockYearnVaultRestData[0].address.toLowerCase()
       })
-      const yvDaiCaip19 = caip19.toCAIP19({
+      const yvDaiCaip19 = toCAIP19({
         chain: ChainTypes.Ethereum,
         network: NetworkTypes.MAINNET,
         assetNamespace: AssetNamespace.ERC20,

--- a/packages/market-service/src/yearn/yearn-vaults.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.ts
@@ -1,4 +1,4 @@
-import { adapters, AssetNamespace, caip19 } from '@shapeshiftoss/caip'
+import { adapters, AssetNamespace, toCAIP19 } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -54,7 +54,7 @@ export class YearnVaultMarketCapService implements MarketService {
             : -1
         )
         .reduce((acc, yearnItem) => {
-          const assetId = caip19.toCAIP19({
+          const assetId = toCAIP19({
             chain: ChainTypes.Ethereum,
             network: NetworkTypes.MAINNET,
             assetNamespace: AssetNamespace.ERC20,

--- a/packages/swapper/src/swappers/zrx/getZrxSendMaxAmount/getZrxSendMaxAmount.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxSendMaxAmount/getZrxSendMaxAmount.ts
@@ -1,4 +1,4 @@
-import { caip19 } from '@shapeshiftoss/caip'
+import { fromCAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes, SendMaxAmountInput } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 
@@ -33,7 +33,7 @@ export async function getZrxSendMaxAmount(
   let balance: string | undefined
   if (tokenId) {
     balance = account.chainSpecific.tokens?.find((token: chainAdapters.AssetBalance) => {
-      return caip19.fromCAIP19(token.caip19).assetReference === tokenId.toLowerCase()
+      return fromCAIP19(token.caip19).assetReference === tokenId.toLowerCase()
     })?.balance
   } else {
     balance = account.balance


### PR DESCRIPTION
This updates the imports from the caip package to use the new flattened imports.
To be opened after https://github.com/shapeshift/lib/pull/560 is merged and `@shapeshiftoss/caip@3.0.0` is published. 