### PR TITLE
chore(types): replace caip properties with their high-level counterparts

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/types",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "description": "Common types shared across packages",
   "repository": "https://github.com/shapeshift/lib",
   "license": "MIT",

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -52,8 +52,6 @@ export enum AssetDataSource {
 
 type AbstractAsset = {
   assetId: string
-  caip2?: string
-  caip19?: string
   chainId: string
   chain: ChainTypes
   description?: string

--- a/packages/types/src/chain-adapters/index.ts
+++ b/packages/types/src/chain-adapters/index.ts
@@ -21,14 +21,14 @@ type ChainSpecificAccount<T> = ChainSpecific<
 export type Account<T extends ChainTypes> = {
   balance: string
   pubkey: string
-  caip2: string
-  caip19: string
+  chainId: string
+  assetId: string
   chain: T
 } & ChainSpecificAccount<T>
 
 export type AssetBalance = {
   balance: string
-  caip19: string
+  assetId: string
 }
 
 export enum FeeDataKey {
@@ -82,7 +82,7 @@ export type SubscribeTxsInput = {
 }
 
 export type TxFee = {
-  caip19: string
+  assetId: string
   value: string
 }
 
@@ -106,7 +106,7 @@ export type Transaction<T extends ChainTypes> = {
   blockHeight: number
   blockTime: number
   chain: T
-  caip2: string
+  chainId: string
   confirmations: number
   txid: string
   fee?: TxFee
@@ -133,7 +133,7 @@ export interface TxMetadata {
 }
 
 export type TxTransfer = {
-  caip19: string
+  assetId: string
   from: string
   to: string
   type: TxType

--- a/packages/types/src/market.ts
+++ b/packages/types/src/market.ts
@@ -20,12 +20,12 @@ export type HistoryData = {
 }
 
 export type PriceHistoryArgs = {
-  caip19: string
+  assetId: string
   timeframe: HistoryTimeframe
 }
 
 export type MarketDataArgs = {
-  caip19: string
+  assetId: string
 }
 
 export type FindAllMarketType = (args: FindAllMarketArgs) => Promise<MarketCapResult>


### PR DESCRIPTION
**BREAKING CHANGE: caip-specific type properties have been renamed with their generic counterparts.**

This is a major version bump to the `@shapeshiftoss/types` package ~and uses semantic release notation~ - manually bumped the version as per https://github.com/shapeshift/lib/pull/560#issuecomment-1111182529.

Follow-on PRs will update all affected packages in `lib`, as well as `web` by handling the breaking change and bumping `@shapeshiftoss/types`.

Contributes to https://github.com/shapeshift/unchained/issues/398.