### PR TITLE
chore(chain-adapters): do not export bn utils

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -17,7 +17,8 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
 
 import { ErrorHandler } from '../../error/ErrorHandler'
-import { bnOrZero, toPath } from '../../utils'
+import { toPath } from '../../utils'
+import { bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 
 export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -17,14 +17,8 @@ import { numberToHex } from 'web3-utils'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
-import {
-  bnOrZero,
-  getAssetNamespace,
-  getStatus,
-  getType,
-  toPath,
-  toRootDerivationPath
-} from '../utils'
+import { getAssetNamespace, getStatus, getType, toPath, toRootDerivationPath } from '../utils'
+import { bnOrZero } from '../utils/bignumber'
 import erc20Abi from './erc20Abi.json'
 
 export interface ChainAdapterArgs {

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -4,7 +4,6 @@ import { Status, TransferType } from '@shapeshiftoss/unchained-client'
 
 export * from './bip44'
 export * from './utxoUtils'
-export * from './bignumber'
 
 export const getAssetNamespace = (type: string): AssetNamespace => {
   if (type === 'ERC20') return AssetNamespace.ERC20

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -6,12 +6,8 @@ import WAValidator from 'multicoin-address-validator'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
-import {
-  accountTypeToScriptType,
-  bnOrZero,
-  convertXpubVersion,
-  toRootDerivationPath
-} from '../utils'
+import { accountTypeToScriptType, convertXpubVersion, toRootDerivationPath } from '../utils'
+import { bnOrZero } from '../utils/bignumber'
 
 export type UTXOChainTypes = ChainTypes.Bitcoin // to be extended in the future to include other UTXOs
 

--- a/packages/market-service/src/osmosis/osmosis.ts
+++ b/packages/market-service/src/osmosis/osmosis.ts
@@ -10,7 +10,7 @@ import {
 import axios from 'axios'
 
 import { MarketService } from '../api'
-import { bnOrZero } from '../utils/bignumber'
+import { bn, bnOrZero } from '../utils/bignumber'
 import { isValidDate } from '../utils/isValidDate'
 import { OsmosisHistoryData, OsmosisMarketCap } from './osmosis-types'
 
@@ -92,17 +92,17 @@ export class OsmosisMarketService implements MarketService {
       case HistoryTimeframe.WEEK:
         range = '7d'
         isV1 = true
-        start = bnOrZero(24).times(7).toNumber()
+        start = bn(24).times(7).toNumber()
         break
       case HistoryTimeframe.MONTH:
         range = '1mo'
         isV1 = true
-        start = bnOrZero(24).times(30).toNumber()
+        start = bn(24).times(30).toNumber()
         break
       case HistoryTimeframe.YEAR:
         range = '1y'
         isV1 = true
-        start = bnOrZero(24).times(365).toNumber()
+        start = bn(24).times(365).toNumber()
         break
       case HistoryTimeframe.ALL:
         // TODO: currently the 'all' range for v2 is returning 500 errors. Using 1y for the time being.

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -1,6 +1,6 @@
 import { ChainTypes, GetQuoteInput, MinMaxOutput } from '@shapeshiftoss/types'
 
-import { bnOrZero } from '../utils/bignumber'
+import { bn, bnOrZero } from '../utils/bignumber'
 import { MAX_ZRX_TRADE } from '../utils/constants'
 import { getUsdRate } from '../utils/helpers/helpers'
 import { ZrxError } from '../ZrxSwapper'
@@ -19,7 +19,7 @@ export const getZrxMinMax = async (
     tokenId: sellAsset.tokenId
   })
 
-  const minimum = bnOrZero(1).dividedBy(bnOrZero(usdRate)).toString()
+  const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString()
 
   return {
     minimum, // $1 worth of the sell token.

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -4,7 +4,7 @@ import { ChainTypes } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import { ZrxSwapper } from '../..'
-import { bnOrZero } from '../utils/bignumber'
+import { bn, bnOrZero } from '../utils/bignumber'
 import { normalizeAmount } from '../utils/helpers/helpers'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
 import { zrxService } from '../utils/zrxService'
@@ -151,7 +151,7 @@ describe('getZrxTradeQuote', () => {
     })
     expect(quote?.sellAmount).toBe(
       bnOrZero(minimum)
-        .times(bnOrZero(10).exponentiatedBy(sellAsset.precision))
+        .times(bn(10).exponentiatedBy(sellAsset.precision))
         .toString()
     )
   })

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -4,7 +4,7 @@ import { AxiosResponse } from 'axios'
 import { GetTradeQuoteInput, TradeQuote } from '../../../api'
 import { getZrxMinMax } from '../getZrxMinMax/getZrxMinMax'
 import { ZrxPriceResponse } from '../types'
-import { bnOrZero } from '../utils/bignumber'
+import { bn, bnOrZero } from '../utils/bignumber'
 import { APPROVAL_GAS_LIMIT, DEFAULT_SOURCE } from '../utils/constants'
 import { normalizeAmount } from '../utils/helpers/helpers'
 import { zrxService } from '../utils/zrxService'
@@ -34,7 +34,7 @@ export async function getZrxTradeQuote(
   const { minimum: minQuoteSellAmount, maximum: maxSellAmount } = await getZrxMinMax(input)
 
   const minQuoteSellAmountWei = bnOrZero(minQuoteSellAmount).times(
-    bnOrZero(10).exponentiatedBy(sellAsset.precision)
+    bn(10).exponentiatedBy(sellAsset.precision)
   )
 
   const amount = useSellAmount ? { sellAmount } : { buyAmount }
@@ -74,7 +74,7 @@ export async function getZrxTradeQuote(
     const { data } = quoteResponse
 
     const estimatedGas = bnOrZero(data.estimatedGas).times(1.5)
-    const rate = useSellAmount ? data.price : bnOrZero(1).div(data.price).toString()
+    const rate = useSellAmount ? data.price : bn(1).div(data.price).toString()
 
     return {
       success: true,

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.test.ts
@@ -4,7 +4,7 @@ import Web3 from 'web3'
 
 import { erc20Abi } from '../abi/erc20-abi'
 import { erc20AllowanceAbi } from '../abi/erc20Allowance-abi'
-import { bnOrZero } from '../bignumber'
+import { bn, bnOrZero } from '../bignumber'
 import {
   getAllowanceRequired,
   getUsdRate,
@@ -96,7 +96,7 @@ describe('utils', () => {
           ...getAllowanceInput,
           sellAsset: { ...sellAsset, symbol: 'ETH' }
         })
-      ).toEqual(bnOrZero(0))
+      ).toEqual(bn(0))
     })
 
     it('should return sellAmount if allowanceOnChain is 0', async () => {
@@ -140,7 +140,7 @@ describe('utils', () => {
         }
       }))
 
-      expect(await getAllowanceRequired(getAllowanceInput)).toEqual(bnOrZero(0))
+      expect(await getAllowanceRequired(getAllowanceInput)).toEqual(bn(0))
     })
 
     it('should return sellAsset minus allowanceOnChain', async () => {
@@ -155,7 +155,7 @@ describe('utils', () => {
       }))
 
       expect(await getAllowanceRequired({ ...getAllowanceInput, sellAmount: '1000' })).toEqual(
-        bnOrZero(900)
+        bn(900)
       )
     })
   })

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -8,7 +8,7 @@ import { AbiItem, numberToHex } from 'web3-utils'
 
 import { SwapError } from '../../../../api'
 import { ZrxError } from '../../ZrxSwapper'
-import { bnOrZero } from '../bignumber'
+import { bn, bnOrZero } from '../bignumber'
 import { zrxService } from '../zrxService'
 
 export type GetAllowanceRequiredArgs = {
@@ -69,7 +69,7 @@ export const getAllowanceRequired = async ({
   erc20AllowanceAbi
 }: GetAllowanceRequiredArgs): Promise<BigNumber> => {
   if (sellAsset.symbol === 'ETH') {
-    return bnOrZero(0)
+    return bn(0)
   }
 
   const ownerAddress = receiveAddress
@@ -96,7 +96,7 @@ export const getAllowanceRequired = async ({
     throw new SwapError(`No allowance data for ${allowanceContract} to ${receiveAddress}`)
   }
   const allowanceRequired = bnOrZero(sellAmount).minus(allowanceOnChain)
-  return allowanceRequired.lt(0) ? bnOrZero(0) : allowanceRequired
+  return allowanceRequired.lt(0) ? bn(0) : allowanceRequired
 }
 
 export const getUsdRate = async (input: Pick<Asset, 'symbol' | 'tokenId'>): Promise<string> => {
@@ -117,7 +117,7 @@ export const getUsdRate = async (input: Pick<Asset, 'symbol' | 'tokenId'>): Prom
 
   if (!price.gt(0)) throw new ZrxError('getUsdRate - Failed to get price data')
 
-  return bnOrZero(1).dividedBy(price).toString()
+  return bn(1).dividedBy(price).toString()
 }
 
 export const grantAllowance = async ({


### PR DESCRIPTION
## Description

This removes the bn exports from chain-adapters utils.
The reason for that is that currently, they are available for consumers, which makes TypeScript Language Server confused and it will often pick the `@shapeshiftoss/` exports over the local ones in consumer(s) (which for now is just web, see https://github.com/shapeshift/web/pull/1760).

Other PRs will follow for `investor-foxy` and `investor-yearn` packages.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A, we just consume bn utils directly from `utils/bignumber` vs. re-exporting them in `utils` and consuming them from there

## Testing

- Tests should still be happy

## Screenshots (if applicable)