### PR TITLE
chore: remove getinfo from cosmos base adapter

### DIFF
--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.test.ts
@@ -193,7 +193,6 @@ describe('BitcoinChainAdapter', () => {
   describe('getAccount', () => {
     it('should return account info for a specified address', async () => {
       args.providers.http = {
-        getInfo: jest.fn().mockResolvedValue({ data: { network: 'mainnet' } }),
         getAccount: jest.fn().mockResolvedValue({
           data: {
             pubkey: '1EjpFGTWJ9CGRJUMA3SdQSdigxM31aXAFx',
@@ -226,7 +225,6 @@ describe('BitcoinChainAdapter', () => {
 
     it('should throw for an unspecified address', async () => {
       args.providers.http = {
-        getInfo: jest.fn().mockResolvedValue({ data: { network: 'mainnet' } }),
         getAccount: jest.fn<any, any>().mockResolvedValue({
           pubkey: '1EjpFGTWJ9CGRJUMA3SdQSdigxM31aXAFx',
           balance: '0'
@@ -287,7 +285,6 @@ describe('BitcoinChainAdapter', () => {
       const wallet: any = await getWallet()
 
       args.providers.http = {
-        getInfo: jest.fn().mockResolvedValue({ data: { network: 'mainnet' } }),
         getUtxos: jest.fn<any, any>().mockResolvedValue(getUtxosMockResponse),
         getTransaction: jest.fn<any, any>().mockResolvedValue(getTransactionMockResponse),
         getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
@@ -355,7 +352,6 @@ describe('BitcoinChainAdapter', () => {
       const wallet: any = await getWallet()
 
       args.providers.http = {
-        getInfo: jest.fn().mockResolvedValue({ data: { network: 'mainnet' } }),
         getUtxos: jest.fn<any, any>().mockResolvedValue(getUtxosMockResponse),
         getTransaction: jest.fn<any, any>().mockResolvedValue(getTransactionMockResponse),
         getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -66,18 +66,6 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
     return this.chainId
   }
 
-  async getInfo(): Promise<chainAdapters.cosmos.Info> {
-    try {
-      const { data } = await this.providers.http.getInfo()
-      return {
-        totalSupply: data.totalSupply,
-        bondedTokens: data.bondedTokens
-      }
-    } catch (err) {
-      return ErrorHandler(err)
-    }
-  }
-
   async getAccount(pubkey: string): Promise<chainAdapters.Account<T>> {
     try {
       const { data } = await this.providers.http.getAccount({ pubkey })

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -83,13 +83,6 @@ describe('EthereumChainAdapter', () => {
   const makeEstimateGasMockedResponse = (overrideArgs?: { data: string }) =>
     merge({ data: '21000' }, overrideArgs)
 
-  const makeGetInfoMockResponse = (overrideArgs?: { data: { network: string } }) =>
-    merge(
-      {
-        data: { network: 'mainnet' }
-      },
-      overrideArgs
-    )
   const makeGetAccountMockResponse = (balance: {
     balance: string
     erc20Balance: string | undefined
@@ -303,7 +296,6 @@ describe('EthereumChainAdapter', () => {
     it('should sign a properly formatted txToSign object', async () => {
       const balance = '2500000'
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(makeGetAccountMockResponse({ balance, erc20Balance: '424242' }))
@@ -332,7 +324,6 @@ describe('EthereumChainAdapter', () => {
     it('should throw on txToSign with invalid data', async () => {
       const balance = '2500000'
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(makeGetAccountMockResponse({ balance, erc20Balance: '424242' }))
@@ -430,7 +421,6 @@ describe('EthereumChainAdapter', () => {
 
     it('should throw if passed tx has ENS as "to" property', async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(
@@ -469,7 +459,6 @@ describe('EthereumChainAdapter', () => {
 
     it('should return a validly formatted ETHSignTx object for a valid BuildSendTxInput parameter', async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', erc20Balance: '424242' }))
@@ -500,7 +489,6 @@ describe('EthereumChainAdapter', () => {
     })
     it('sendmax: true without chainSpecific.erc20ContractAddress should throw if ETH balance is 0', async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', erc20Balance: '424242' }))
@@ -526,7 +514,6 @@ describe('EthereumChainAdapter', () => {
         bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any
       )
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(makeGetAccountMockResponse({ balance, erc20Balance: '424242' }))
@@ -558,7 +545,6 @@ describe('EthereumChainAdapter', () => {
     })
     it("should build a tx with value: '0' for ERC20 txs without sendMax", async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(
@@ -591,7 +577,6 @@ describe('EthereumChainAdapter', () => {
     })
     it('sendmax: true with chainSpecific.erc20ContractAddress should build a tx with full account balance - gas fee', async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(
@@ -627,7 +612,6 @@ describe('EthereumChainAdapter', () => {
 
     it('sendmax: true with chainSpecific.erc20ContractAddress should throw if token balance is 0', async () => {
       const httpProvider = {
-        getInfo: jest.fn().mockResolvedValue(makeGetInfoMockResponse()),
         getAccount: jest
           .fn<any, any>()
           .mockResolvedValue(

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxDeps.ts
@@ -9,7 +9,6 @@ export const chainAdapterMockFuncs = {
   buildSendTransaction: jest.fn(() => Promise.resolve({ txToSign: {} })),
   signTransaction: jest.fn(() => Promise.resolve('signedTx')),
   broadcastTransaction: jest.fn(() => Promise.resolve('broadcastedTx')),
-  getInfo: jest.fn(() => Promise.resolve({ data: { network: 'mainnet' } })),
   getAddress: jest.fn(() => Promise.resolve('address')),
   getAccount: jest.fn(() =>
     Promise.resolve({


### PR DESCRIPTION
getInfo is not part of the chain adapter interface and is not used anywhere.

We noticed this trying to implement osmosis and believe it should be removed
