### PR TITLE
fix: timeframes for fiat rates

### DIFF
--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -13,8 +13,13 @@ const mockedAxios = axios as jest.Mocked<typeof axios>
 const exchangeRateHostService = new ExchangeRateHostService()
 
 describe('ExchangeRateHostService', () => {
+  const mockDay = '2020-12-31'
+  const mockTime = 'T12:00:00.000Z'
+  const mockDate = `${mockDay}${mockTime}`
+  beforeEach(() => jest.useFakeTimers().setSystemTime(new Date(mockDate)))
   afterEach(() => {
     jest.restoreAllMocks()
+    jest.useRealTimers()
   })
 
   describe('findByFiatSymbol', () => {
@@ -49,17 +54,17 @@ describe('ExchangeRateHostService', () => {
       timeframe: HistoryTimeframe.WEEK
     }
 
-    it('should return historical fiat market data for EUR', async () => {
-      const mockHistoryData = {
-        rates: {
-          '2020-01-01': { EUR: 0.891186 },
-          '2020-01-02': { EUR: 0.891186 },
-          '2020-01-03': { EUR: 0.895175 },
-          '2020-01-04': { EUR: 0.895175 }
-        }
+    const data = {
+      rates: {
+        '2020-01-01': { EUR: 0.891186 },
+        '2020-01-02': { EUR: 0.891186 },
+        '2020-01-03': { EUR: 0.895175 },
+        '2020-01-04': { EUR: 0.895175 }
       }
+    }
 
-      mockedAxios.get.mockResolvedValue({ data: mockHistoryData })
+    it('should return historical fiat market data for EUR', async () => {
+      mockedAxios.get.mockResolvedValue({ data })
       expect(await exchangeRateHostService.findPriceHistoryByFiatSymbol(args)).toEqual(
         mockERHPriceHistoryData
       )
@@ -72,6 +77,42 @@ describe('ExchangeRateHostService', () => {
         new Error('ExchangeRateHost(findPriceHistoryByFiatSymbol): error fetching price history')
       )
       expect(consoleSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should have different start and end dates for hour timeframe', async () => {
+      mockedAxios.get.mockResolvedValue({ data })
+
+      await exchangeRateHostService.findPriceHistoryByFiatSymbol({
+        symbol: 'EUR',
+        timeframe: HistoryTimeframe.HOUR
+      })
+      expect(mockedAxios.get).toBeCalledWith(
+        `https://api.exchangerate.host/timeseries?base=USD&symbols=EUR&start_date=2020-12-30&end_date=${mockDay}`
+      )
+    })
+
+    it('should have different sensible dates for day timeframe', async () => {
+      mockedAxios.get.mockResolvedValue({ data })
+
+      await exchangeRateHostService.findPriceHistoryByFiatSymbol({
+        symbol: 'EUR',
+        timeframe: HistoryTimeframe.DAY
+      })
+      expect(mockedAxios.get).toBeCalledWith(
+        `https://api.exchangerate.host/timeseries?base=USD&symbols=EUR&start_date=2020-12-30&end_date=${mockDay}`
+      )
+    })
+
+    it('should have different sensible dates for week timeframe', async () => {
+      mockedAxios.get.mockResolvedValue({ data })
+
+      await exchangeRateHostService.findPriceHistoryByFiatSymbol({
+        symbol: 'EUR',
+        timeframe: HistoryTimeframe.WEEK
+      })
+      expect(mockedAxios.get).toBeCalledWith(
+        `https://api.exchangerate.host/timeseries?base=USD&symbols=EUR&start_date=2020-12-24&end_date=${mockDay}`
+      )
     })
   })
 })

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -91,7 +91,7 @@ describe('ExchangeRateHostService', () => {
       )
     })
 
-    it('should have different sensible dates for day timeframe', async () => {
+    it('should have different and sensible dates for day timeframe', async () => {
       mockedAxios.get.mockResolvedValue({ data })
 
       await exchangeRateHostService.findPriceHistoryByFiatSymbol({

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.test.ts
@@ -103,7 +103,7 @@ describe('ExchangeRateHostService', () => {
       )
     })
 
-    it('should have different sensible dates for week timeframe', async () => {
+    it('should have different and sensible dates for week timeframe', async () => {
       mockedAxios.get.mockResolvedValue({ data })
 
       await exchangeRateHostService.findPriceHistoryByFiatSymbol({

--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
@@ -21,7 +21,7 @@ export const makeExchangeRateRequestUrls = (
   symbol: SupportedFiatCurrencies,
   baseUrl: string
 ): string[] => {
-  const daysBetween: number = end.diff(start, 'day')
+  const daysBetween = end.diff(start, 'day')
   /**
    * https://exchangerate.host/#/#docs
    * Timeseries endpoint are for daily historical rates between two dates of your choice, with a maximum time frame of 366 days.
@@ -63,11 +63,12 @@ export class ExchangeRateHostService implements FiatMarketService {
     symbol,
     timeframe
   }: FiatPriceHistoryArgs): Promise<HistoryData[]> => {
-    const end = dayjs().startOf('day')
+    const end = dayjs().endOf('day')
     let start
     switch (timeframe) {
       case HistoryTimeframe.HOUR:
-        start = end.subtract(1, 'hour')
+        // minimum granularity on upstream API is 1 day
+        start = end.subtract(1, 'day')
         break
       case HistoryTimeframe.DAY:
         start = end.subtract(1, 'day')


### PR DESCRIPTION
see the tests - we weren't returning any data for the hourly timeframe with the previous changes. ensures this works across all timeframes.