### PR TITLE
feat: regenerate asset data with assetId as sorting criteria

### DIFF
--- a/packages/asset-service/src/generateAssetData/generateAssetData.ts
+++ b/packages/asset-service/src/generateAssetData/generateAssetData.ts
@@ -18,7 +18,7 @@ const generateAssetData = async () => {
   // remove blacklisted assets
   const filteredAssetData = filterBlacklistedAssets(blacklist, unfilteredAssetData)
   // deterministic order so diffs are readable
-  const generatedAssetData = orderBy(filteredAssetData, 'caip19')
+  const generatedAssetData = orderBy(filteredAssetData, 'assetId')
 
   await fs.promises.writeFile(
     `./src/service/generatedAssetData.json`,


### PR DESCRIPTION
This:
- changes the sorting criteria for `filteredAssetData` from `caip19` to `assetId` to match the new high-level terminology we use. It will be needed for https://github.com/shapeshift/lib/pull/605 since it also regenerates asset data, but with the old criteria.
- regenerates `packages/asset-service/src/generateAssetData/generateAssetData.ts`.