### PR TITLE
feat(caip): use branded types

### DIFF
--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/caip",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "CAIP Implementation",
   "homepage": "",
   "license": "MIT",

--- a/packages/caip/src/accountId/accountId.ts
+++ b/packages/caip/src/accountId/accountId.ts
@@ -1,8 +1,9 @@
 import { ChainId, ChainNamespace, ChainReference, fromChainId, toChainId } from '../chainId/chainId'
 import { CHAIN_NAMESPACE } from '../constants'
 import { assertIsChainId, assertIsChainNamespace, assertIsChainReference } from '../typeGuards'
+import { Brand } from '../utils'
 
-export type AccountId = string
+export type AccountId = Brand<string, 'AccountId'>
 
 type ToAccountIdWithChainId = {
   chainId: ChainId
@@ -42,7 +43,7 @@ export const toAccountId: ToAccountId = ({
   const outputAccount =
     chainNamespace === CHAIN_NAMESPACE.Ethereum ? account.toLowerCase() : account
 
-  return `${chainId}:${outputAccount}`
+  return `${chainId}:${outputAccount}` as AccountId
 }
 
 type FromAccountIdReturn = {

--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -1,7 +1,7 @@
 import entries from 'lodash/entries'
 import toLower from 'lodash/toLower'
 
-import { fromAssetId } from '../../assetId/assetId'
+import { AssetId, fromAssetId } from '../../assetId/assetId'
 import { ChainId } from '../../chainId/chainId'
 
 const AssetIdToBanxaTickerMap = {
@@ -57,9 +57,9 @@ export const getSupportedBanxaAssets = () =>
  * chain won't be exactly the same as ours.
  */
 const chainIdToBanxaBlockchainCodeMap: Record<ChainId, string> = {
-  'eip155:1': 'ETH',
-  'bip122:000000000019d6689c085ae165831e93': 'BTC',
-  'cosmos:cosmoshub-4': 'COSMOS'
+  ['eip155:1' as ChainId]: 'ETH',
+  ['bip122:000000000019d6689c085ae165831e93' as ChainId]: 'BTC',
+  ['cosmos:cosmoshub-4' as ChainId]: 'COSMOS'
 } as const
 
 /**
@@ -69,7 +69,7 @@ const chainIdToBanxaBlockchainCodeMap: Record<ChainId, string> = {
  * @returns {string} - a Banxa chain identifier; e.g., 'cosmos'
  */
 export const getBanxaBlockchainFromBanxaAssetTicker = (banxaAssetId: string): string => {
-  const assetId = banxaTickerToAssetId(banxaAssetId.toLowerCase())
+  const assetId = banxaTickerToAssetId(banxaAssetId.toLowerCase()) as AssetId
   if (!assetId)
     throw new Error(`getBanxaBlockchainFromBanxaAssetTicker: ${banxaAssetId} is not supported`)
   const { chainId } = fromAssetId(assetId)

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -11,9 +11,9 @@ import {
   isAssetId,
   isAssetNamespace
 } from '../typeGuards'
-import { parseAssetIdRegExp } from '../utils'
+import { Brand, parseAssetIdRegExp } from '../utils'
 
-export type AssetId = string
+export type AssetId = Brand<string, 'AssetId'>
 
 export type AssetNamespace = typeof ASSET_NAMESPACE_STRINGS[number]
 
@@ -109,7 +109,7 @@ export const toAssetId: ToAssetId = (args: ToAssetIdArgs): AssetId => {
     ? assetReference.toLowerCase()
     : assetReference
 
-  return `${chainId}/${assetNamespace}:${assetReferenceCaseCorrected}`
+  return `${chainId}/${assetNamespace}:${assetReferenceCaseCorrected}` as AssetId
 }
 
 type FromAssetIdReturn = {

--- a/packages/caip/src/chainId/chainId.ts
+++ b/packages/caip/src/chainId/chainId.ts
@@ -7,8 +7,9 @@ import {
   assertIsChainReference,
   assertValidChainPartsPair
 } from '../typeGuards'
+import { Brand } from '../utils'
 
-export type ChainId = string
+export type ChainId = Brand<string, 'ChainId'>
 
 export type ChainNamespace = typeof CHAIN_NAMESPACE[keyof typeof CHAIN_NAMESPACE]
 export type ChainReference = typeof CHAIN_REFERENCE[keyof typeof CHAIN_REFERENCE]

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -1,15 +1,15 @@
-import { AssetNamespace } from './assetId/assetId'
-import { ChainNamespace, ChainReference } from './chainId/chainId'
+import { AssetId, AssetNamespace } from './assetId/assetId'
+import { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 
-export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
-export const ethAssetId = 'eip155:1/slip44:60'
-export const cosmosAssetId = 'cosmos:cosmoshub-4/slip44:118'
-export const osmosisAssetId = 'cosmos:osmosis-1/slip44:118'
+export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0' as AssetId
+export const ethAssetId = 'eip155:1/slip44:60' as AssetId
+export const cosmosAssetId = 'cosmos:cosmoshub-4/slip44:118' as AssetId
+export const osmosisAssetId = 'cosmos:osmosis-1/slip44:118' as AssetId
 
-export const ethChainId = 'eip155:1'
-export const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
-export const cosmosChainId = 'cosmos:cosmoshub-4'
-export const osmosisChainId = 'cosmos:osmosis-1'
+export const ethChainId = 'eip155:1' as ChainId
+export const btcChainId = 'bip122:000000000019d6689c085ae165831e93' as ChainId
+export const cosmosChainId = 'cosmos:cosmoshub-4' as ChainId
+export const osmosisChainId = 'cosmos:osmosis-1' as ChainId
 
 export const CHAIN_NAMESPACE = {
   Ethereum: 'eip155',

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -84,3 +84,4 @@ export const makeOsmosisData = () => {
   })
   return { [assetId]: 'osmosis' }
 }
+export type Brand<K, T> = K & { __brand: T }


### PR DESCRIPTION
A proof of concept demonstrating the use of nominal typing on `AssetId`, `AccountId`, and `ChainId`.

These are currently structurally typed as `string`s, which is not useful as they aren't checked by the compiler. 
An example is outlined below:

```ts
type Brand<K, T> = K & { __brand: T }

type StructuralChainId = string
type BrandedChainId = Brand<string, 'chainId'>

const notAChainId = '1234'

const acceptsStructuralChainIdArg = (chainId: StructuralChainId) => chainId
const acceptsBrandedChainIdArg = (chainId: BrandedChainId) => chainId

acceptsStructuralChainIdArg(notAChainId) // 😞 No type error!
acceptsBrandedChainIdArg(notAChainId) // 😁 Argument of type 'string' is not assignable to parameter of type 'BrandedChainId'
```

---

BREAKING CHANGE: changes AssetId, AccountId, and ChainId types