### PR TITLE
fix: unbreak lib build

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@ethersproject/providers": "^5.5.2",
     "@shapeshiftoss/caip": "^2.0.0",
-    "@shapeshiftoss/types": "^2.1.0",
+    "@shapeshiftoss/types": "^3.0.0",
     "@types/lodash": "^4.14.172",
     "@yfi/sdk": "^1.0.30",
     "dotenv": "^14.3.0",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -48,7 +48,7 @@
     "@shapeshiftoss/caip": "^2.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
-    "@shapeshiftoss/types": "^2.1.0",
+    "@shapeshiftoss/types": "^3.0.0",
     "@shapeshiftoss/unchained-client": "^6.6.0",
     "@types/bs58check": "^2.1.0",
     "@types/multicoin-address-validator": "^0.5.0"

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -30,7 +30,8 @@ const transformValidator = (
   address: validator.address,
   moniker: validator.moniker,
   commission: validator.commission.rate,
-  apr: validator.apr
+  apr: validator.apr,
+  tokens: validator.tokens
 })
 
 export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implements IChainAdapter<T> {

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -45,6 +45,6 @@
     "@shapeshiftoss/caip": "^2.1.2",
     "@shapeshiftoss/chain-adapters": "^2.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
-    "@shapeshiftoss/types": "^2.1.0"
+    "@shapeshiftoss/types": "^3.0.0"
   }
 }

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -55,7 +55,7 @@ import {
 export * from './foxy-types'
 
 export type ConstructorArgs = {
-  adapter: ChainAdapter<ChainTypes>
+  adapter: ChainAdapter<ChainTypes.Ethereum>
   providerUrl: string
   foxyAddresses: FoxyAddressesType
   network?:
@@ -82,7 +82,7 @@ export const transformData = ({ tvl, apy, expired, ...contractData }: FoxyOpport
 const TOKE_IPFS_URL = 'https://ipfs.tokemaklabs.xyz/ipfs'
 
 export class FoxyApi {
-  public adapter: ChainAdapter<ChainTypes>
+  public adapter: ChainAdapter<ChainTypes.Ethereum>
   public provider: HttpProvider
   private providerUrl: string
   public jsonRpcProvider: JsonRpcProvider

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -1,5 +1,5 @@
 import { caip2 } from '@shapeshiftoss/caip'
-import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
+import { ChainAdapter, ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
@@ -44,9 +44,9 @@ const main = async (): Promise<void> => {
   const liquidityReserveContractAddress = foxyAddresses[0].liquidityReserve
 
   const api = new FoxyApi({
-    adapter: await adapterManager.byChainId(
+    adapter: (await adapterManager.byChainId(
       caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
-    ),
+    )) as ChainAdapter<ChainTypes.Ethereum>,
     providerUrl: process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
     foxyAddresses: foxyAddresses
   })

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -40,8 +40,8 @@
     "@shapeshiftoss/types": "^2.1.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/chain-adapters": "^2.0.0",
+    "@shapeshiftoss/chain-adapters": "^2.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
-    "@shapeshiftoss/types": "^2.1.0"
+    "@shapeshiftoss/types": "^3.0.0"
   }
 }

--- a/packages/market-service/src/market-service-manager.ts
+++ b/packages/market-service/src/market-service-manager.ts
@@ -6,7 +6,7 @@ import {
   PriceHistoryArgs,
   PriceHistoryType
 } from '@shapeshiftoss/types'
-import { FindAllMarketArgs } from '@shapeshiftoss/types/src'
+import { FindAllMarketArgs } from '@shapeshiftoss/types'
 
 import { MarketProviders } from './market-providers'
 

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -41,7 +41,7 @@
     "@shapeshiftoss/caip": "^2.0.0",
     "@shapeshiftoss/chain-adapters": "^2.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
-    "@shapeshiftoss/types": "^2.1.0",
+    "@shapeshiftoss/types": "^3.0.0",
     "@types/readline-sync": "^1.4.4",
     "readline-sync": "^1.4.10",
     "web3-utils": "^1.5.2"


### PR DESCRIPTION
This unbreaks the `yarn build` step, which is currently broken in latest develop since https://github.com/shapeshift/lib/commit/e02a2f4046e7a734f6e92d5ec448234a17818092:


<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/166226029-09eff927-da4e-474c-ae33-07c103a664a6.png">

- update `@shapeshiftoss/types` to latest where needed
- add missing `tokens` property in `transformValidator` return type
- narrow down the adapter type to be `ChainTypes.Ethereum` vs. `ChainTypes` currently in `investor-foxy`. This gives it a proper `T` generic type that's passed down to various methods and solves many type errors. This also gives it typing parity with `investor-yearn`, where the typing is actually the correct narrowed down one:
https://github.com/shapeshift/lib/blob/bf5aa33d3f3396ae652e618d3e1d5e4440711792/packages/investor-yearn/src/api/api.ts#L32
https://github.com/shapeshift/lib/blob/bf5aa33d3f3396ae652e618d3e1d5e4440711792/packages/investor-yearn/src/api/api.ts#L40
- add `ChainAdapter<ChainTypes.Ethereum>` type casting to adapter property in `FoxyApi` args. Until we narrow down the types in `chain-adapters` `byChainId`, that's probably the easiest way to go 
- bump `@shapeshiftoss/chain-adapters` to ^2.13.0 in `investor-yearn` for version parity with `investor-foxy` 
- import correct, non-namespaced path in `packages/market-service/src/market-service-manager.ts`:  `import { FindAllMarketArgs } from '@shapeshiftoss/types/src'` -> `import { FindAllMarketArgs } from '@shapeshiftoss/types'`
https://github.com/shapeshift/lib/blob/597dc6ed2a8367656204ba2687cd31466a963e61/packages/market-service/src/market-service-manager.ts#L9

