### PR TITLE
chore: remove unused from swapper

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -6,9 +6,8 @@ import {
   chainAdapters,
   ChainTypes,
   ExecQuoteOutput,
-  GetQuoteInput,
+  GetMinMaxInput,
   MinMaxOutput,
-  Quote,
   SwapperType
 } from '@shapeshiftoss/types'
 export type SupportedAssetInput = {
@@ -32,8 +31,7 @@ export type SupportedSellAssetsInput = {
 export type CommonTradeInput = {
   sellAsset: Asset
   buyAsset: Asset
-  sellAmount?: string
-  buyAmount?: string
+  sellAmount: string
   sendMax: boolean
   sellAssetAccountId: string
 }
@@ -85,12 +83,12 @@ export type SwapSource = {
 }
 
 export type ApproveInfiniteInput<C extends ChainTypes> = {
-  quote: Quote<C> | TradeQuote<C>
+  quote: TradeQuote<C>
   wallet: HDWallet
 }
 
 export type ApprovalNeededInput<C extends ChainTypes> = {
-  quote: Quote<C> | TradeQuote<C>
+  quote: TradeQuote<C>
   wallet: HDWallet
 }
 
@@ -118,7 +116,7 @@ export interface Swapper {
   /**
    * Get the minimum and maximum trade value of the sellAsset and buyAsset
    */
-  getMinMax(input: GetQuoteInput): Promise<MinMaxOutput>
+  getMinMax(input: GetMinMaxInput): Promise<MinMaxOutput>
 
   /**
    * Execute a trade built with buildTrade by signing and broadcasting

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -4,7 +4,7 @@ import {
   Asset,
   ChainTypes,
   ExecQuoteOutput,
-  GetQuoteInput,
+  GetMinMaxInput,
   MinMaxOutput,
   SwapperType
 } from '@shapeshiftoss/types'
@@ -35,7 +35,7 @@ export class TestSwapper implements Swapper {
     throw new Error('TestSwapper: getUsdRate unimplemented')
   }
 
-  getMinMax(input: GetQuoteInput): Promise<MinMaxOutput> {
+  getMinMax(input: GetMinMaxInput): Promise<MinMaxOutput> {
     console.info(input)
     throw new Error('TestSwapper: getMinMax unimplemented')
   }

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -4,7 +4,7 @@ import {
   Asset,
   ChainTypes,
   ExecQuoteOutput,
-  GetQuoteInput,
+  GetMinMaxInput,
   MinMaxOutput,
   SwapperType
 } from '@shapeshiftoss/types'
@@ -21,7 +21,7 @@ export class ThorchainSwapper implements Swapper {
     throw new Error('ThorchainSwapper: getUsdRate unimplemented')
   }
 
-  getMinMax(input: GetQuoteInput): Promise<MinMaxOutput> {
+  getMinMax(input: GetMinMaxInput): Promise<MinMaxOutput> {
     console.info(input)
     throw new Error('ThorchainSwapper: getMinMax unimplemented')
   }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -1,6 +1,6 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { ChainTypes, Quote, SwapperType } from '@shapeshiftoss/types'
+import { ChainTypes, SwapperType } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import { ZrxError } from '../..'

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -5,7 +5,7 @@ import {
   Asset,
   ChainTypes,
   ExecQuoteOutput,
-  GetQuoteInput,
+  GetMinMaxInput,
   MinMaxOutput,
   SwapperType
 } from '@shapeshiftoss/types'
@@ -66,8 +66,8 @@ export class ZrxSwapper implements Swapper {
     return getUsdRate(input)
   }
 
-  async getMinMax(input: GetQuoteInput): Promise<MinMaxOutput> {
-    return getZrxMinMax(input)
+  async getMinMax(input: GetMinMaxInput): Promise<MinMaxOutput> {
+    return getZrxMinMax(input.sellAsset, input.buyAsset)
   }
 
   async executeTrade(args: ExecuteTradeInput<ChainTypes>): Promise<ExecQuoteOutput> {

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -1,15 +1,11 @@
-import { ChainTypes, GetQuoteInput, MinMaxOutput } from '@shapeshiftoss/types'
+import { Asset, ChainTypes, MinMaxOutput } from '@shapeshiftoss/types'
 
 import { bnOrZero } from '../utils/bignumber'
 import { MAX_ZRX_TRADE } from '../utils/constants'
 import { getUsdRate } from '../utils/helpers/helpers'
 import { ZrxError } from '../ZrxSwapper'
 
-export const getZrxMinMax = async (
-  input: Pick<GetQuoteInput, 'sellAsset' | 'buyAsset'>
-): Promise<MinMaxOutput> => {
-  const { sellAsset, buyAsset } = input
-
+export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<MinMaxOutput> => {
   if (sellAsset.chain !== ChainTypes.Ethereum || buyAsset.chain !== ChainTypes.Ethereum) {
     throw new ZrxError('getZrxMinMax - must be eth assets')
   }

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -1,12 +1,13 @@
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { Asset, ChainTypes, Quote, QuoteResponse } from '@shapeshiftoss/types'
+import { Asset, ChainTypes } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { AbiItem, numberToHex } from 'web3-utils'
 
-import { SwapError } from '../../../../api'
+import { SwapError, TradeQuote } from '../../../../api'
+import { ZrxPriceResponse } from '../../types'
 import { ZrxError } from '../../ZrxSwapper'
 import { bnOrZero } from '../bignumber'
 import { zrxService } from '../zrxService'
@@ -29,7 +30,7 @@ export type GetERC20AllowanceArgs = {
 }
 
 type GrantAllowanceArgs = {
-  quote: Quote<ChainTypes>
+  quote: TradeQuote<ChainTypes>
   wallet: HDWallet
   adapter: ChainAdapter<ChainTypes.Ethereum>
   erc20Abi: AbiItem[]
@@ -102,7 +103,7 @@ export const getAllowanceRequired = async ({
 export const getUsdRate = async (input: Pick<Asset, 'symbol' | 'tokenId'>): Promise<string> => {
   const { symbol, tokenId } = input
   if (symbol === 'USDC') return '1' // Will break if comparing against usdc
-  const rateResponse: AxiosResponse<QuoteResponse> = await zrxService.get<QuoteResponse>(
+  const rateResponse: AxiosResponse<ZrxPriceResponse> = await zrxService.get<ZrxPriceResponse>(
     '/swap/v1/price',
     {
       params: {

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -26,18 +26,11 @@ export async function zrxBuildTrade(
     sellAsset,
     buyAsset,
     sellAmount,
-    buyAmount,
     slippage,
     sellAssetAccountId,
     buyAssetAccountId,
     wallet
   } = input
-
-  if ((buyAmount && sellAmount) || (!buyAmount && !sellAmount)) {
-    throw new SwapError(
-      'ZrxSwapper:ZrxBuildTrade Exactly one of buyAmount or sellAmount is required'
-    )
-  }
 
   if (!sellAssetAccountId || !buyAssetAccountId) {
     throw new SwapError(
@@ -83,7 +76,6 @@ export async function zrxBuildTrade(
      *   sellToken: contract address (or symbol) of token to sell
      *   buyToken: contractAddress (or symbol) of token to buy
      *   sellAmount?: integer string value of the smallest increment of the sell token
-     *   buyAmount?: integer string value of the smallest incremtent of the buy token
      * }
      */
 
@@ -109,7 +101,6 @@ export async function zrxBuildTrade(
           buyToken,
           sellToken,
           sellAmount: normalizeAmount(sellAmount?.toString()),
-          buyAmount: normalizeAmount(buyAmount?.toString()),
           takerAddress: receiveAddress,
           slippagePercentage,
           skipValidation: false,

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -1,7 +1,3 @@
-import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-
-import { QuoteFeeData } from './chain-adapters'
-
 /** Common */
 
 export type BIP44Params = {
@@ -105,65 +101,9 @@ export interface MinMaxOutput {
   maximum: string
 }
 
-export type QuoteResponse = {
-  price: string
-  to: string
-  data?: string
-  value?: string
-  gas?: string
-  estimatedGas?: string
-  gasPrice?: string
-  protocolFee?: string
-  minimumProtocolFee?: string
-  buyTokenAddress?: string
-  sellTokenAddress?: string
-  buyAmount?: string
-  sellAmount?: string
-  allowanceTarget?: string
-  sources?: Array<SwapSource>
-}
-
-export type Quote<C extends ChainTypes> = {
-  success: boolean
-  statusReason?: string
-  sellAssetAccountId?: string
-  buyAssetAccountId?: string
+export type GetMinMaxInput = {
   sellAsset: Asset
   buyAsset: Asset
-  feeData?: QuoteFeeData<C>
-  rate?: string
-  depositAddress?: string // this is dex contract address for eth swaps
-  receiveAddress?: string
-  buyAmount?: string
-  sellAmount?: string
-  minimum?: string | null
-  maximum?: string | null
-  txData?: string
-  value?: string
-  allowanceContract?: string
-  sources?: Array<SwapSource>
-}
-
-export type GetQuoteInput = {
-  sellAsset: Asset
-  buyAsset: Asset
-  sellAmount?: string
-  buyAmount?: string
-  sellAssetAccountId?: string
-  buyAssetAccountId?: string
-  slippage?: string
-  sendMax?: boolean
-  priceImpact?: string // TODO this doesnt belong here but frontend needs it to not break (for now)
-}
-
-export type BuildQuoteTxInput = {
-  input: GetQuoteInput
-  wallet: HDWallet
-}
-
-export type ExecQuoteInput<C extends ChainTypes> = {
-  quote: Quote<C>
-  wallet: HDWallet
 }
 
 export type ExecQuoteOutput = {


### PR DESCRIPTION
- Remove buyAmount from getTradeQuote() and buildTrade() input and make sellAmount mandatory.
- Remove custom logic around buyAmount
- Remove misc. unused types