### PR TITLE
fix: add blacklist and make getBestSwapper return possibly undefined

### DIFF
--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -40,6 +40,22 @@ export class SwapperManager {
   /**
    *
    * @param swapperType swapper type {SwapperType|string}
+   * @returns {Swapper}
+   * @deprecated this will be removed, currently used in swapper tests
+   */
+  getSwapper(swapperType: SwapperType): Swapper {
+    const swapper = this.swappers.get(swapperType)
+    if (!swapper)
+      throw new SwapError('[getSwapper] - swapperType doesnt exist', {
+        code: SwapErrorTypes.MANAGER_ERROR,
+        details: { swapperType }
+      })
+    return swapper
+  }
+
+  /**
+   *
+   * @param swapperType swapper type {SwapperType|string}
    * @returns {SwapperManager}
    */
   removeSwapper(swapperType: SwapperType): this {

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -40,21 +40,6 @@ export class SwapperManager {
   /**
    *
    * @param swapperType swapper type {SwapperType|string}
-   * @returns {Swapper}
-   */
-  getSwapper(swapperType: SwapperType): Swapper {
-    const swapper = this.swappers.get(swapperType)
-    if (!swapper)
-      throw new SwapError('[getSwapper] - swapperType doesnt exist', {
-        code: SwapErrorTypes.MANAGER_ERROR,
-        details: { swapperType }
-      })
-    return swapper
-  }
-
-  /**
-   *
-   * @param swapperType swapper type {SwapperType|string}
    * @returns {SwapperManager}
    */
   removeSwapper(swapperType: SwapperType): this {
@@ -68,7 +53,7 @@ export class SwapperManager {
     return this
   }
 
-  async getBestSwapper(args: ByPairInput): Promise<Swapper> {
+  async getBestSwapper(args: ByPairInput): Promise<Swapper | undefined> {
     // TODO: This will eventually have logic to determine the best swapper.
     // For now we return the first swapper we get from getSwappersByPair
     return this.getSwappersByPair(args)[0]

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -103,7 +103,12 @@ const main = async (): Promise<void> => {
   const manager = new SwapperManager()
   const zrxSwapper = new ZrxSwapper(zrxSwapperDeps)
   manager.addSwapper(SwapperType.Zrx, zrxSwapper)
-  const swapper = manager.getSwapper(SwapperType.Zrx)
+  const swapper = await manager.getBestSwapper({
+    sellAssetId: 'eip155:1/slip44:60',
+    buyAssetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
+  })
+
+  if (!swapper) return
   const sellAmountBase = toBaseUnit(sellAmount, sellAsset.precision)
 
   let quote

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -24,6 +24,7 @@ import {
 } from '../../api'
 import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
 import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
+import { UNSUPPORTED_ASSETS } from './utils/blacklist'
 import { getUsdRate } from './utils/helpers/helpers'
 import { ZrxApprovalNeeded } from './ZrxApprovalNeeded/ZrxApprovalNeeded'
 import { ZrxApproveInfinite } from './ZrxApproveInfinite/ZrxApproveInfinite'
@@ -79,10 +80,15 @@ export class ZrxSwapper implements Swapper {
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
     const { assetIds = [], sellAssetId } = args
-    return assetIds.filter((id) => id.startsWith('eip155:1') && sellAssetId?.startsWith('eip155:1'))
+    return assetIds.filter(
+      (id) =>
+        id.startsWith('eip155:1') &&
+        sellAssetId?.startsWith('eip155:1') &&
+        !UNSUPPORTED_ASSETS.includes(id)
+    )
   }
 
   filterAssetIdsBySellable(assetIds: AssetId[] = []): AssetId[] {
-    return assetIds.filter((id) => id.startsWith('eip155:1'))
+    return assetIds.filter((id) => id.startsWith('eip155:1') && !UNSUPPORTED_ASSETS.includes(id))
   }
 }

--- a/packages/swapper/src/swappers/zrx/utils/blacklist.ts
+++ b/packages/swapper/src/swappers/zrx/utils/blacklist.ts
@@ -1,0 +1,6 @@
+// Zrx doesnt have an easily accessible master assets list.
+// We assume all erc20's are supported and remove these explicitely unsupported assets
+export const UNSUPPORTED_ASSETS = Object.freeze([
+  // Foxy token unsupported by zrx
+  'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3'
+])


### PR DESCRIPTION
add blacklist and make getBestSwapper return possibly undefined

remove unused getSwapper()