### PR TITLE
chore(chainAdapters): bump chain-adapters CAIP dependency to 5.0.0

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -37,7 +37,7 @@
     "web3-utils": "^1.6.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
@@ -45,7 +45,7 @@
     "bs58check": "^2.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/hdwallet-native": "^1.20.0",
     "@shapeshiftoss/types": "^4.0.0",

--- a/packages/chain-adapters/src/ChainAdapterManager.test.ts
+++ b/packages/chain-adapters/src/ChainAdapterManager.test.ts
@@ -111,7 +111,6 @@ describe('ChainAdapterManager', () => {
 
   describe('getSupportedAdapters', () => {
     it('should return array of adapter classes', () => {
-      // @ts-ignore
       expect(getCAM().getSupportedAdapters()).toStrictEqual([expect.any(Function)])
     })
   })
@@ -133,12 +132,12 @@ describe('ChainAdapterManager', () => {
 
     it('should throw an error for an invalid ChainId', () => {
       const cam = new ChainAdapterManager({})
-      expect(() => cam.byChainId('fake:chainId')).toThrow('invalid')
+      expect(() => cam.byChainId('fake:chainId')).toThrow('Chain [fake:chainId] is not supported')
     })
 
     it('should throw an error if there is no supported adapter', () => {
       const cam = new ChainAdapterManager({})
-      expect(() => cam.byChainId('eip155:1')).toThrow('not supported')
+      expect(() => cam.byChainId('eip155:1')).toThrow('Chain [eip155:1] is not supported')
     })
   })
 })

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -1,4 +1,11 @@
-import { ASSET_REFERENCE, AssetId, ChainId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
+import {
+  ASSET_REFERENCE,
+  AssetId,
+  CHAIN_NAMESPACE,
+  ChainId,
+  fromChainId,
+  toAssetId
+} from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   BTCOutputAddressType,
@@ -56,14 +63,15 @@ export class ChainAdapter
     } else {
       this.chainId = this.supportedChainIds[0]
     }
-    const { chain, network } = fromChainId(this.chainId)
-    if (chain !== ChainTypes.Bitcoin) {
+
+    const chainId = this.chainId
+    const { chainNamespace } = fromChainId(chainId)
+    if (chainNamespace !== CHAIN_NAMESPACE.Bitcoin) {
       throw new Error('chainId must be a bitcoin chain type')
     }
     this.coinName = args.coinName
     this.assetId = toAssetId({
-      chain,
-      network,
+      chainId,
       assetNamespace: 'slip44',
       assetReference: ASSET_REFERENCE.Bitcoin
     })

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -1,10 +1,4 @@
-import {
-  ASSET_REFERENCE,
-  AssetId,
-  CHAIN_REFERENCE,
-  fromChainId,
-  toAssetId
-} from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, AssetId, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   CosmosSignTx,
@@ -37,11 +31,10 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Cosmos> {
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = fromChainId(this.chainId)
+    const chainId = this.chainId
 
     this.assetId = toAssetId({
-      chain,
-      network,
+      chainId,
       assetNamespace: 'slip44',
       assetReference: ASSET_REFERENCE.Cosmos
     })

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -1,10 +1,4 @@
-import {
-  ASSET_REFERENCE,
-  AssetId,
-  CHAIN_REFERENCE,
-  fromChainId,
-  toAssetId
-} from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, AssetId, CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import {
   bip32ToAddressNList,
   OsmosisSignTx,
@@ -37,11 +31,10 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<ChainTypes.Osmosis> {
   constructor(args: ChainAdapterArgs) {
     super(args)
 
-    const { chain, network } = fromChainId(this.chainId)
+    const chainId = this.chainId
 
     this.assetId = toAssetId({
-      chain,
-      network,
+      chainId,
       assetNamespace: 'slip44',
       assetReference: ASSET_REFERENCE.Osmosis
     })

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -2,6 +2,7 @@ import { Contract } from '@ethersproject/contracts'
 import {
   ASSET_REFERENCE,
   AssetId,
+  CHAIN_NAMESPACE,
   ChainId,
   fromAssetId,
   fromChainId,
@@ -52,8 +53,8 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
   constructor(args: ChainAdapterArgs) {
     if (args.chainId) {
       try {
-        const { chain } = fromChainId(args.chainId)
-        if (chain !== ChainTypes.Ethereum) {
+        const { chainNamespace } = fromChainId(args.chainId)
+        if (chainNamespace !== CHAIN_NAMESPACE.Ethereum) {
           throw new Error()
         }
         this.chainId = args.chainId
@@ -79,7 +80,6 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
   async getAccount(pubkey: string): Promise<chainAdapters.Account<ChainTypes.Ethereum>> {
     try {
       const chainId = this.getChainId()
-      const { chain, network } = fromChainId(chainId)
       const { data } = await this.providers.http.getAccount({ pubkey })
 
       const balance = bnOrZero(data.balance).plus(bnOrZero(data.unconfirmedBalance))
@@ -88,8 +88,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
         balance: balance.toString(),
         chainId,
         assetId: toAssetId({
-          chain,
-          network,
+          chainId,
           assetNamespace: 'slip44',
           assetReference: ASSET_REFERENCE.Ethereum
         }),
@@ -99,8 +98,7 @@ export class ChainAdapter implements IChainAdapter<ChainTypes.Ethereum> {
           tokens: data.tokens.map((token) => ({
             balance: token.balance,
             assetId: toAssetId({
-              chain,
-              network,
+              chainId,
               assetNamespace: getAssetNamespace(token.type),
               assetReference: token.contract
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,11 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
+"@shapeshiftoss/caip@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.1.tgz#e1afdfafd540769c2d9ee9c2236fbbf4136467f6"
+  integrity sha512-kwb2S3QUKLJ5lPhumi6FYm1x9/bhzjJqPVR4NvEqU6kQgE03Ovf4zVT6FWxWPqcqNGK6w4DJIsmvy2YBRmdCEQ==
+
 "@shapeshiftoss/common-api@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-6.11.0.tgz#cea7fc9acc02645bef376ef77a8b4977b31441c4"


### PR DESCRIPTION
- Updates `chain-adapters`' CAIP package dependency to `5.0.0`, a breaking change: https://github.com/shapeshift/lib/pull/676

---

This is a patch release of `@shapeshiftoss/chain-adapters`.