### PR TITLE
fix(errors): update tsconfigs to match other packages

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -15,10 +15,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
-    "clean": "rm -rf dist",
+    "build": "yarn clean && yarn compile",
+    "clean": "rm -rf dist && rm -rf tsconfig.build.tsbuildinfo",
+    "compile": "tsc -p tsconfig.build.json",
     "dev": "tsc --watch",
-    "test": "jest test",
+    "prepare": "yarn build",
+    "test": "jest --coverage",
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/errors/tsconfig.build.json
+++ b/packages/errors/tsconfig.build.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "esModuleInterop": true,
+    "composite": true,
     "outDir": "./dist",
-    "resolveJsonModule": true,
-    "declaration": true
+    "rootDir": "src",
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"],
 }

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,20 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "esModuleInterop": true,
-    "outDir": "./dist"
+    "composite": true,
   },
-  "watchOptions": {
-    // Use native file system events for files and directories
-    "watchFile": "useFsEvents",
-    "watchDirectory": "useFsEvents",
-    // Poll files for updates more frequently
-    // when they're updated a lot. (use as fallback)
-    "fallbackPolling": "dynamicPriority",
-    // Don't coalesce watch notification
-    "synchronousWatchDirectory": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
A recent change to the tsconfig files was made in every package except errors. This copies over all the configs from the 'logger' package.