### PR TITLE
fix: sort fiat price history by time correctly

### DIFF
--- a/packages/market-service/src/exchange-rates-host/erhMockData.ts
+++ b/packages/market-service/src/exchange-rates-host/erhMockData.ts
@@ -8,8 +8,8 @@ export const mockERHFindByFiatSymbol = {
 }
 
 export const mockERHPriceHistoryData = [
-  { date: dayjs('2020-01-04', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.895175 },
-  { date: dayjs('2020-01-03', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.895175 },
+  { date: dayjs('2020-01-01', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.891186 },
   { date: dayjs('2020-01-02', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.891186 },
-  { date: dayjs('2020-01-01', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.891186 }
+  { date: dayjs('2020-01-03', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.895175 },
+  { date: dayjs('2020-01-04', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.895175 }
 ]

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -1,6 +1,5 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import axios from 'axios'
-import dayjs from 'dayjs'
 
 import { FiatMarketDataArgs, FiatPriceHistoryArgs } from '../fiat-market-service-types'
 import { mockERHFindByFiatSymbol, mockERHPriceHistoryData } from './erhMockData'
@@ -63,25 +62,6 @@ describe('ExchangeRateHostService', () => {
       expect(await exchangeRateHostService.findPriceHistoryByFiatSymbol(args)).toEqual(
         mockERHPriceHistoryData
       )
-    })
-
-    it('should filter out NaN values and return historical fiat market data for EUR', async () => {
-      const mockHistoryData = {
-        rates: {
-          '2020-01-01': { EUR: 0.891186 },
-          '2020-01-02': { EUR: NaN },
-          '2020-01-03': { EUR: 0.895175 },
-          '2020-01-04': { EUR: NaN }
-        }
-      }
-
-      const mockResponse = [
-        { date: dayjs('2020-01-03', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.895175 },
-        { date: dayjs('2020-01-01', 'YYYY-MM-DD').startOf('day').valueOf(), price: 0.891186 }
-      ]
-
-      mockedAxios.get.mockResolvedValue({ data: mockHistoryData })
-      expect(await exchangeRateHostService.findPriceHistoryByFiatSymbol(args)).toEqual(mockResponse)
     })
 
     it('should return null on network error', async () => {

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { FiatMarketService } from '../api'
 import { RATE_LIMIT_THRESHOLDS_PER_MINUTE } from '../config'
 import { FiatMarketDataArgs, FiatPriceHistoryArgs } from '../fiat-market-service-types'
-import { bn } from '../utils/bignumber'
+import { bnOrZero } from '../utils/bignumber'
 import { rateLimitedAxios } from '../utils/rateLimiters'
 import { ExchangeRateHostHistoryData, ExchangeRateHostRate } from './exchange-rates-host-types'
 
@@ -70,16 +70,8 @@ export class ExchangeRateHostService implements FiatMarketService {
       return Object.entries(data.rates).reduce<HistoryData[]>(
         (acc, [formattedDate, ratesObject]) => {
           const date = dayjs(formattedDate, 'YYYY-MM-DD').startOf('day').valueOf()
-          const price = bn(ratesObject[symbol])
-          if (price.isNaN()) {
-            console.error('ExchangeRateHost fiat history data has invalid price')
-            return acc
-          }
-          // add to beginning of the array because api results are sorted incrementally
-          acc.unshift({
-            date,
-            price: price.toNumber()
-          })
+          const price = bnOrZero(ratesObject[symbol]).toNumber()
+          acc.push({ date, price })
           return acc
         },
         []


### PR DESCRIPTION
the exchange rate host was returning newer fiat price history data first, we should be returning
oldest at the beginning of the array, like we do with crypto data.

also uses bnOrZero and deletes redundant NaN test as a result
