### PR TITLE
feat: add getSupportedAccountTypes to ChainAdapterManager

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -1,5 +1,5 @@
 import { CAIP2, caip2 } from '@shapeshiftoss/caip'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapter } from './api'
@@ -88,6 +88,22 @@ export class ChainAdapterManager {
 
   getSupportedChains(): Array<ChainTypes> {
     return Array.from(this.supported.keys())
+  }
+
+  getSupportedAccountTypes(): Record<ChainTypes, Array<UtxoAccountType | undefined>> {
+    return {
+      [ChainTypes.Bitcoin]: [
+        UtxoAccountType.SegwitNative,
+        UtxoAccountType.SegwitP2sh,
+        UtxoAccountType.P2pkh
+      ],
+      // this looks funky, but we need a non zero length array to map over
+      // where we consume it - it either looks weird here or in the consumption
+      // so...  ¯\_(ツ)_/¯
+      [ChainTypes.Ethereum]: [undefined],
+      [ChainTypes.Cosmos]: [undefined],
+      [ChainTypes.Osmosis]: [undefined]
+    }
   }
 
   getSupportedAdapters(): Array<() => ChainAdapter<ChainTypes>> {


### PR DESCRIPTION
This adds `getSupportedAccountTypes` into `ChainAdapterManager`, effectively giving this guy a better house:
https://github.com/shapeshift/web/blob/89e26b31f9e46638e9578544486edc663311954e/src/state/slices/portfolioSlice/portfolioSliceCommon.ts#L4-L10

Take one, not sure about this way of abstracting it and having it all as one object in the manager.

A second PR (#611) has an alternative implementation, having each adapter define its own supported account types, which for all chains apart from UTXOs means `[undefined]` for now, but when thinking with the future of what we house as "accounts" (e.g account abstractions like ERC4437), they might be populated with some items at some point in the future.