### PR TITLE
chore: bump peer dependencies and remove src imports

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -34,12 +34,12 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
     "@ethersproject/providers": "^5.5.2",
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/types": "^4.0.0",
     "@types/lodash": "^4.14.172",
     "@yfi/sdk": "^1.0.30",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -37,19 +37,19 @@
     "web3-utils": "^1.6.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
-    "@shapeshiftoss/unchained-client": "^7.0.0",
+    "@shapeshiftoss/unchained-client": "^8.0.0",
     "bs58check": "^2.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
-    "@shapeshiftoss/unchained-client": "^7.0.0",
+    "@shapeshiftoss/unchained-client": "^8.0.0",
     "@types/bs58check": "^2.1.0",
     "@types/multicoin-address-validator": "^0.5.0"
   }

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -1,5 +1,10 @@
-import { AssetId, CHAIN_REFERENCE, fromChainId, toAssetId } from '@shapeshiftoss/caip'
-import { ASSET_REFERENCE } from '@shapeshiftoss/caip/src'
+import {
+  ASSET_REFERENCE,
+  AssetId,
+  CHAIN_REFERENCE,
+  fromChainId,
+  toAssetId
+} from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   CosmosSignTx,

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -36,14 +36,14 @@
     "web3-utils": "^1.7.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"
   }

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -35,12 +35,12 @@
     "web3-utils": "^1.7.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"
   }

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -36,11 +36,11 @@
     "p-ratelimit": "^1.0.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/types": "^4.0.0",
     "limiter": "^2.1.0"
   }

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -30,19 +30,19 @@
     "web3": "^1.6.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/asset-service": "^2.0.0",
-    "@shapeshiftoss/caip": "^3.0.0",
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/asset-service": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
     "@shapeshiftoss/errors": "^1.1.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/asset-service": "^2.0.0",
-    "@shapeshiftoss/caip": "^3.0.0",
-    "@shapeshiftoss/chain-adapters": "^3.0.0",
+    "@shapeshiftoss/asset-service": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
+    "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
-    "@shapeshiftoss/types": "^4.0.0",
+    "@shapeshiftoss/types": "^4.1.0",
     "@shapeshiftoss/errors": "^1.1.0",
     "@types/readline-sync": "^1.4.4",
     "readline-sync": "^1.4.10",

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -28,12 +28,12 @@
     "ws": "^8.3.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^3.0.0",
+    "@shapeshiftoss/caip": "^4.0.0",
     "@shapeshiftoss/common-api": "^6.11.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^4.0.0",

--- a/packages/unchained-client/src/ethereum/parser/index.ts
+++ b/packages/unchained-client/src/ethereum/parser/index.ts
@@ -1,6 +1,5 @@
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { AssetId, ChainId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
-import { ASSET_REFERENCE } from '@shapeshiftoss/caip/src'
+import { ASSET_REFERENCE, AssetId, ChainId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
 import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,10 +2714,10 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@shapeshiftoss/asset-service@^2.0.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/asset-service/-/asset-service-2.6.0.tgz#810ae765f546b1780d5fc635ef0350ff057bd2d3"
-  integrity sha512-TN/V2Tsr0PomkFwJAb6G83db8zlE8MmnlT1a4GBAh342QngOVyuz0K+goDXgodyS3tHBEgvhabvz7Z5vWA/e+Q==
+"@shapeshiftoss/asset-service@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/asset-service/-/asset-service-3.0.1.tgz#a141d8954e070735e0e161ea8eb6cfaae32ffcc5"
+  integrity sha512-4bzPFjAsvjQU1uHRxsUi8j6uxEeYoqQjWovKkZQm17UchgtLaqbeDA18S66MqujvJFWk6d5fI2JjZyaDWqCZPw==
   dependencies:
     axios "^0.26.0"
     identicon.js "^2.3.3"


### PR DESCRIPTION
- Update peer dependencies to breaking changes in https://github.com/shapeshift/lib/pull/656
- Remove 2 erroneous imports from `/src`