### PR TITLE
fix: fetch multiple years for fiat price history

### DIFF
--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 
 import { FiatMarketDataArgs, FiatPriceHistoryArgs } from '../fiat-market-service-types'
 import { mockERHFindByFiatSymbol, mockERHPriceHistoryData } from './erhMockData'
-import { ExchangeRateHostService, makeUrls } from './exchange-rates-host'
+import { ExchangeRateHostService, makeExchangeRateRequestUrls } from './exchange-rates-host'
 import { ExchangeRateHostRate } from './exchange-rates-host-types'
 
 jest.mock('axios')
@@ -76,13 +76,13 @@ describe('ExchangeRateHostService', () => {
   })
 })
 
-describe('makeUrls', () => {
+describe('makeExchangeRateRequestUrls', () => {
   it('should make one url', () => {
     const start = dayjs('2020-01-01')
     const end = dayjs('2020-01-02')
     const symbol = 'EUR'
     const baseUrl = 'https://api.exchangeratesapi.io'
-    expect(makeUrls(start, end, symbol, baseUrl)).toEqual([
+    expect(makeExchangeRateRequestUrls(start, end, symbol, baseUrl)).toEqual([
       'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2020-01-01&end_date=2020-01-02'
     ])
   })
@@ -92,11 +92,11 @@ describe('makeUrls', () => {
     const end = dayjs('2022-05-17')
     const symbol = 'EUR'
     const baseUrl = 'https://api.exchangeratesapi.io'
-    expect(makeUrls(start, end, symbol, baseUrl)).toEqual([
-      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2017-05-20&end_date=2018-05-21',
-      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2018-05-21&end_date=2019-05-22',
-      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2019-05-22&end_date=2020-05-22',
-      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2020-05-22&end_date=2021-05-23',
+    expect(makeExchangeRateRequestUrls(start, end, symbol, baseUrl)).toEqual([
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2017-05-20&end_date=2018-05-20',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2018-05-21&end_date=2019-05-21',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2019-05-22&end_date=2020-05-21',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2020-05-22&end_date=2021-05-22',
       'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2021-05-23&end_date=2022-05-17'
     ])
   })

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -1,9 +1,10 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import axios from 'axios'
+import dayjs from 'dayjs'
 
 import { FiatMarketDataArgs, FiatPriceHistoryArgs } from '../fiat-market-service-types'
 import { mockERHFindByFiatSymbol, mockERHPriceHistoryData } from './erhMockData'
-import { ExchangeRateHostService } from './exchange-rates-host'
+import { ExchangeRateHostService, makeUrls } from './exchange-rates-host'
 import { ExchangeRateHostRate } from './exchange-rates-host-types'
 
 jest.mock('axios')
@@ -72,5 +73,31 @@ describe('ExchangeRateHostService', () => {
       )
       expect(consoleSpy).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe('makeUrls', () => {
+  it('should make one url', () => {
+    const start = dayjs('2020-01-01')
+    const end = dayjs('2020-01-02')
+    const symbol = 'EUR'
+    const baseUrl = 'https://api.exchangeratesapi.io'
+    expect(makeUrls(start, end, symbol, baseUrl)).toEqual([
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2020-01-01&end_date=2020-01-02'
+    ])
+  })
+
+  it('should make five urls', () => {
+    const start = dayjs('2017-05-20')
+    const end = dayjs('2022-05-17')
+    const symbol = 'EUR'
+    const baseUrl = 'https://api.exchangeratesapi.io'
+    expect(makeUrls(start, end, symbol, baseUrl)).toEqual([
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2017-05-20&end_date=2018-05-21',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2018-05-21&end_date=2019-05-22',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2019-05-22&end_date=2020-05-22',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2020-05-22&end_date=2021-05-23',
+      'https://api.exchangeratesapi.io/timeseries?base=USD&symbols=EUR&start_date=2021-05-23&end_date=2022-05-17'
+    ])
   })
 })

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
@@ -15,7 +15,7 @@ import { ExchangeRateHostHistoryData, ExchangeRateHostRate } from './exchange-ra
 const axios = rateLimitedAxios(RATE_LIMIT_THRESHOLDS_PER_MINUTE.DEFAULT)
 const baseCurrency = 'USD'
 
-export const makeUrls = (
+export const makeExchangeRateRequestUrls = (
   start: Dayjs,
   end: Dayjs,
   symbol: SupportedFiatCurrencies,
@@ -31,7 +31,7 @@ export const makeUrls = (
     .fill(null)
     .map((_, i) => {
       const urlStart = start.add(i * maxDaysPerRequest, 'day')
-      const maybeEnd = urlStart.add(maxDaysPerRequest, 'day')
+      const maybeEnd = urlStart.add(maxDaysPerRequest - 1, 'day')
       const urlEnd = maybeEnd.isAfter(end) ? end : maybeEnd
       return `${baseUrl}/timeseries?base=${baseCurrency}&symbols=${symbol}&start_date=${urlStart.format(
         'YYYY-MM-DD'
@@ -89,7 +89,7 @@ export class ExchangeRateHostService implements FiatMarketService {
     }
 
     try {
-      const urls: string[] = makeUrls(start, end, symbol, this.baseUrl)
+      const urls: string[] = makeExchangeRateRequestUrls(start, end, symbol, this.baseUrl)
 
       const results = await Promise.all(
         urls.map((url) => axios.get<ExchangeRateHostHistoryData>(url))

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
@@ -1,15 +1,43 @@
 import { HistoryData, HistoryTimeframe, MarketData } from '@shapeshiftoss/types'
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 
 import { FiatMarketService } from '../api'
 import { RATE_LIMIT_THRESHOLDS_PER_MINUTE } from '../config'
-import { FiatMarketDataArgs, FiatPriceHistoryArgs } from '../fiat-market-service-types'
+import {
+  FiatMarketDataArgs,
+  FiatPriceHistoryArgs,
+  SupportedFiatCurrencies
+} from '../fiat-market-service-types'
 import { bnOrZero } from '../utils/bignumber'
 import { rateLimitedAxios } from '../utils/rateLimiters'
 import { ExchangeRateHostHistoryData, ExchangeRateHostRate } from './exchange-rates-host-types'
 
 const axios = rateLimitedAxios(RATE_LIMIT_THRESHOLDS_PER_MINUTE.DEFAULT)
 const baseCurrency = 'USD'
+
+export const makeUrls = (
+  start: Dayjs,
+  end: Dayjs,
+  symbol: SupportedFiatCurrencies,
+  baseUrl: string
+): string[] => {
+  const daysBetween: number = end.diff(start, 'day')
+  /**
+   * https://exchangerate.host/#/#docs
+   * Timeseries endpoint are for daily historical rates between two dates of your choice, with a maximum time frame of 366 days.
+   */
+  const maxDaysPerRequest = 366
+  return Array(Math.ceil(daysBetween / maxDaysPerRequest))
+    .fill(null)
+    .map((_, i) => {
+      const urlStart = start.add(i * maxDaysPerRequest, 'day')
+      const maybeEnd = urlStart.add(maxDaysPerRequest, 'day')
+      const urlEnd = maybeEnd.isAfter(end) ? end : maybeEnd
+      return `${baseUrl}/timeseries?base=${baseCurrency}&symbols=${symbol}&start_date=${urlStart.format(
+        'YYYY-MM-DD'
+      )}&end_date=${urlEnd.format('YYYY-MM-DD')}`
+    })
+}
 
 export class ExchangeRateHostService implements FiatMarketService {
   baseUrl = 'https://api.exchangerate.host'
@@ -54,28 +82,27 @@ export class ExchangeRateHostService implements FiatMarketService {
         start = end.subtract(1, 'year')
         break
       case HistoryTimeframe.ALL:
-        start = end.subtract(20, 'years')
+        start = end.subtract(5, 'years')
         break
       default:
         start = end
     }
 
     try {
-      const from = start.startOf('day').format('YYYY-MM-DD')
-      const to = end.startOf('day').format('YYYY-MM-DD')
-      const url = `${this.baseUrl}/timeseries?base=${baseCurrency}&symbols=${symbol}&start_date=${from}&end_date=${to}`
+      const urls: string[] = makeUrls(start, end, symbol, this.baseUrl)
 
-      const { data } = await axios.get<ExchangeRateHostHistoryData>(url)
+      const results = await Promise.all(
+        urls.map((url) => axios.get<ExchangeRateHostHistoryData>(url))
+      )
 
-      return Object.entries(data.rates).reduce<HistoryData[]>(
-        (acc, [formattedDate, ratesObject]) => {
+      return results.reduce<HistoryData[]>((acc, { data }) => {
+        Object.entries(data.rates).forEach(([formattedDate, ratesObject]) => {
           const date = dayjs(formattedDate, 'YYYY-MM-DD').startOf('day').valueOf()
           const price = bnOrZero(ratesObject[symbol]).toNumber()
           acc.push({ date, price })
-          return acc
-        },
-        []
-      )
+        })
+        return acc
+      }, [])
     } catch (e) {
       console.warn(e)
       throw new Error(


### PR DESCRIPTION
the upstream API we use to fetch fiat pricing returns a max of 366 days per request - make multiple requests to return 5 years worth of data.
also only return 5 years as charts only go back that far
