### PR TITLE
chore(caip): banxa file caip19s renamed to assetid

### DIFF
--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -40,9 +40,9 @@ const invert = <T extends Record<string, string>>(data: T) =>
 
 const banxaTickerToAssetIdMap = invert(assetIdToBanxaTickerMap)
 
-export const banxaTickerToCAIP19 = (id: string): string | undefined => banxaTickerToAssetIdMap[id]
+export const banxaTickerToAssetId = (id: string): string | undefined => banxaTickerToAssetIdMap[id]
 
-export const CAIP19ToBanxaTicker = (assetId: string): string | undefined =>
+export const assetIdToBanxaTicker = (assetId: string): string | undefined =>
   assetIdToBanxaTickerMap[toLower(assetId)]
 
 export const getSupportedBanxaAssets = () =>
@@ -69,10 +69,10 @@ const chainIdToBanxaBlockchainCodeMap: Record<ChainId, string> = {
  * @returns {string} - a Banxa chain identifier; e.g., 'cosmos'
  */
 export const getBanxaBlockchainFromBanxaAssetTicker = (banxaAssetId: string): string => {
-  const assetCAIP19 = banxaTickerToCAIP19(banxaAssetId.toLowerCase())
-  if (!assetCAIP19)
+  const assetId = banxaTickerToAssetId(banxaAssetId.toLowerCase())
+  if (!assetId)
     throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${banxaAssetId} is not supported`)
-  const { chain, network } = fromCAIP19(assetCAIP19)
+  const { chain, network } = fromCAIP19(assetId)
   const chainId = toCAIP2({ network, chain })
   return chainIdToBanxaBlockchainCodeMap[chainId]
 }

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -4,7 +4,7 @@ import toLower from 'lodash/toLower'
 import { ChainId, toCAIP2 } from '../../caip2/caip2'
 import { fromCAIP19 } from '../../caip19/caip19'
 
-const CAIP19ToBanxaTickerMap = {
+const assetIdToBanxaTickerMap = {
   'bip122:000000000019d6689c085ae165831e93/slip44:0': 'btc',
   'cosmos:cosmoshub-4/slip44:118': 'atom',
   'eip155:1/slip44:60': 'eth',
@@ -38,16 +38,16 @@ const CAIP19ToBanxaTickerMap = {
 const invert = <T extends Record<string, string>>(data: T) =>
   Object.entries(data).reduce((acc, [k, v]) => ((acc[v] = k), acc), {} as Record<string, string>)
 
-const banxaTickerToCAIP19Map = invert(CAIP19ToBanxaTickerMap)
+const banxaTickerToAssetIdMap = invert(assetIdToBanxaTickerMap)
 
-export const banxaTickerToCAIP19 = (id: string): string | undefined => banxaTickerToCAIP19Map[id]
+export const banxaTickerToCAIP19 = (id: string): string | undefined => banxaTickerToAssetIdMap[id]
 
-export const CAIP19ToBanxaTicker = (caip19: string): string | undefined =>
-  CAIP19ToBanxaTickerMap[toLower(caip19)]
+export const CAIP19ToBanxaTicker = (assetId: string): string | undefined =>
+  assetIdToBanxaTickerMap[toLower(assetId)]
 
 export const getSupportedBanxaAssets = () =>
-  entries(CAIP19ToBanxaTickerMap).map(([CAIP19, ticker]) => ({
-    CAIP19,
+  entries(assetIdToBanxaTickerMap).map(([assetId, ticker]) => ({
+    assetId,
     ticker
   }))
 


### PR DESCRIPTION
Banxa ramp - `Caip19`s renamed to `assetId` for consistency.