### PR TITLE
feat(caip): add caip-related utils/constants to caip package

### DIFF
--- a/packages/caip/src/caip19/caip19.ts
+++ b/packages/caip/src/caip19/caip19.ts
@@ -1,7 +1,13 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
 import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 
-import { ChainNamespace, ChainReference, toCAIP2 } from '../caip2/caip2'
+import {
+  ChainNamespace,
+  chainNamespaceToChainType,
+  ChainReference,
+  chainReferenceToNetworkType,
+  toCAIP2
+} from '../caip2/caip2'
 
 /**
  * @deprecated - Temporarily left in place for backwards compatibility, to be replaced with AssetId
@@ -51,24 +57,6 @@ const validAssetNamespaces = Object.freeze({
     AssetNamespace.NATIVE,
     AssetNamespace.Slip44
   ]
-})
-
-const chainReferenceToNetworkType: Record<string, NetworkTypes> = Object.freeze({
-  [ChainReference.BitcoinMainnet]: NetworkTypes.MAINNET,
-  [ChainReference.BitcoinTestnet]: NetworkTypes.TESTNET,
-  [ChainReference.EthereumMainnet]: NetworkTypes.MAINNET,
-  [ChainReference.EthereumRopsten]: NetworkTypes.ETH_ROPSTEN,
-  [ChainReference.EthereumRinkeby]: NetworkTypes.ETH_RINKEBY,
-  [ChainReference.CosmosHubMainnet]: NetworkTypes.COSMOSHUB_MAINNET,
-  [ChainReference.CosmosHubVega]: NetworkTypes.COSMOSHUB_VEGA,
-  [ChainReference.OsmosisMainnet]: NetworkTypes.OSMOSIS_MAINNET,
-  [ChainReference.OsmosisTestnet]: NetworkTypes.OSMOSIS_TESTNET
-})
-
-const chainNamespaceToChainType: Record<string, ChainTypes> = Object.freeze({
-  [ChainNamespace.Bitcoin]: ChainTypes.Bitcoin,
-  [ChainNamespace.Ethereum]: ChainTypes.Ethereum,
-  [ChainNamespace.Cosmos]: ChainTypes.Cosmos
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -139,8 +127,8 @@ export const fromCAIP19 = (caip19: string): FromCAIP19Return => {
 
   // We're okay casting these strings to enums because we check to make sure
   // they are valid enum values
-  let chain: ChainTypes = chainNamespaceToChainType[matches[1]]
-  const network = chainReferenceToNetworkType[matches[2]]
+  let chain: ChainTypes = chainNamespaceToChainType[matches[1] as ChainNamespace]
+  const network = chainReferenceToNetworkType[matches[2] as ChainReference]
   const assetNamespace = stringToEnum<AssetNamespace>(AssetNamespace, matches[3])
   let assetReference = matches[4]
 

--- a/packages/caip/src/caip2/caip2.ts
+++ b/packages/caip/src/caip2/caip2.ts
@@ -1,6 +1,7 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 
 import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import invert from 'lodash/invert'
 
 /**
  * @deprecated - Temporarily left in place for backwards compatibility, to be replaced with ChainId
@@ -237,3 +238,26 @@ export const isCAIP2: IsCAIP2 = (caip2) => {
 
   throw new Error(`isCAIP2: invalid caip2 ${caip2}`)
 }
+
+export const chainReferenceToNetworkType: Record<ChainReference, NetworkTypes> = Object.freeze({
+  [ChainReference.BitcoinMainnet]: NetworkTypes.MAINNET,
+  [ChainReference.BitcoinTestnet]: NetworkTypes.TESTNET,
+  [ChainReference.EthereumMainnet]: NetworkTypes.MAINNET,
+  [ChainReference.EthereumRopsten]: NetworkTypes.ETH_ROPSTEN,
+  [ChainReference.EthereumRinkeby]: NetworkTypes.ETH_RINKEBY,
+  [ChainReference.CosmosHubMainnet]: NetworkTypes.COSMOSHUB_MAINNET,
+  [ChainReference.CosmosHubVega]: NetworkTypes.COSMOSHUB_VEGA,
+  [ChainReference.OsmosisMainnet]: NetworkTypes.OSMOSIS_MAINNET,
+  [ChainReference.OsmosisTestnet]: NetworkTypes.OSMOSIS_TESTNET
+})
+
+export const networkTypeToChainReference = invert(chainReferenceToNetworkType) as Record<
+  NetworkTypes,
+  ChainReference
+>
+
+export const chainNamespaceToChainType: Record<ChainNamespace, ChainTypes> = Object.freeze({
+  [ChainNamespace.Bitcoin]: ChainTypes.Bitcoin,
+  [ChainNamespace.Ethereum]: ChainTypes.Ethereum,
+  [ChainNamespace.Cosmos]: ChainTypes.Cosmos
+})

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -5,7 +5,7 @@ import {
   btcAssetId,
   btcChainId,
   ethChainId,
-  getReferenceFromChainId
+  getChainReferenceFromChainId
 } from './utils'
 
 describe('accountIdToChainId', () => {
@@ -52,25 +52,23 @@ describe('assetIdtoChainId', () => {
   })
 })
 
-describe('getReferenceFromChainId', () => {
+describe('getChainReferenceFromChainId', () => {
   it('returns the reference from a caip2 string with a valid reference', () => {
     const validCaip2 = 'cosmos:cosmoshub-4'
     const validCaip2Reference = 'cosmoshub-4'
 
-    const reference = getReferenceFromChainId(validCaip2)
+    const reference = getChainReferenceFromChainId(validCaip2)
     expect(reference).toEqual(validCaip2Reference)
   })
   it('returns undefined from an empty caip2 string', () => {
     const invalidCaip2 = ''
 
-    const reference = getReferenceFromChainId(invalidCaip2)
-    expect(reference).toBeUndefined()
+    expect(() => getChainReferenceFromChainId(invalidCaip2)).toThrow()
   })
 
   it('returns undefined from an invalid caip2 string', () => {
     const invalidCaip2 = 'foobar'
 
-    const reference = getReferenceFromChainId(invalidCaip2)
-    expect(reference).toBeUndefined()
+    expect(() => getChainReferenceFromChainId(invalidCaip2)).toThrow()
   })
 })

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -1,0 +1,53 @@
+import {
+  accountIdToChainId,
+  accountIdToSpecifier,
+  assetIdtoChainId,
+  btcChainId,
+  ethChainId
+} from './utils'
+
+describe('accountIdToChainId', () => {
+  it('can get eth caip2 from accountId', () => {
+    const accountId = 'eip155:1:0xdef1cafe'
+    const chainId = accountIdToChainId(accountId)
+    expect(chainId).toEqual(ethChainId)
+  })
+
+  it('can get btc caip2 from accountId', () => {
+    const accountId = 'bip122:000000000019d6689c085ae165831e93:xpubfoobarbaz'
+    const chainId = accountIdToChainId(accountId)
+    expect(chainId).toEqual(btcChainId)
+  })
+})
+
+describe('accountIdToSpecifier', () => {
+  it('can get eth address from accountId', () => {
+    const address = '0xdef1cafe'
+    const accountId = 'eip155:1:0xdef1cafe'
+    const result = accountIdToSpecifier(accountId)
+    expect(result).toEqual(address)
+  })
+
+  it('can get xpub form accountId', () => {
+    const xpub = 'xpubfoobarbaz'
+    const accountId = 'bip122:000000000019d6689c085ae165831e93:xpubfoobarbaz'
+    const result = accountIdToSpecifier(accountId)
+    expect(result).toEqual(xpub)
+  })
+})
+
+describe('assetIdtoChainId', () => {
+  it('returns a ETH chainId for a given ETH assetId', () => {
+    const ethAssetId = 'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb'
+    const chainId = 'eip155:1'
+    const result = assetIdtoChainId(ethAssetId)
+    expect(result).toEqual(chainId)
+  })
+
+  it('returns a BTC chainId for a given BTC assetId', () => {
+    const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+    const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
+    const result = assetIdtoChainId(btcAssetId)
+    expect(result).toEqual(btcChainId)
+  })
+})

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -5,7 +5,7 @@ import {
   btcAssetId,
   btcChainId,
   ethChainId,
-  getCaip2Reference
+  getReferenceFromChainId
 } from './utils'
 
 describe('accountIdToChainId', () => {
@@ -52,25 +52,25 @@ describe('assetIdtoChainId', () => {
   })
 })
 
-describe('getCaip2Reference', () => {
+describe('getReferenceFromChainId', () => {
   it('returns the reference from a caip2 string with a valid reference', () => {
     const validCaip2 = 'cosmos:cosmoshub-4'
     const validCaip2Reference = 'cosmoshub-4'
 
-    const reference = getCaip2Reference(validCaip2)
+    const reference = getReferenceFromChainId(validCaip2)
     expect(reference).toEqual(validCaip2Reference)
   })
   it('returns undefined from an empty caip2 string', () => {
     const invalidCaip2 = ''
 
-    const reference = getCaip2Reference(invalidCaip2)
+    const reference = getReferenceFromChainId(invalidCaip2)
     expect(reference).toBeUndefined()
   })
 
   it('returns undefined from an invalid caip2 string', () => {
     const invalidCaip2 = 'foobar'
 
-    const reference = getCaip2Reference(invalidCaip2)
+    const reference = getReferenceFromChainId(invalidCaip2)
     expect(reference).toBeUndefined()
   })
 })

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -1,7 +1,7 @@
 import {
   accountIdToChainId,
   accountIdToSpecifier,
-  assetIdtoChainId,
+  assetIdToChainId,
   btcAssetId,
   btcChainId,
   ethChainId,
@@ -9,13 +9,13 @@ import {
 } from './utils'
 
 describe('accountIdToChainId', () => {
-  it('can get eth caip2 from accountId', () => {
+  it('can get eth chainId from accountId', () => {
     const accountId = 'eip155:1:0xdef1cafe'
     const chainId = accountIdToChainId(accountId)
     expect(chainId).toEqual(ethChainId)
   })
 
-  it('can get btc caip2 from accountId', () => {
+  it('can get btc chainId from accountId', () => {
     const accountId = 'bip122:000000000019d6689c085ae165831e93:xpubfoobarbaz'
     const chainId = accountIdToChainId(accountId)
     expect(chainId).toEqual(btcChainId)
@@ -30,7 +30,7 @@ describe('accountIdToSpecifier', () => {
     expect(result).toEqual(address)
   })
 
-  it('can get xpub form accountId', () => {
+  it('can get xpub from accountId', () => {
     const xpub = 'xpubfoobarbaz'
     const accountId = 'bip122:000000000019d6689c085ae165831e93:xpubfoobarbaz'
     const result = accountIdToSpecifier(accountId)
@@ -38,37 +38,37 @@ describe('accountIdToSpecifier', () => {
   })
 })
 
-describe('assetIdtoChainId', () => {
+describe('assetIdToChainId', () => {
   it('returns a ETH chainId for a given ETH assetId', () => {
     const ethAssetId = 'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb'
     const chainId = 'eip155:1'
-    const result = assetIdtoChainId(ethAssetId)
+    const result = assetIdToChainId(ethAssetId)
     expect(result).toEqual(chainId)
   })
 
   it('returns a BTC chainId for a given BTC assetId', () => {
-    const result = assetIdtoChainId(btcAssetId)
+    const result = assetIdToChainId(btcAssetId)
     expect(result).toEqual(btcChainId)
   })
 })
 
 describe('getChainReferenceFromChainId', () => {
-  it('returns the reference from a caip2 string with a valid reference', () => {
-    const validCaip2 = 'cosmos:cosmoshub-4'
-    const validCaip2Reference = 'cosmoshub-4'
+  it('returns the reference from a chainId string with a valid reference', () => {
+    const validChainId = 'cosmos:cosmoshub-4'
+    const validChainIdReference = 'cosmoshub-4'
 
-    const reference = getChainReferenceFromChainId(validCaip2)
-    expect(reference).toEqual(validCaip2Reference)
+    const reference = getChainReferenceFromChainId(validChainId)
+    expect(reference).toEqual(validChainIdReference)
   })
-  it('returns undefined from an empty caip2 string', () => {
-    const invalidCaip2 = ''
+  it('returns undefined from an empty chainId string', () => {
+    const invalidChainId = ''
 
-    expect(() => getChainReferenceFromChainId(invalidCaip2)).toThrow()
+    expect(() => getChainReferenceFromChainId(invalidChainId)).toThrow()
   })
 
-  it('returns undefined from an invalid caip2 string', () => {
-    const invalidCaip2 = 'foobar'
+  it('returns undefined from an invalid chainId string', () => {
+    const invalidChainId = 'foobar'
 
-    expect(() => getChainReferenceFromChainId(invalidCaip2)).toThrow()
+    expect(() => getChainReferenceFromChainId(invalidChainId)).toThrow()
   })
 })

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -2,6 +2,7 @@ import {
   accountIdToChainId,
   accountIdToSpecifier,
   assetIdtoChainId,
+  btcAssetId,
   btcChainId,
   ethChainId
 } from './utils'
@@ -45,8 +46,6 @@ describe('assetIdtoChainId', () => {
   })
 
   it('returns a BTC chainId for a given BTC assetId', () => {
-    const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
-    const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
     const result = assetIdtoChainId(btcAssetId)
     expect(result).toEqual(btcChainId)
   })

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -4,7 +4,8 @@ import {
   assetIdtoChainId,
   btcAssetId,
   btcChainId,
-  ethChainId
+  ethChainId,
+  getCaip2Reference
 } from './utils'
 
 describe('accountIdToChainId', () => {
@@ -48,5 +49,28 @@ describe('assetIdtoChainId', () => {
   it('returns a BTC chainId for a given BTC assetId', () => {
     const result = assetIdtoChainId(btcAssetId)
     expect(result).toEqual(btcChainId)
+  })
+})
+
+describe('getCaip2Reference', () => {
+  it('returns the reference from a caip2 string with a valid reference', () => {
+    const validCaip2 = 'cosmos:cosmoshub-4'
+    const validCaip2Reference = 'cosmoshub-4'
+
+    const reference = getCaip2Reference(validCaip2)
+    expect(reference).toEqual(validCaip2Reference)
+  })
+  it('returns undefined from an empty caip2 string', () => {
+    const invalidCaip2 = ''
+
+    const reference = getCaip2Reference(invalidCaip2)
+    expect(reference).toBeUndefined()
+  })
+
+  it('returns undefined from an invalid caip2 string', () => {
+    const invalidCaip2 = 'foobar'
+
+    const reference = getCaip2Reference(invalidCaip2)
+    expect(reference).toBeUndefined()
   })
 })

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -1,4 +1,4 @@
-import { ChainId } from './caip2/caip2'
+import { CAIP2, ChainId } from './caip2/caip2'
 import { AssetId } from './caip19/caip19'
 
 export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
@@ -34,3 +34,9 @@ export const accountIdToSpecifier = (accountId: AccountSpecifier): string => {
   // in the case of utxo based chains, this is an x/y/zpub
   return accountId.split(':')[2] ?? ''
 }
+
+// TODO(gomes): Do we still want to call this "reference" or do we want a higher-level naming for this?
+// We're already using accountId, assetId, and chainId higher-level terminologies vs. the specc-y ones from CAIP
+export const getCaip2Reference = (caip2: CAIP2) =>
+  caip2.match(/^(?<caip2Namespace>[-a-z0-9]{3,8}):(?<caip2Reference>[-a-zA-Z0-9]{1,32})$/)?.groups
+    ?.caip2Reference

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -1,5 +1,10 @@
 import { ChainId } from './caip2/caip2'
 import { AssetId } from './caip19/caip19'
+
+export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+export const ethAssetId = 'eip155:1/slip44:60'
+export const cosmosAssetId = 'cosmos:cosmoshub-4/slip44:118'
+
 export const ethChainId = 'eip155:1'
 export const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
 export const cosmosChainId = 'cosmos:cosmoshub-4'

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -1,4 +1,5 @@
-import { CAIP2, ChainId } from './caip2/caip2'
+import { ChainId, fromCAIP2, networkTypeToChainReference } from './caip2/caip2'
+import { AccountId, fromCAIP10 } from './caip10/caip10'
 import { AssetId } from './caip19/caip19'
 
 export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
@@ -29,14 +30,13 @@ export const accountIdToChainId = (accountId: AccountSpecifier): ChainId => {
   return `${chain}:${network}`
 }
 
-export const accountIdToSpecifier = (accountId: AccountSpecifier): string => {
-  // in the case of account based chains (eth), this is an address
-  // in the case of utxo based chains, this is an x/y/zpub
-  return accountId.split(':')[2] ?? ''
+export const accountIdToSpecifier = (accountId: AccountId): string => {
+  const { account } = fromCAIP10(accountId)
+  return account
 }
 
-// TODO(gomes): Do we still want to call this "reference" or do we want a higher-level naming for this?
-// We're already using accountId, assetId, and chainId higher-level terminologies vs. the specc-y ones from CAIP
-export const getReferenceFromChainId = (caip2: CAIP2) =>
-  caip2.match(/^(?<caip2Namespace>[-a-z0-9]{3,8}):(?<caip2Reference>[-a-zA-Z0-9]{1,32})$/)?.groups
-    ?.caip2Reference
+export const getChainReferenceFromChainId = (chainId: ChainId) => {
+  const { network } = fromCAIP2(chainId)
+  const chainReference = networkTypeToChainReference[network]
+  return chainReference
+}

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -1,0 +1,31 @@
+import { ChainId } from './caip2/caip2'
+import { AssetId } from './caip19/caip19'
+export const ethChainId = 'eip155:1'
+export const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
+export const cosmosChainId = 'cosmos:cosmoshub-4'
+
+export const chainIdToAssetId: Record<string, string> = {
+  [ethChainId]: 'eip155:1/slip44:60',
+  [btcChainId]: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  [cosmosChainId]: 'cosmos:cosmoshub-4/slip44:118'
+}
+// TODO(gomes): this probably needs better terminology than "supported"?
+const supportedChainIds = [ethChainId, btcChainId, cosmosChainId] as const
+
+export type ChainIdType = typeof supportedChainIds[number]
+export type AccountSpecifier = string
+
+export const assetIdtoChainId = (assetId: AssetId): ChainIdType =>
+  assetId.split('/')[0] as ChainIdType
+
+export const accountIdToChainId = (accountId: AccountSpecifier): ChainId => {
+  // accountId = 'eip155:1:0xdef1...cafe
+  const [chain, network] = accountId.split(':')
+  return `${chain}:${network}`
+}
+
+export const accountIdToSpecifier = (accountId: AccountSpecifier): string => {
+  // in the case of account based chains (eth), this is an address
+  // in the case of utxo based chains, this is an x/y/zpub
+  return accountId.split(':')[2] ?? ''
+}

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -24,4 +24,5 @@ export const accountIdToChainId = (accountId: AccountId): ChainId => fromCAIP10(
 
 export const accountIdToSpecifier = (accountId: AccountId): string => fromCAIP10(accountId).account
 
-export const getChainReferenceFromChainId = (chainId: ChainId) => networkTypeToChainReference[fromCAIP2(chainId).network]
+export const getChainReferenceFromChainId = (chainId: ChainId) =>
+  networkTypeToChainReference[fromCAIP2(chainId).network]

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -17,20 +17,11 @@ export const chainIdToAssetId: Record<string, string> = {
 }
 export const assetIdToChainId = (assetId: AssetId): string => {
   const { chain, network } = fromCAIP19(assetId)
-  const chainId = toCAIP2({ chain, network })
-
-  return chainId
+  return toCAIP2({ chain, network })
 }
 
 export const accountIdToChainId = (accountId: AccountId): ChainId => fromCAIP10(accountId).caip2
 
-export const accountIdToSpecifier = (accountId: AccountId): string => {
-  const { account } = fromCAIP10(accountId)
-  return account
-}
+export const accountIdToSpecifier = (accountId: AccountId): string => fromCAIP10(accountId).account
 
-export const getChainReferenceFromChainId = (chainId: ChainId) => {
-  const { network } = fromCAIP2(chainId)
-  const chainReference = networkTypeToChainReference[network]
-  return chainReference
-}
+export const getChainReferenceFromChainId = (chainId: ChainId) => networkTypeToChainReference[fromCAIP2(chainId).network]

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -1,6 +1,6 @@
-import { ChainId, fromCAIP2, networkTypeToChainReference } from './caip2/caip2'
+import { ChainId, fromCAIP2, networkTypeToChainReference, toCAIP2 } from './caip2/caip2'
 import { AccountId, fromCAIP10 } from './caip10/caip10'
-import { AssetId } from './caip19/caip19'
+import { AssetId, fromCAIP19 } from './caip19/caip19'
 
 export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
 export const ethAssetId = 'eip155:1/slip44:60'
@@ -15,19 +15,17 @@ export const chainIdToAssetId: Record<string, string> = {
   [btcChainId]: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   [cosmosChainId]: 'cosmos:cosmoshub-4/slip44:118'
 }
-// TODO(gomes): this probably needs better terminology than "supported"?
-const supportedChainIds = [ethChainId, btcChainId, cosmosChainId] as const
+export const assetIdtoChainId = (assetId: AssetId): string => {
+  const { chain, network } = fromCAIP19(assetId)
+  const chainId = toCAIP2({ chain, network })
 
-export type ChainIdType = typeof supportedChainIds[number]
-export type AccountSpecifier = string
+  return chainId
+}
 
-export const assetIdtoChainId = (assetId: AssetId): ChainIdType =>
-  assetId.split('/')[0] as ChainIdType
-
-export const accountIdToChainId = (accountId: AccountSpecifier): ChainId => {
+export const accountIdToChainId = (accountId: AccountId): ChainId => {
   // accountId = 'eip155:1:0xdef1...cafe
-  const [chain, network] = accountId.split(':')
-  return `${chain}:${network}`
+  const { caip2 } = fromCAIP10(accountId)
+  return caip2
 }
 
 export const accountIdToSpecifier = (accountId: AccountId): string => {

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -15,18 +15,14 @@ export const chainIdToAssetId: Record<string, string> = {
   [btcChainId]: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   [cosmosChainId]: 'cosmos:cosmoshub-4/slip44:118'
 }
-export const assetIdtoChainId = (assetId: AssetId): string => {
+export const assetIdToChainId = (assetId: AssetId): string => {
   const { chain, network } = fromCAIP19(assetId)
   const chainId = toCAIP2({ chain, network })
 
   return chainId
 }
 
-export const accountIdToChainId = (accountId: AccountId): ChainId => {
-  // accountId = 'eip155:1:0xdef1...cafe
-  const { caip2 } = fromCAIP10(accountId)
-  return caip2
-}
+export const accountIdToChainId = (accountId: AccountId): ChainId => fromCAIP10(accountId).caip2
 
 export const accountIdToSpecifier = (accountId: AccountId): string => {
   const { account } = fromCAIP10(accountId)

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -10,7 +10,7 @@ export const ethChainId = 'eip155:1'
 export const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
 export const cosmosChainId = 'cosmos:cosmoshub-4'
 
-export const chainIdToAssetId: Record<string, string> = {
+export const chainIdToAssetId: Record<ChainId, AssetId> = {
   [ethChainId]: 'eip155:1/slip44:60',
   [btcChainId]: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
   [cosmosChainId]: 'cosmos:cosmoshub-4/slip44:118'

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -37,6 +37,6 @@ export const accountIdToSpecifier = (accountId: AccountSpecifier): string => {
 
 // TODO(gomes): Do we still want to call this "reference" or do we want a higher-level naming for this?
 // We're already using accountId, assetId, and chainId higher-level terminologies vs. the specc-y ones from CAIP
-export const getCaip2Reference = (caip2: CAIP2) =>
+export const getReferenceFromChainId = (caip2: CAIP2) =>
   caip2.match(/^(?<caip2Namespace>[-a-z0-9]{3,8}):(?<caip2Reference>[-a-zA-Z0-9]{1,32})$/)?.groups
     ?.caip2Reference


### PR DESCRIPTION
This moves the CAIP-related utils as well as related constants from web.

### Issue

closes #557

### Notes

This only moves utils that are strictly related to CAIPs.
If the input/output of such util is something from a domain-specific logic that's not *strictly* related to CAIPs (e.g account type, label, UTXO params etc...), it should not belong here and should stay defined where it is currently 