### PR TITLE
chore(assetService): bump asset-service CAIP dependency to 5.0.0

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -34,12 +34,12 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
     "@ethersproject/providers": "^5.5.2",
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/types": "^4.0.0",
     "@types/lodash": "^4.14.172",
     "@yfi/sdk": "^1.0.30",

--- a/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/ethereum.ts
@@ -53,8 +53,8 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
   for (const [i, batch] of tokenBatches.entries()) {
     console.info(`processing batch ${i + 1} of ${tokenBatches.length}`)
     const promises = batch.map(async (token) => {
-      const { chain } = fromAssetId(token.assetId)
-      const { info } = generateTrustWalletUrl({ chain, tokenId: token.tokenId })
+      const { chainNamespace } = fromAssetId(token.assetId)
+      const { info } = generateTrustWalletUrl({ chainNamespace, tokenId: token.tokenId })
       return axios.head(info) // return promise
     })
     const result = await Promise.allSettled(promises)
@@ -80,8 +80,11 @@ export const addTokensToEth = async (): Promise<BaseAsset> => {
         }
         return uniqueTokens[key] // token without modified icon
       } else {
-        const { chain } = fromAssetId(uniqueTokens[key].assetId)
-        const { icon } = generateTrustWalletUrl({ chain, tokenId: uniqueTokens[key].tokenId })
+        const { chainNamespace } = fromAssetId(uniqueTokens[key].assetId)
+        const { icon } = generateTrustWalletUrl({
+          chainNamespace,
+          tokenId: uniqueTokens[key].tokenId
+        })
         return { ...uniqueTokens[key], icon }
       }
     })

--- a/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/foxy.ts
@@ -1,20 +1,17 @@
-import { toAssetId, toChainId } from '@shapeshiftoss/caip'
-import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
+import { ethChainId as chainId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetDataSource, TokenAsset } from '@shapeshiftoss/types'
 
 export const getFoxyToken = (): TokenAsset[] => {
-  const chain = ChainTypes.Ethereum
-  const network = NetworkTypes.MAINNET
   const assetNamespace = 'erc20'
   const assetReference = '0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3' // FOXy contract address
 
   const result: TokenAsset = {
     assetId: toAssetId({
-      chain,
-      network,
+      chainId,
       assetNamespace,
       assetReference
     }),
-    chainId: toChainId({ chain, network }),
+    chainId,
     dataSource: AssetDataSource.CoinGecko,
     name: 'FOX Yieldy',
     precision: 18,

--- a/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/uniswap.ts
@@ -1,5 +1,5 @@
-import { toAssetId, toChainId } from '@shapeshiftoss/caip'
-import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
+import { ethChainId as chainId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetDataSource, TokenAsset } from '@shapeshiftoss/types'
 import axios from 'axios'
 import lodash from 'lodash'
 
@@ -27,8 +27,6 @@ export async function getUniswapTokens(): Promise<TokenAsset[]> {
     'https://tokens.coingecko.com/uniswap/all.json'
   )
 
-  const chain = ChainTypes.Ethereum
-  const network = NetworkTypes.MAINNET
   const assetNamespace = 'erc20'
 
   return uniswapTokenData.tokens.reduce<TokenAsset[]>((acc, token) => {
@@ -49,8 +47,8 @@ export async function getUniswapTokens(): Promise<TokenAsset[]> {
       return acc
     }
     const result: TokenAsset = {
-      assetId: toAssetId({ chain, network, assetNamespace, assetReference }),
-      chainId: toChainId({ chain, network }),
+      assetId: toAssetId({ chainId, assetNamespace, assetReference }),
+      chainId,
       dataSource: AssetDataSource.CoinGecko,
       name: token.name,
       precision: token.decimals,

--- a/packages/asset-service/src/generateAssetData/ethTokens/uniswapV2Pools.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/uniswapV2Pools.ts
@@ -1,20 +1,17 @@
-import { toAssetId, toChainId } from '@shapeshiftoss/caip'
-import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
+import { ethChainId as chainId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetDataSource, TokenAsset } from '@shapeshiftoss/types'
 
 export const getUniswapV2Pools = (): TokenAsset[] => {
-  const chain = ChainTypes.Ethereum
-  const network = NetworkTypes.MAINNET
   const assetNamespace = 'erc20'
   const assetReference = '0x470e8de2ebaef52014a47cb5e6af86884947f08c' // Uniswap V2 - FOX/WETH contract address
 
   const result: TokenAsset = {
     assetId: toAssetId({
-      chain,
-      network,
+      chainId,
       assetNamespace,
       assetReference
     }),
-    chainId: toChainId({ chain, network }),
+    chainId,
     dataSource: AssetDataSource.CoinGecko,
     name: 'Uniswap V2 - FOX/WETH',
     precision: 18,

--- a/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
+++ b/packages/asset-service/src/generateAssetData/ethTokens/yearnVaults.ts
@@ -1,5 +1,5 @@
-import { toAssetId, toChainId } from '@shapeshiftoss/caip'
-import { AssetDataSource, ChainTypes, NetworkTypes, TokenAsset } from '@shapeshiftoss/types'
+import { ethChainId as chainId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetDataSource, TokenAsset } from '@shapeshiftoss/types'
 import { Token, Vault } from '@yfi/sdk'
 import toLower from 'lodash/toLower'
 
@@ -21,13 +21,9 @@ export const getYearnVaults = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: vault.symbol,
       tokenId: toLower(vault.address),
-      chainId: toChainId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET
-      }),
+      chainId,
       assetId: toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainId,
         assetNamespace: 'erc20',
         assetReference: vault.address
       })
@@ -50,13 +46,9 @@ export const getIronBankTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: toChainId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET
-      }),
+      chainId,
       assetId: toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainId,
         assetNamespace: 'erc20',
         assetReference: token.address
       })
@@ -79,13 +71,9 @@ export const getZapperTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: toChainId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET
-      }),
+      chainId,
       assetId: toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainId,
         assetNamespace: 'erc20',
         assetReference: token.address
       })
@@ -108,13 +96,9 @@ export const getUnderlyingVaultTokens = async (): Promise<TokenAsset[]> => {
       sendSupport: true,
       symbol: token.symbol,
       tokenId: toLower(token.address),
-      chainId: toChainId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET
-      }),
+      chainId,
       assetId: toAssetId({
-        chain: ChainTypes.Ethereum,
-        network: NetworkTypes.MAINNET,
+        chainId,
         assetNamespace: 'erc20',
         assetReference: token.address
       })

--- a/packages/asset-service/src/service/TrustWalletService.ts
+++ b/packages/asset-service/src/service/TrustWalletService.ts
@@ -1,16 +1,16 @@
-import { ChainTypes } from '@shapeshiftoss/types'
+import { CHAIN_NAMESPACE, ChainNamespace } from '@shapeshiftoss/caip'
 import Web3 from 'web3'
 
 type TrustWalletServiceProps = {
-  chain: ChainTypes
+  chainNamespace: ChainNamespace
   tokenId: string
 }
-export const generateTrustWalletUrl = ({ chain, tokenId }: TrustWalletServiceProps) => {
-  let url = `https://rawcdn.githack.com/trustwallet/assets/master/blockchains/${chain}`
+export const generateTrustWalletUrl = ({ chainNamespace, tokenId }: TrustWalletServiceProps) => {
+  let url = `https://rawcdn.githack.com/trustwallet/assets/master/blockchains/${chainNamespace}`
   if (tokenId) {
     url += `/assets/`
-    switch (chain) {
-      case ChainTypes.Ethereum:
+    switch (chainNamespace) {
+      case CHAIN_NAMESPACE.Ethereum:
         url += Web3.utils.toChecksumAddress(tokenId)
         break
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,11 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
+"@shapeshiftoss/caip@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.1.tgz#e1afdfafd540769c2d9ee9c2236fbbf4136467f6"
+  integrity sha512-kwb2S3QUKLJ5lPhumi6FYm1x9/bhzjJqPVR4NvEqU6kQgE03Ovf4zVT6FWxWPqcqNGK6w4DJIsmvy2YBRmdCEQ==
+
 "@shapeshiftoss/common-api@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-6.11.0.tgz#cea7fc9acc02645bef376ef77a8b4977b31441c4"


### PR DESCRIPTION
- Updates `asset-service`'s CAIP package dependency to `5.0.0`, a breaking change: https://github.com/shapeshift/lib/pull/676

No asset re-generation should be necessary as this is a refactor only.

---

This is a patch release of `@shapeshiftoss/asset-service`.