### PR TITLE
feat: add supply and maxSupply to marketData

### DIFF
--- a/packages/types/src/market.ts
+++ b/packages/types/src/market.ts
@@ -3,6 +3,8 @@ export type MarketData = {
   marketCap: string
   volume: string
   changePercent24Hr: number
+  supply?: string
+  maxSupply?: string
 }
 
 export enum HistoryTimeframe {


### PR DESCRIPTION
Due to previous PR changing 2 packages, creating this one containing only `types` changes from this PR : https://github.com/shapeshift/lib/pull/670
To be merged first.