### PR TITLE
chore: add zrx specific trade type to hold zrx specific trade data

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -83,9 +83,12 @@ export interface TradeQuote<C extends SupportedChainIds> extends TradeBase<C> {
 }
 
 export interface Trade<C extends SupportedChainIds> extends TradeBase<C> {
+  receiveAddress: string
+}
+
+export interface ZrxTrade<C extends SupportedChainIds> extends Trade<C> {
   txData: string
   depositAddress: string
-  receiveAddress: string
 }
 
 export type ExecuteTradeInput<C extends SupportedChainIds> = {

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -19,8 +19,8 @@ import {
   ExecuteTradeInput,
   GetTradeQuoteInput,
   Swapper,
-  Trade,
-  TradeQuote
+  TradeQuote,
+  ZrxTrade
 } from '../../api'
 import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
 import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
@@ -48,7 +48,7 @@ export class ZrxSwapper implements Swapper {
     return SwapperType.Zrx
   }
 
-  async buildTrade(args: BuildTradeInput): Promise<Trade<SupportedChainIds>> {
+  async buildTrade(args: BuildTradeInput): Promise<ZrxTrade<SupportedChainIds>> {
     return zrxBuildTrade(this.deps, args)
   }
 

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -1,8 +1,9 @@
 import { SupportedChainIds } from '@shapeshiftoss/types'
+import { SwapperType } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 import * as rax from 'retry-axios'
 
-import { BuildTradeInput, SwapError, SwapErrorTypes, Trade } from '../../..'
+import { BuildTradeInput, SwapError, SwapErrorTypes, ZrxTrade } from '../../..'
 import { ZrxQuoteResponse } from '../types'
 import { erc20AllowanceAbi } from '../utils/abi/erc20Allowance-abi'
 import { applyAxiosRetry } from '../utils/applyAxiosRetry'
@@ -20,7 +21,7 @@ import { ZrxSwapperDeps } from '../ZrxSwapper'
 export async function zrxBuildTrade(
   { adapterManager, web3 }: ZrxSwapperDeps,
   input: BuildTradeInput
-): Promise<Trade<SupportedChainIds>> {
+): Promise<ZrxTrade<SupportedChainIds>> {
   const {
     sellAsset,
     buyAsset,
@@ -90,7 +91,8 @@ export async function zrxBuildTrade(
 
     const estimatedGas = bnOrZero(data.gas || 0)
 
-    const trade: Trade<'eip155:1'> = {
+    const trade: ZrxTrade<'eip155:1'> = {
+      swapperType: SwapperType.Zrx,
       sellAsset,
       buyAsset,
       success: true,

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -1,5 +1,4 @@
 import { SupportedChainIds } from '@shapeshiftoss/types'
-import { SwapperType } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 import * as rax from 'retry-axios'
 
@@ -92,7 +91,6 @@ export async function zrxBuildTrade(
     const estimatedGas = bnOrZero(data.gas || 0)
 
     const trade: ZrxTrade<'eip155:1'> = {
-      swapperType: SwapperType.Zrx,
       sellAsset,
       buyAsset,
       success: true,

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -39,7 +39,7 @@ describe('ZrxExecuteTrade', () => {
       fee: '0',
       chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' }
     },
-    sources: [],
+    sources: []
   }
 
   const execTradeInput: ExecuteTradeInput<'eip155:1'> = {

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -21,37 +21,36 @@ describe('ZrxExecuteTrade', () => {
     }))
   }
   const deps = { adapterManager } as unknown as ZrxSwapperDeps
+
+  const trade: ZrxTrade<'eip155:1'> = {
+    buyAsset,
+    sellAsset,
+    success: true,
+    statusReason: '',
+    sellAmount: '1',
+    buyAmount: '',
+    depositAddress: '0x123',
+    allowanceContract: 'allowanceTargetAddress',
+    receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    sellAssetAccountId: '0',
+    txData: '0x123',
+    rate: '1',
+    feeData: {
+      fee: '0',
+      chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' }
+    },
+    sources: [],
+  }
+
   const execTradeInput: ExecuteTradeInput<'eip155:1'> = {
-    trade: {
-      buyAsset,
-      sellAsset,
-      success: true,
-      statusReason: '',
-      sellAmount: '1',
-      buyAmount: '',
-      depositAddress: '0x123',
-      allowanceContract: 'allowanceTargetAddress',
-      receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-      sellAssetAccountId: '0',
-      txData: '0x123',
-      rate: '1',
-      feeData: {
-        fee: '0',
-        chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' }
-      },
-      sources: []
-    } as ZrxTrade<'eip155:1'>,
+    trade,
     wallet
   }
 
   it('returns txid if offline signing is supported', async () => {
     expect(
       await zrxExecuteTrade(deps, {
-        ...execTradeInput,
-        trade: {
-          ...execTradeInput.trade,
-          depositAddress: '0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765'
-        } as ZrxTrade<'eip155:1'>
+        ...execTradeInput
       })
     ).toEqual({ txid })
   })
@@ -64,11 +63,7 @@ describe('ZrxExecuteTrade', () => {
 
     expect(
       await zrxExecuteTrade(deps, {
-        ...execTradeInput,
-        trade: {
-          ...execTradeInput.trade,
-          depositAddress: '0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765'
-        } as ZrxTrade<'eip155:1'>
+        ...execTradeInput
       })
     ).toEqual({ txid })
   })

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -1,6 +1,6 @@
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 
-import { ExecuteTradeInput } from '../../../api'
+import { ExecuteTradeInput, ZrxTrade } from '../../../api'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
 import { zrxExecuteTrade } from './zrxExecuteTrade'
@@ -40,7 +40,7 @@ describe('ZrxExecuteTrade', () => {
         chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' }
       },
       sources: []
-    },
+    } as ZrxTrade<'eip155:1'>,
     wallet
   }
 
@@ -51,7 +51,7 @@ describe('ZrxExecuteTrade', () => {
         trade: {
           ...execTradeInput.trade,
           depositAddress: '0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765'
-        }
+        } as ZrxTrade<'eip155:1'>
       })
     ).toEqual({ txid })
   })
@@ -68,7 +68,7 @@ describe('ZrxExecuteTrade', () => {
         trade: {
           ...execTradeInput.trade,
           depositAddress: '0x728F1973c71f7567dE2a34Fa2838D4F0FB7f9765'
-        }
+        } as ZrxTrade<'eip155:1'>
       })
     ).toEqual({ txid })
   })


### PR DESCRIPTION
Add zrx specific trade type to hold zrx specific trade tx data.

This is safe to merge because web uses the `Trade` type and `ZrxTrade` extends `Trade`