### PR TITLE
fix: correct fee calculation for eth/erc20 sends

### DIFF
--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -172,27 +172,27 @@ describe('EthereumChainAdapter', () => {
           average: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '50180000000',
+              gasPrice: '45000000000',
               maxFeePerGas: '300',
               maxPriorityFeePerGas: '10'
             },
-            txFee: '1053780000000000'
+            txFee: '945000000000000'
           },
           fast: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '55477500000',
-              maxFeePerGas: '332',
+              gasPrice: '50180000000',
+              maxFeePerGas: '335',
               maxPriorityFeePerGas: '12'
             },
-            txFee: '1165027500000000'
+            txFee: '1053780000000000'
           },
           slow: {
             chainSpecific: {
               gasLimit: '21000',
               gasPrice: '41000000000',
-              maxFeePerGas: '246',
-              maxPriorityFeePerGas: '9'
+              maxFeePerGas: '274',
+              maxPriorityFeePerGas: '10'
             },
             txFee: '861000000000000'
           }

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -273,55 +273,61 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
 
     const feeData = (await this.providers.http.getGasFees()).data
     const normalizationConstants = {
-      fast: bnOrZero(fees.fast).dividedBy(fees.standard).toString(),
+      fast: bnOrZero(new BigNumber(fees.fast).dividedBy(fees.standard)).toString(),
       average: String(1),
-      slow: bnOrZero(fees.low).dividedBy(fees.standard).toString()
+      slow: bnOrZero(new BigNumber(fees.low).dividedBy(fees.standard)).toString()
     }
 
     return {
       fast: {
-        txFee: new BigNumber(fees.fast).times(gasLimit).toPrecision(),
+        txFee: bnOrZero(new BigNumber(fees.fast).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
-          gasPrice: String(fees.fast),
-          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
-            .times(normalizationConstants.fast)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString(),
-          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
-            .times(normalizationConstants.fast)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString()
+          gasPrice: bnOrZero(fees.fast).toString(),
+          maxFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxFeePerGas)
+              .times(normalizationConstants.fast)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString(),
+          maxPriorityFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxPriorityFeePerGas)
+              .times(normalizationConstants.fast)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString()
         }
       },
       average: {
-        txFee: new BigNumber(fees.standard).times(gasLimit).toPrecision(),
+        txFee: bnOrZero(new BigNumber(fees.standard).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
-          gasPrice: String(fees.standard),
-          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
-            .times(normalizationConstants.average)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString(),
-          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
-            .times(normalizationConstants.average)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString()
+          gasPrice: bnOrZero(fees.standard).toString(),
+          maxFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxFeePerGas)
+              .times(normalizationConstants.average)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString(),
+          maxPriorityFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxPriorityFeePerGas)
+              .times(normalizationConstants.average)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString()
         }
       },
       slow: {
-        txFee: new BigNumber(fees.low).times(gasLimit).toPrecision(),
+        txFee: bnOrZero(new BigNumber(fees.low).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
-          gasPrice: String(fees.low),
-          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
-            .times(normalizationConstants.slow)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString(),
-          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
-            .times(normalizationConstants.slow)
-            .toFixed(0, BigNumber.ROUND_CEIL)
-            .toString()
+          gasPrice: bnOrZero(fees.low).toString(),
+          maxFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxFeePerGas)
+              .times(normalizationConstants.slow)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString(),
+          maxPriorityFeePerGas: bnOrZero(
+            new BigNumber(feeData.maxPriorityFeePerGas)
+              .times(normalizationConstants.slow)
+              .toFixed(0, BigNumber.ROUND_CEIL)
+          ).toString()
         }
       }
     }

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -273,32 +273,32 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
 
     const feeData = (await this.providers.http.getGasFees()).data
     const normalizationConstants = {
-      instant: bnOrZero(fees.instant).dividedBy(fees.fast).toString(),
+      fast: bnOrZero(fees.fast).dividedBy(fees.standard).toString(),
       average: String(1),
-      slow: bnOrZero(fees.low).dividedBy(fees.fast).toString()
+      slow: bnOrZero(fees.low).dividedBy(fees.standard).toString()
     }
 
     return {
       fast: {
-        txFee: new BigNumber(fees.instant).times(gasLimit).toPrecision(),
+        txFee: new BigNumber(fees.fast).times(gasLimit).toPrecision(),
         chainSpecific: {
           gasLimit,
-          gasPrice: String(fees.instant),
+          gasPrice: String(fees.fast),
           maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
-            .times(normalizationConstants.instant)
+            .times(normalizationConstants.fast)
             .toFixed(0, BigNumber.ROUND_CEIL)
             .toString(),
           maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
-            .times(normalizationConstants.instant)
+            .times(normalizationConstants.fast)
             .toFixed(0, BigNumber.ROUND_CEIL)
             .toString()
         }
       },
       average: {
-        txFee: new BigNumber(fees.fast).times(gasLimit).toPrecision(),
+        txFee: new BigNumber(fees.standard).times(gasLimit).toPrecision(),
         chainSpecific: {
           gasLimit,
-          gasPrice: String(fees.fast),
+          gasPrice: String(fees.standard),
           maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
             .times(normalizationConstants.average)
             .toFixed(0, BigNumber.ROUND_CEIL)

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -18,7 +18,7 @@ import { numberToHex } from 'web3-utils'
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
 import { getAssetNamespace, getStatus, getType, toPath, toRootDerivationPath } from '../utils'
-import { bnOrZero } from '../utils/bignumber'
+import { bn, bnOrZero } from '../utils/bignumber'
 import erc20Abi from './erc20Abi.json'
 
 export interface ChainAdapterArgs {
@@ -164,12 +164,12 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
           if (!erc20Balance) throw new Error('no balance')
           tx.value = erc20Balance
         } else {
-          if (new BigNumber(account.balance).isZero()) throw new Error('no balance')
+          if (bnOrZero(account.balance).isZero()) throw new Error('no balance')
 
           // (The type system guarantees that either maxFeePerGas or gasPrice will be undefined, but not both)
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const fee = new BigNumber((maxFeePerGas ?? gasPrice)!).times(gasLimit)
-          tx.value = new BigNumber(account.balance).minus(fee).toString()
+          const fee = bnOrZero((maxFeePerGas ?? gasPrice)!).times(bnOrZero(gasLimit))
+          tx.value = bnOrZero(account.balance).minus(fee).toString()
         }
       }
       const data = await getErc20Data(to, tx?.value, erc20ContractAddress)
@@ -273,61 +273,55 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
 
     const feeData = (await this.providers.http.getGasFees()).data
     const normalizationConstants = {
-      fast: bnOrZero(new BigNumber(fees.fast).dividedBy(fees.standard)).toString(),
-      average: String(1),
-      slow: bnOrZero(new BigNumber(fees.low).dividedBy(fees.standard)).toString()
+      fast: bnOrZero(bn(fees.fast).dividedBy(fees.standard)),
+      average: bn(1),
+      slow: bnOrZero(bn(fees.low).dividedBy(fees.standard))
     }
 
     return {
       fast: {
-        txFee: bnOrZero(new BigNumber(fees.fast).times(gasLimit)).toPrecision(),
+        txFee: bnOrZero(bn(fees.fast).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
           gasPrice: bnOrZero(fees.fast).toString(),
-          maxFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxFeePerGas)
-              .times(normalizationConstants.fast)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString(),
-          maxPriorityFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxPriorityFeePerGas)
-              .times(normalizationConstants.fast)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString()
+          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
+            .times(normalizationConstants.fast)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString(),
+          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
+            .times(normalizationConstants.fast)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString()
         }
       },
       average: {
-        txFee: bnOrZero(new BigNumber(fees.standard).times(gasLimit)).toPrecision(),
+        txFee: bnOrZero(bn(fees.standard).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
           gasPrice: bnOrZero(fees.standard).toString(),
-          maxFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxFeePerGas)
-              .times(normalizationConstants.average)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString(),
-          maxPriorityFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxPriorityFeePerGas)
-              .times(normalizationConstants.average)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString()
+          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
+            .times(normalizationConstants.average)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString(),
+          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
+            .times(normalizationConstants.average)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString()
         }
       },
       slow: {
-        txFee: bnOrZero(new BigNumber(fees.low).times(gasLimit)).toPrecision(),
+        txFee: bnOrZero(bn(fees.low).times(gasLimit)).toPrecision(),
         chainSpecific: {
           gasLimit,
           gasPrice: bnOrZero(fees.low).toString(),
-          maxFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxFeePerGas)
-              .times(normalizationConstants.slow)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString(),
-          maxPriorityFeePerGas: bnOrZero(
-            new BigNumber(feeData.maxPriorityFeePerGas)
-              .times(normalizationConstants.slow)
-              .toFixed(0, BigNumber.ROUND_CEIL)
-          ).toString()
+          maxFeePerGas: bnOrZero(feeData.maxFeePerGas)
+            .times(normalizationConstants.slow)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString(),
+          maxPriorityFeePerGas: bnOrZero(feeData.maxPriorityFeePerGas)
+            .times(normalizationConstants.slow)
+            .toFixed(0, BigNumber.ROUND_CEIL)
+            .toString()
         }
       }
     }


### PR DESCRIPTION
Fixes issue: https://github.com/shapeshift/web/issues/1716

- Use standard fee as the normalization constant
- Use fast instead of instant (instant was often lower than slow for unknown reasons)
- Use the correct fee data for each return object (slow, average, fast)

There is a larger question/concern of relying on https://gas.api.0x.org/ for our fee calculations. Using the `MEDIAN` return value from this api results in a lower gas price than that returned by geth or something like https://etherchain.org/tools/gasnow. The result lines up more with https://ethgasstation.info/.

There are clearly fee discrepancies across the ecosystem depending on where you look, so we should have a discussion on whether we are ok with the returned data from 0x or if we want to build out the unchained fees response to include slow/average/fast results that we can adjust and control ourselves.

It is also worth noting that the difference between slow/average/fast from the 0x gas api is very small resulting in very little diff between the levels to the point they don't even matter much (specifically for sending eth/erc20s). This may just be the current network state, but something to keep our eyes on.