### PR TITLE
chore: bump packages unaffected by CAIP 5.0.0 breaking change

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/asset-service": "^3.0.0",
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "1.20.0",
     "@shapeshiftoss/types": "^4.0.0",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@shapeshiftoss/asset-service": "^3.0.0",
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.20.0",
     "@shapeshiftoss/types": "^4.1.0",

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -30,13 +30,13 @@
     "ws": "^8.3.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^4.0.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.5.1",
-    "@shapeshiftoss/caip": "^4.0.1",
+    "@shapeshiftoss/caip": "^5.0.0",
     "@shapeshiftoss/common-api": "^6.11.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,11 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
+"@shapeshiftoss/caip@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.1.tgz#e1afdfafd540769c2d9ee9c2236fbbf4136467f6"
+  integrity sha512-kwb2S3QUKLJ5lPhumi6FYm1x9/bhzjJqPVR4NvEqU6kQgE03Ovf4zVT6FWxWPqcqNGK6w4DJIsmvy2YBRmdCEQ==
+
 "@shapeshiftoss/common-api@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-6.11.0.tgz#cea7fc9acc02645bef376ef77a8b4977b31441c4"


### PR DESCRIPTION
Bump `@shapeshiftoss/caip` to `5.0.0` in packages that are unaffected by the breaking change in https://github.com/shapeshift/lib/pull/676.

This is a patch release for the two affected package:
- `@shapeshiftoss/swapper`
- `@shapeshiftoss/unchained-client`