### PR TITLE
chore(types): trigger major version bump attempt 2

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,4 +1,4 @@
-## ShapeShift Types
+# ShapeShift Types
 
 ## Getting Started
 


### PR DESCRIPTION
BREAKING CHANGE: trigger the major version bump that should have occurred with the changes in 3.1.4 in https://github.com/shapeshift/lib/pull/604.

Also fix the README header...