### PR TITLE
chore: add get fee asset id to chain adapters

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -8,6 +8,12 @@ export type ChainAdapter<T extends ChainTypes> = {
   getType(): T
 
   getChainId(): ChainId
+
+  /**
+   * Base fee asset used to pay for txs on a given chain
+   */
+  getFeeAssetId(): string
+
   /**
    * Get the supported account types for an adapter
    * For UTXO coins, that's the list of UTXO account types

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { BIP44Params, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 
 export type ChainAdapter<T extends ChainTypes> = {

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -12,7 +12,7 @@ export type ChainAdapter<T extends ChainTypes> = {
   /**
    * Base fee asset used to pay for txs on a given chain
    */
-  getFeeAssetId(): string
+  getFeeAssetId(): AssetId
 
   /**
    * Get the supported account types for an adapter

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -79,7 +79,7 @@ export class ChainAdapter
     return ChainTypes.Bitcoin
   }
 
-  getFeeAssetId(): string {
+  getFeeAssetId(): AssetId {
     return 'bip122:000000000019d6689c085ae165831e93/slip44:0'
   }
 

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -79,6 +79,10 @@ export class ChainAdapter
     return ChainTypes.Bitcoin
   }
 
+  getFeeAssetId(): string {
+    return 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+  }
+
   getSupportedAccountTypes() {
     return ChainAdapter.supportedAccountTypes
   }

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,4 +1,5 @@
 import {
+  AssetId,
   AssetNamespace,
   AssetReference,
   ChainId,

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -66,6 +66,8 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainTypes> implement
     return this.chainId
   }
 
+  abstract getFeeAssetId(): AssetId
+
   async getAccount(pubkey: string): Promise<chainAdapters.Account<T>> {
     try {
       const { data } = await this.providers.http.getAccount({ pubkey })

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -54,7 +54,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
     return ChainTypes.Cosmos
   }
 
-  getFeeAssetId(): string {
+  getFeeAssetId(): AssetId {
     return 'cosmos:cosmoshub-4/slip44:118'
   }
 

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -54,6 +54,10 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
     return ChainTypes.Cosmos
   }
 
+  getFeeAssetId(): string {
+    return 'cosmos:cosmoshub-4/slip44:118'
+  }
+
   async getAddress(input: chainAdapters.GetAddressInput): Promise<string> {
     const { wallet, bip44Params = ChainAdapter.defaultBIP44Params } = input
     const path = toPath(bip44Params)

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -43,6 +43,10 @@ export class ChainAdapter
     return ChainTypes.Osmosis
   }
 
+  getFeeAssetId(): AssetId {
+    return 'cosmos:osmosis-1/slip44:118'
+  }
+
   async getAddress(input: chainAdapters.GetAddressInput): Promise<string> {
     const { wallet, bip44Params = ChainAdapter.defaultBIP44Params } = input
     const path = toPath(bip44Params)

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -1,5 +1,6 @@
 import { Contract } from '@ethersproject/contracts'
 import {
+  AssetId,
   AssetNamespace,
   AssetReference,
   ChainId,

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -72,6 +72,10 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return this.chainId
   }
 
+  getFeeAssetId(): string {
+    return 'eip155:1/slip44:60'
+  }
+
   async getAccount(pubkey: string): Promise<chainAdapters.Account<ChainTypes.Ethereum>> {
     try {
       const chainId = this.getChainId()

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -72,7 +72,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
     return this.chainId
   }
 
-  getFeeAssetId(): string {
+  getFeeAssetId(): AssetId {
     return 'eip155:1/slip44:60'
   }
 

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -56,7 +56,7 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainTypes> implements IChai
   abstract closeTxs(): void
   abstract getType(): T
   abstract getSupportedAccountTypes(): UtxoAccountType[]
-
+  abstract getFeeAssetId(): AssetId
   abstract getTxHistory(
     input: chainAdapters.TxHistoryInput
   ): Promise<chainAdapters.TxHistoryResponse<T>>


### PR DESCRIPTION
Add fee asset id to chain adapters to make it easier to get the fee asset for a given asset