### PR TITLE
perf(caip): breaking readme change

### DIFF
--- a/packages/caip/README.md
+++ b/packages/caip/README.md
@@ -1,7 +1,6 @@
 # CAIPs
 
 This package is ShapeShift's partial implementation of [CAIPs](https://github.com/ChainAgnostic/CAIPs) - Chain Agnostic Improvement Protocols.
-
 It is not exhaustive and is currently only used internally.
 
 ## ChainId - Blockchain ID Specification

--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/caip",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "description": "CAIP Implementation",
   "homepage": "",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE to major bump the caip package after https://github.com/shapeshift/lib/pull/625 did not.