### PR TITLE
chore(investorFoxy): bump investor-foxy CAIP dependency to 5.0.0

### DIFF
--- a/packages/investor-foxy/README.md
+++ b/packages/investor-foxy/README.md
@@ -12,11 +12,11 @@ yarn add @shapeshiftoss/investor-foxy
 
 ```javascript
 import { FoxyApi } from '@shapeshiftoss/investor-foxy'
-import { toChainId } from '@shapeshiftoss/caip'
+import { toChainId, CHAIN_NAMESPACE, CHAIN_REFERENCE } from '@shapeshiftoss/caip'
 
 const api = new FoxyApi({
   adapter: await adapterManager.byChainId(
-    toChainId({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+    toChainId({ chainNamespace: CHAIN_NAMESPACE.Ethereum, chainReference: CHAIN_REFERENCE.EthereumMainnet })
   ), // adapter is an ETH @shapeshiftoss/chain-adapters
   providerUrl: '<your eth node privider url>'
 })
@@ -60,7 +60,7 @@ For more in-depth examples, check out ./src/foxycli.ts
 ```javascript
 const api = new FoxyApi({
   adapter: await adapterManager.byChainId(
-    toChainId({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+    toChainId({ chainNamespace: CHAIN_NAMESPACE.Ethereum, chainReference: CHAIN_REFERENCE.EthereumMainnet })
   ),
   providerUrl: 'https://dev-api.ethereum.shapeshift.com'
 })

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -36,13 +36,13 @@
     "web3-utils": "^1.7.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0"

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1,7 +1,7 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { CHAIN_REFERENCE, ChainReference, toAssetId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, CHAIN_REFERENCE, ChainReference, toAssetId } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
-import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
+import { ChainTypes, WithdrawType } from '@shapeshiftoss/types'
 import axios from 'axios'
 import { BigNumber } from 'bignumber.js'
 import { toLower } from 'lodash'
@@ -53,7 +53,7 @@ import {
 
 export * from './foxy-types'
 
-type Network =
+type EthereumChainReference =
   | typeof CHAIN_REFERENCE.EthereumMainnet
   | typeof CHAIN_REFERENCE.EthereumRinkeby
   | typeof CHAIN_REFERENCE.EthereumRopsten
@@ -62,7 +62,7 @@ export type ConstructorArgs = {
   adapter: ChainAdapter<ChainTypes.Ethereum>
   providerUrl: string
   foxyAddresses: FoxyAddressesType
-  network?: Network
+  chainReference?: EthereumChainReference
 }
 
 export const transformData = ({ tvl, apy, expired, ...contractData }: FoxyOpportunityInputData) => {
@@ -90,14 +90,14 @@ export class FoxyApi {
   public web3: Web3
   private foxyStakingContracts: Contract[]
   private liquidityReserveContracts: Contract[]
-  private network: ChainReference
+  private readonly ethereumChainReference: ChainReference
   private foxyAddresses: FoxyAddressesType
 
   constructor({
     adapter,
     providerUrl,
     foxyAddresses,
-    network = CHAIN_REFERENCE.EthereumMainnet
+    chainReference = CHAIN_REFERENCE.EthereumMainnet
   }: ConstructorArgs) {
     this.adapter = adapter
     this.provider = new Web3.providers.HttpProvider(providerUrl)
@@ -109,7 +109,7 @@ export class FoxyApi {
     this.liquidityReserveContracts = foxyAddresses.map(
       (addresses) => new this.web3.eth.Contract(liquidityReserveAbi, addresses.liquidityReserve)
     )
-    this.network = network
+    this.ethereumChainReference = chainReference
     this.providerUrl = providerUrl
     this.foxyAddresses = foxyAddresses
   }
@@ -408,11 +408,11 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const estimatedGas = estimatedGasBN.toString()
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -474,10 +474,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -524,10 +524,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -639,10 +639,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -749,10 +749,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -797,10 +797,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -844,10 +844,10 @@ export class FoxyApi {
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
     const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
-    const chainId = Number(this.network)
+    const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
-      chainId,
+      chainId: chainReferenceAsNumber,
       data,
       estimatedGas,
       gasPrice,
@@ -1080,12 +1080,12 @@ export class FoxyApi {
       }
     })
 
-    const chain = ChainTypes.Ethereum
-    const network = NetworkTypes.MAINNET
+    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainReference = CHAIN_REFERENCE.EthereumMainnet
     const assetNamespace = 'erc20'
     const assetReference = tokenContractAddress
     // foxy assetId
-    const assetId = toAssetId({ chain, network, assetNamespace, assetReference })
+    const assetId = toAssetId({ chainNamespace, chainReference, assetNamespace, assetReference })
 
     const results = await Promise.allSettled(
       events.map(async (event) => {

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -1,7 +1,7 @@
-import { toChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, CHAIN_REFERENCE, toChainId } from '@shapeshiftoss/caip'
 import { ChainAdapter, ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { ChainTypes, NetworkTypes, WithdrawType } from '@shapeshiftoss/types'
+import { ChainTypes, WithdrawType } from '@shapeshiftoss/types'
 import dotenv from 'dotenv'
 import readline from 'readline-sync'
 
@@ -45,7 +45,10 @@ const main = async (): Promise<void> => {
 
   const api = new FoxyApi({
     adapter: (await adapterManager.byChainId(
-      toChainId({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+      toChainId({
+        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet
+      })
     )) as ChainAdapter<ChainTypes.Ethereum>,
     providerUrl: process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
     foxyAddresses


### PR DESCRIPTION
- Updates `investor-foxy`'s CAIP package dependency to `5.0.0`, a breaking change: https://github.com/shapeshift/lib/pull/676
- Fixes variable naming of 'network' and 'chainId' - the values they contained were not these things

---

This is a patch release of `@shapeshiftoss/investor-foxy`.