### PR TITLE
chore(marketService): bump market-service CAIP dependency to 5.0.0

### DIFF
--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -36,11 +36,11 @@
     "p-ratelimit": "^1.0.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/types": "^4.3.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/types": "^4.3.0",
     "limiter": "^2.1.0"
   }

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -1,4 +1,4 @@
-import { adapters, fromAssetId } from '@shapeshiftoss/caip'
+import { adapters, CHAIN_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import {
   ChainTypes,
   FindAllMarketArgs,
@@ -94,8 +94,8 @@ export class CoinGeckoMarketService implements MarketService {
   findByAssetId = async ({ assetId }: MarketDataArgs): Promise<MarketData | null> => {
     try {
       if (!adapters.assetIdToCoingecko(assetId)) return null
-      const { chain, assetReference } = fromAssetId(assetId)
-      const isToken = chain === ChainTypes.Ethereum && assetReference.startsWith('0x')
+      const { chainNamespace, assetReference } = fromAssetId(assetId)
+      const isToken = chainNamespace === CHAIN_NAMESPACE.Ethereum && assetReference.startsWith('0x')
       const id = isToken ? 'ethereum' : adapters.assetIdToCoingecko(assetId)
       const contractUrl = isToken ? `/contract/${assetReference}` : ''
 
@@ -131,8 +131,8 @@ export class CoinGeckoMarketService implements MarketService {
   }: PriceHistoryArgs): Promise<HistoryData[]> => {
     if (!adapters.assetIdToCoingecko(assetId)) return []
     try {
-      const { chain, assetReference } = fromAssetId(assetId)
-      const isToken = chain === ChainTypes.Ethereum && assetReference.startsWith('0x')
+      const { chainNamespace, assetReference } = fromAssetId(assetId)
+      const isToken = chainNamespace === CHAIN_NAMESPACE.Ethereum && assetReference.startsWith('0x')
       const id = isToken ? 'ethereum' : adapters.assetIdToCoingecko(assetId)
       const contract = isToken ? `/contract/${assetReference}` : ''
 

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -1,5 +1,4 @@
-import { toAssetId } from '@shapeshiftoss/caip'
-import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { CHAIN_NAMESPACE, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 
 import { YearnTokenMarketCapService } from './yearn-tokens'
 import { mockYearnTokenRestData } from './yearnMockData'
@@ -69,14 +68,14 @@ describe('yearn token market service', () => {
     it('can map yearn to assetIds', async () => {
       const result = await yearnTokenMarketCapService.findAll()
       const yvBtcAssetId = toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnTokenRestData[0].address.toLowerCase()
       })
       const yvDaiAssetId = toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnTokenRestData[1].address.toLowerCase()
       })

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -1,12 +1,10 @@
-import { adapters, toAssetId } from '@shapeshiftoss/caip'
+import { adapters, CHAIN_NAMESPACE, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import {
-  ChainTypes,
   FindAllMarketArgs,
   HistoryData,
   MarketCapResult,
   MarketData,
-  MarketDataArgs,
-  NetworkTypes
+  MarketDataArgs
 } from '@shapeshiftoss/types'
 import { ChainId, Token, Yearn } from '@yfi/sdk'
 import uniqBy from 'lodash/uniqBy'
@@ -57,8 +55,8 @@ export class YearnTokenMarketCapService implements MarketService {
 
       return tokens.reduce((acc, token) => {
         const _assetId: string = toAssetId({
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET,
+          chainNamespace: CHAIN_NAMESPACE.Ethereum,
+          chainReference: CHAIN_REFERENCE.EthereumMainnet,
           assetNamespace: 'erc20',
           assetReference: token.address
         })

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -1,5 +1,5 @@
-import { toAssetId } from '@shapeshiftoss/caip'
-import { ChainTypes, HistoryTimeframe, NetworkTypes } from '@shapeshiftoss/types'
+import { CHAIN_NAMESPACE, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import { HistoryTimeframe } from '@shapeshiftoss/types'
 
 import { YearnVaultMarketCapService } from './yearn-vaults'
 import { mockYearnGQLData, mockYearnVaultRestData } from './yearnMockData'
@@ -38,8 +38,8 @@ describe('yearn market service', () => {
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result)[0]).toEqual(
         toAssetId({
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET,
+          chainNamespace: CHAIN_NAMESPACE.Ethereum,
+          chainReference: CHAIN_REFERENCE.EthereumMainnet,
           assetNamespace: 'erc20',
           assetReference: yvBTCAddress.toLowerCase()
         })
@@ -73,14 +73,14 @@ describe('yearn market service', () => {
     it('can map yearn to AssetIds', async () => {
       const result = await yearnVaultMarketCapService.findAll()
       const yvBtcAssetId = toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnVaultRestData[0].address.toLowerCase()
       })
       const yvDaiAssetId = toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnVaultRestData[1].address.toLowerCase()
       })

--- a/packages/market-service/src/yearn/yearn-vaults.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.ts
@@ -1,13 +1,11 @@
-import { adapters, toAssetId } from '@shapeshiftoss/caip'
+import { adapters, CHAIN_NAMESPACE, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import {
-  ChainTypes,
   FindAllMarketArgs,
   HistoryData,
   HistoryTimeframe,
   MarketCapResult,
   MarketData,
   MarketDataArgs,
-  NetworkTypes,
   PriceHistoryArgs
 } from '@shapeshiftoss/types'
 import { ChainId, Yearn } from '@yfi/sdk'
@@ -55,8 +53,8 @@ export class YearnVaultMarketCapService implements MarketService {
         )
         .reduce((acc, yearnItem) => {
           const assetId = toAssetId({
-            chain: ChainTypes.Ethereum,
-            network: NetworkTypes.MAINNET,
+            chainNamespace: CHAIN_NAMESPACE.Ethereum,
+            chainReference: CHAIN_REFERENCE.EthereumMainnet,
             assetNamespace: 'erc20',
             assetReference: yearnItem.address
           })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,11 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
+"@shapeshiftoss/caip@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.1.tgz#e1afdfafd540769c2d9ee9c2236fbbf4136467f6"
+  integrity sha512-kwb2S3QUKLJ5lPhumi6FYm1x9/bhzjJqPVR4NvEqU6kQgE03Ovf4zVT6FWxWPqcqNGK6w4DJIsmvy2YBRmdCEQ==
+
 "@shapeshiftoss/common-api@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-6.11.0.tgz#cea7fc9acc02645bef376ef77a8b4977b31441c4"


### PR DESCRIPTION
- Updates `market-service`'s CAIP package dependency to `5.0.0`, a breaking change: https://github.com/shapeshift/lib/pull/676

---

This is a patch release of `@shapeshiftoss/market-service`.