### PR TITLE
perf(caip): remove CAIP vernacular exports

### DIFF
--- a/packages/caip/src/index.ts
+++ b/packages/caip/src/index.ts
@@ -1,10 +1,4 @@
-import * as adapters from './adapters'
-// TODO: These all go away on the caip breaking change PR
-import * as caip2 from './caip2/caip2'
-import * as caip10 from './caip10/caip10'
-import * as caip19 from './caip19/caip19'
-export { adapters, caip2, caip19, caip10 }
-// ENDTODO
+export * as adapters from './adapters'
 export * from './caip2/caip2'
 export * from './caip10/caip10'
 export * from './caip19/caip19'


### PR DESCRIPTION
BREAKING CHANGE: This removes the namespaced caip exports.
caip imports should be done directly from `@shapeshiftoss/caip` packages
e.g `import {caip19} from caip19; const assetId = caip19.toCAIP19(args)`
becomes: `import { toCAIP19 } from '@shapeshiftoss/caip'; const assetId
= toCaip19(args)`