### PR TITLE
feat(chain-adapters): change byChainId to by synchronous

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -41,7 +41,7 @@
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
-    "@shapeshiftoss/unchained-client": "^8.0.0",
+    "@shapeshiftoss/unchained-client": "^8.2.0",
     "bs58check": "^2.0.0"
   },
   "devDependencies": {
@@ -49,7 +49,7 @@
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
-    "@shapeshiftoss/unchained-client": "^8.0.0",
+    "@shapeshiftoss/unchained-client": "^8.2.0",
     "@types/bs58check": "^2.1.0",
     "@types/multicoin-address-validator": "^0.5.0"
   }

--- a/packages/chain-adapters/src/ChainAdapterManager.test.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { ChainTypes } from '@shapeshiftoss/types'
 
-import { UnchainedUrls } from './ChainAdapterManager'
-import { ChainAdapterManager } from './ChainAdapterManager'
+import { ChainAdapterManager, UnchainedUrls } from './ChainAdapterManager'
 import * as ethereum from './ethereum'
 
 const getCAM = (opts?: UnchainedUrls) => {
@@ -118,7 +117,7 @@ describe('ChainAdapterManager', () => {
   })
 
   describe('byChainId', () => {
-    it('should find a supported chain adapter', async () => {
+    it('should find a supported chain adapter', () => {
       const cam = new ChainAdapterManager({})
       // @ts-ignore
       cam.addChain(ChainTypes.Bitcoin, () => ({
@@ -129,17 +128,17 @@ describe('ChainAdapterManager', () => {
         getChainId: () => 'eip155:1'
       }))
 
-      await expect(cam.byChainId('eip155:1')).resolves.toBeTruthy()
+      expect(cam.byChainId('eip155:1')).toBeTruthy()
     })
 
-    it('should throw an error for an invalid ChainId', async () => {
+    it('should throw an error for an invalid ChainId', () => {
       const cam = new ChainAdapterManager({})
-      await expect(cam.byChainId('fake:chainId')).rejects.toThrow('invalid')
+      expect(() => cam.byChainId('fake:chainId')).toThrow('invalid')
     })
 
-    it('should throw an error if there is no supported adapter', async () => {
+    it('should throw an error if there is no supported adapter', () => {
       const cam = new ChainAdapterManager({})
-      await expect(cam.byChainId('eip155:1')).rejects.toThrow('not supported')
+      expect(() => cam.byChainId('eip155:1')).toThrow('not supported')
     })
   })
 })

--- a/packages/chain-adapters/src/ChainAdapterManager.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.ts
@@ -127,14 +127,14 @@ export class ChainAdapterManager {
     return adapter as ChainAdapter<T>
   }
 
-  async byChainId(chainId: ChainId) {
+  byChainId(chainId: ChainId) {
     // this function acts like a validation function and throws if the check doesn't pass
     isChainId(chainId)
 
     for (const [chain] of this.supported) {
       // byChain calls the factory function so we need to call it to create the instances
       const adapter = this.byChain(chain)
-      if ((await adapter.getChainId()) === chainId) return adapter
+      if (adapter.getChainId() === chainId) return adapter
     }
 
     throw new Error(`Chain [${chainId}] is not supported`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,12 +3091,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
-"@types/node@^12.12.6":
-  version "12.20.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
-  integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
-
-"@types/node@^12.7.2":
+"@types/node@^12.12.6", "@types/node@^12.7.2":
   version "12.20.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.50.tgz#14ba5198f1754ffd0472a2f84ab433b45ee0b65e"
   integrity sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==


### PR DESCRIPTION
`ChainAdapter.getChainId()` was changed to a synchronous function a while back but the `byChainId` function was never updated to match.

`byChainId` was async for legacy reasons when we used to get the ChainId from the backend. We don't do that anymore and `byChain` was already changed to synchronous but `byChainId` didn't get changed at the same time.

This isn't a breaking change because you can `await` a synchronous function and you'll get back the correct result. This will only break cases where we use `.then` or `.catch` but I don't think we do.