### PR TITLE
chore: add e2e release test

### DIFF
--- a/.verdaccio/config.yaml
+++ b/.verdaccio/config.yaml
@@ -1,0 +1,41 @@
+# path to a directory with all packages
+storage: ../build/local-registry/storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: true
+  yarn:
+    url: https://registry.yarnpkg.com
+    cache: true
+
+packages:
+  '@shapeshiftoss/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    access: $all
+
+    # allow all users (including non-authenticated users) to publish/publish packages
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to 'yarn' registry
+    proxy: npmjs
+
+# log settings
+logs:
+  type: stdout
+  format: pretty
+  level: http

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clean-link": "yarn clean && yarn && yarn build && yarn link-packages",
     "test": "jest",
     "test:dev": "jest --watch",
+    "test:e2e": "./scripts/e2e/release.sh",
     "type-check": "lerna run type-check",
     "release": "yarn workspaces run semantic-release -e semantic-release-monorepo",
     "publish:lerna": "lerna publish --yes",

--- a/scripts/e2e/local-registry.sh
+++ b/scripts/e2e/local-registry.sh
@@ -14,7 +14,6 @@ function startLocalRegistry {
   echo "Starting Local Registry"
   echo "Registry output file: $tmp_registry_log"
   VERDACCIO_HANDLE_KILL_SIGNALS=true
-  # (yarn verdaccio --config ./.verdaccio/config.yml)
   (nohup npx $default_verdaccio_package --config ./.verdaccio/config.yaml &>$tmp_registry_log &)
   # Wait for Verdaccio to boot
   grep -q 'http address' <(tail -f $tmp_registry_log)
@@ -44,6 +43,4 @@ function publishToLocalRegistry {
   # -f force
 	git clean -df
   yarn release --dry-run
-  # --yes skip all confirmation prompts
-  # ./node_modules/.bin/lerna publish --yes --force-publish=* --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest
 }

--- a/scripts/e2e/local-registry.sh
+++ b/scripts/e2e/local-registry.sh
@@ -4,11 +4,8 @@
 
 set -x
 
-# TODO: set default if no arg
-verdaccio_config=$1
-
 default_verdaccio_package=verdaccio@^5.10.0
-local_registry_url="http://localhost:4873"
+registry_url="http://localhost:4873"
 original_npm_registry_url=`npm get registry`
 original_yarn_registry_url=`yarn config get registry`
 
@@ -18,7 +15,7 @@ function startLocalRegistry {
   echo "Registry output file: $tmp_registry_log"
   VERDACCIO_HANDLE_KILL_SIGNALS=true
   # (yarn verdaccio --config ./.verdaccio/config.yml)
-  nohup npx $default_verdaccio_package --config $verdaccio_config &>$tmp_registry_log &
+  (nohup npx $default_verdaccio_package --config ./.verdaccio/config.yaml &>$tmp_registry_log &)
   # Wait for Verdaccio to boot
   grep -q 'http address' <(tail -f $tmp_registry_log)
 
@@ -37,11 +34,6 @@ function stopLocalRegistry {
   echo "  > NPM:  $CURRENT_NPM_REGISTRY"
   echo "  > YARN: $CURRENT_YARN_REIGSTRY"
 }
-
-if [[ $COMMAND == "clear" ]]; then
-  echo "Clearing Local Registry"
-  rm -rf ./build/local-registry/storage
-fi
 
 # Use following source to extend functionality:
 # @source: https://github.com/facebook/create-react-app/blob/v4.0.0/tasks/publish.sh

--- a/scripts/e2e/local-registry.sh
+++ b/scripts/e2e/local-registry.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# @source https://github.com/nrwl/nx/blob/master/scripts/local-registry.sh
+# @source https://github.com/facebook/create-react-app/blob/v4.0.0/tasks/local-registry.sh
+
+set -x
+
+# TODO: set default if no arg
+verdaccio_config=$1
+
+default_verdaccio_package=verdaccio@^5.10.0
+local_registry_url="http://localhost:4873"
+original_npm_registry_url=`npm get registry`
+original_yarn_registry_url=`yarn config get registry`
+
+function startLocalRegistry {
+  tmp_registry_log=`mktemp`
+  echo "Starting Local Registry"
+  echo "Registry output file: $tmp_registry_log"
+  VERDACCIO_HANDLE_KILL_SIGNALS=true
+  # (yarn verdaccio --config ./.verdaccio/config.yml)
+  nohup npx $default_verdaccio_package --config $verdaccio_config &>$tmp_registry_log &
+  # Wait for Verdaccio to boot
+  grep -q 'http address' <(tail -f $tmp_registry_log)
+
+  echo "Setting registry to local registry"
+  npm config set registry $registry_url
+  yarn config set registry $registry_url
+}
+
+function stopLocalRegistry {
+  npm config delete registry
+  yarn config delete registry
+  CURRENT_NPM_REGISTRY=$(npm config get registry)
+  CURRENT_YARN_REGISTRY=$(yarn config get registry)
+
+  echo "Reverting registries"
+  echo "  > NPM:  $CURRENT_NPM_REGISTRY"
+  echo "  > YARN: $CURRENT_YARN_REIGSTRY"
+}
+
+if [[ $COMMAND == "clear" ]]; then
+  echo "Clearing Local Registry"
+  rm -rf ./build/local-registry/storage
+fi
+
+# Use following source to extend functionality:
+# @source: https://github.com/facebook/create-react-app/blob/v4.0.0/tasks/publish.sh
+function publishToLocalRegistry {
+	echo "Publishing to Local Registry"
+  # Remove untracked files from the working tree
+  # -d to recurse directories since no path is specified
+  # -f force
+	git clean -df
+  yarn release --dry-run
+  # --yes skip all confirmation prompts
+  # ./node_modules/.bin/lerna publish --yes --force-publish=* --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest
+}

--- a/scripts/e2e/release.sh
+++ b/scripts/e2e/release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# @source https://github.com/facebook/create-react-app/blob/v4.0.0/tasks/e2e-simple.sh
+
+set -x
+
+root_path=$PWD
+
+
+# Load functions for working with local NPM registry (Verdaccio)
+source ./scripts/e2e/local-registry.sh
+
+function cleanup {
+  echo "Cleaning up."
+  stopLocalRegistry
+}
+
+# Error messages are redirected to stderr
+function handle_error {
+  echo "$(basename $0): ERROR! An error was encountered executing line $1." 1>&2;
+  cleanup
+  echo "Exiting with error." 1>&2;
+  exit 1
+}
+
+function handle_exit {
+  cleanup
+  echo "Exiting without error." 1>&2;
+  exit
+}
+
+# Exit the script with a helpful error message when any error is encountered
+trap 'set +x; handle_error $LINENO $BASH_COMMAND' ERR
+
+# Cleanup before exit on any termination signal
+trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
+
+# Bootstrap monorepo
+yarn
+
+startLocalRegistry ./.verdaccio/config.yml
+
+yarn lint
+yarn build
+# TODO: test dev encironment
+
+# Run tests with CI flag
+CI=true yarn test
+
+# Publish monorepo to local registry
+publishToLocalRegistry
+
+# Cleanup
+cleanup

--- a/scripts/e2e/release.sh
+++ b/scripts/e2e/release.sh
@@ -3,8 +3,6 @@
 
 set -x
 
-root_path=$PWD
-
 # Load functions for working with local NPM registry (Verdaccio)
 source ./scripts/e2e/local-registry.sh
 

--- a/scripts/e2e/release.sh
+++ b/scripts/e2e/release.sh
@@ -5,7 +5,6 @@ set -x
 
 root_path=$PWD
 
-
 # Load functions for working with local NPM registry (Verdaccio)
 source ./scripts/e2e/local-registry.sh
 
@@ -37,11 +36,10 @@ trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
 # Bootstrap monorepo
 yarn
 
-startLocalRegistry ./.verdaccio/config.yml
+startLocalRegistry
 
 yarn lint
 yarn build
-# TODO: test dev encironment
 
 # Run tests with CI flag
 CI=true yarn test


### PR DESCRIPTION
Closes issue #579 by implementing a continuous integration test script. Script will install a [Verdaccio](https://verdaccio.org/) locally for pushing and pulling all packages; this is done via `npx` to reduce project install time. When script finishes, everything is cleaned up.