### PR TITLE
chore(release): change refactor commits to trigger a patch release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,6 +7,7 @@
       "preset": "angular",
       "releaseRules": [
         { "type": "chore", "release": "patch" },
+        { "type": "refactor", "release": "patch" },
         { "type": "test", "release": "patch" }
       ]
     }],


### PR DESCRIPTION
Currently, commits prefixed with `refactor` do not trigger a release. This PR changes that so that refactor commits will trigger a `patch` release.