### PR TITLE
chore: add noUnusedLocals TS rule

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: printf '%s' "$TITLE" | npx commitlint
       - name: Build
         run: yarn build
-      - name: Type check
+      - name: TypeScript compilation check
         run: yarn tsc --project ./tsconfig.json --noEmit
       - name: Lint
         run: yarn lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: printf '%s' "$TITLE" | npx commitlint
+      - name: Type check
+        run: yarn tsc --project ./tsconfig.json --noEmit
       - name: Build
         run: yarn build
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,10 +26,10 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: printf '%s' "$TITLE" | npx commitlint
-      - name: Type check
-        run: yarn tsc --project ./tsconfig.json --noEmit
       - name: Build
         run: yarn build
+      - name: Type check
+        run: yarn tsc --project ./tsconfig.json --noEmit
       - name: Lint
         run: yarn lint
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,8 +28,6 @@ jobs:
         run: printf '%s' "$TITLE" | npx commitlint
       - name: Build
         run: yarn build
-      - name: TypeScript compilation check
-        run: yarn tsc --project ./tsconfig.json --noEmit
       - name: Lint
         run: yarn lint
       - name: Test

--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -4,6 +4,6 @@ import * as caip10 from './caip10/caip10'
 import * as caip19 from './caip19/caip19'
 
 export { adapters, caip2, caip19, caip10 }
-export { ChainId, CAIP2 } from './caip2/caip2'
+export { ChainId, CAIP2, ChainReference } from './caip2/caip2'
 export { AccountId, CAIP10 } from './caip10/caip10'
 export { AssetId, AssetNamespace, AssetReference, CAIP19 } from './caip19/caip19'

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP44Params, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { BIP44Params, ChainTypes } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 
 import { cosmossdk } from './'

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { BIP44Params, ChainTypes } from '@shapeshiftoss/types'
+import { BIP44Params, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 
 import { cosmossdk } from './'

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { AssetNamespace, caip19, ChainReference } from '@shapeshiftoss/caip'
+import { AssetNamespace, caip2, caip19 } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import axios from 'axios'
@@ -58,9 +58,9 @@ export type ConstructorArgs = {
   providerUrl: string
   foxyAddresses: FoxyAddressesType
   network?:
-    | ChainReference.EthereumMainnet
-    | ChainReference.EthereumRinkeby
-    | ChainReference.EthereumRopsten
+    | caip2.ChainReference.EthereumMainnet
+    | caip2.ChainReference.EthereumRinkeby
+    | caip2.ChainReference.EthereumRopsten
 }
 
 export const transformData = ({ tvl, apy, expired, ...contractData }: FoxyOpportunityInputData) => {
@@ -88,14 +88,14 @@ export class FoxyApi {
   public web3: Web3
   private foxyStakingContracts: Contract[]
   private liquidityReserveContracts: Contract[]
-  private network: ChainReference
+  private network: caip2.ChainReference
   private foxyAddresses: FoxyAddressesType
 
   constructor({
     adapter,
     providerUrl,
     foxyAddresses,
-    network = ChainReference.EthereumMainnet
+    network = caip2.ChainReference.EthereumMainnet
   }: ConstructorArgs) {
     this.adapter = adapter
     this.provider = new Web3.providers.HttpProvider(providerUrl)

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1,6 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
-import { ChainReference } from '@shapeshiftoss/caip/dist/caip2/caip2'
+import { AssetNamespace, caip19, ChainReference } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
 import axios from 'axios'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -25,6 +25,7 @@
     "strictPropertyInitialization": false /* Enable strict checking of property initialization in classes. */,
     "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
     "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+    "noUnusedLocals": true /* Report errors on unused local variables. */,
     /* Additional Checks */
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": false /* Report errors for fallthrough cases in switch statement. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "@shapeshiftoss/swapper/*": ["packages/swapper"],
       "@shapeshiftoss/types/*": ["packages/types"],
     },
-    "noEmit": true
+    "noEmit": true,
+    "noUnusedLocals": true
   },
   "watchOptions": {
     // Use native file system events for files and directories

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
       "@shapeshiftoss/swapper/*": ["packages/swapper"],
       "@shapeshiftoss/types/*": ["packages/types"],
     },
-    "noEmit": true,
-    "noUnusedLocals": true
+    "noEmit": true
   },
   "watchOptions": {
     // Use native file system events for files and directories


### PR DESCRIPTION
## Description

- Add `noUnusedLocals` TS rule.
- Fix existing code that breaks the rule

Note, this PR uses the name-spaced `caip2` import to match our existing, but incorrect convention - this better implementation is addressed separately in https://github.com/shapeshift/lib/pull/560.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

N/A

## Screenshots (if applicable)

N/A