### PR TITLE
chore: move types to swapper package & remove unused

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -5,7 +5,6 @@ import {
   ApprovalNeededOutput,
   Asset,
   ChainSpecific,
-  ExecQuoteOutput,
   GetMinMaxInput,
   MinMaxOutput,
   SupportedChainIds,
@@ -164,7 +163,7 @@ export interface Swapper {
   /**
    * Execute a trade built with buildTrade by signing and broadcasting
    */
-  executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<ExecQuoteOutput>
+  executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<TradeResult>
 
   /**
    * Get a boolean if a quote needs approval

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -122,7 +122,6 @@ export type ApprovalNeededOutput = {
   gasPrice?: string
 }
 
-
 // Swap Errors
 export enum SwapErrorTypes {
   ALLOWANCE_REQUIRED_FAILED = 'ALLOWANCE_REQUIRED_FAILED',

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -1,7 +1,7 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { createErrorClass } from '@shapeshiftoss/errors'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { Asset, ChainSpecific, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+import { Asset, ChainSpecific, SupportedChainIds } from '@shapeshiftoss/types'
 
 export const SwapError = createErrorClass('SwapError')
 
@@ -120,6 +120,12 @@ export type ApprovalNeededOutput = {
   approvalNeeded: boolean
   gas?: string
   gasPrice?: string
+}
+
+export enum SwapperType {
+  Zrx = '0x',
+  Thorchain = 'Thorchain',
+  Test = 'Test'
 }
 
 // Swap Errors

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -1,15 +1,7 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { createErrorClass } from '@shapeshiftoss/errors'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import {
-  ApprovalNeededOutput,
-  Asset,
-  ChainSpecific,
-  GetMinMaxInput,
-  MinMaxOutput,
-  SupportedChainIds,
-  SwapperType
-} from '@shapeshiftoss/types'
+import { Asset, ChainSpecific, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
 
 export const SwapError = createErrorClass('SwapError')
 
@@ -99,11 +91,6 @@ export type TradeResult = {
   txid: string
 }
 
-export type SwapSource = {
-  name: string
-  proportion: string
-}
-
 export type ApproveInfiniteInput<C extends SupportedChainIds> = {
   quote: TradeQuote<C>
   wallet: HDWallet
@@ -113,6 +100,28 @@ export type ApprovalNeededInput<C extends SupportedChainIds> = {
   quote: TradeQuote<C>
   wallet: HDWallet
 }
+
+export type SwapSource = {
+  name: string
+  proportion: string
+}
+
+export interface MinMaxOutput {
+  minimum: string
+  maximum: string
+}
+
+export type GetMinMaxInput = {
+  sellAsset: Asset
+  buyAsset: Asset
+}
+
+export type ApprovalNeededOutput = {
+  approvalNeeded: boolean
+  gas?: string
+  gasPrice?: string
+}
+
 
 // Swap Errors
 export enum SwapErrorTypes {

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import { SwapperType } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
+import { SwapperType } from '../api'
 import { ThorchainSwapper, ZrxSwapper } from '../swappers'
 import { SwapperManager } from './SwapperManager'
 

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -1,8 +1,7 @@
-import { SwapperType } from '@shapeshiftoss/types'
 import uniq from 'lodash/uniq'
 
 import { BuyAssetBySellIdInput, ByPairInput, SupportedSellAssetsInput, Swapper } from '..'
-import { SwapError, SwapErrorTypes } from '../api'
+import { SwapError, SwapErrorTypes, SwapperType } from '../api'
 
 function validateSwapper(swapper: Swapper) {
   if (!(typeof swapper === 'object' && typeof swapper.getType === 'function'))

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -1,15 +1,15 @@
 import { AssetService } from '@shapeshiftoss/asset-service'
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { Asset, ChainTypes, NetworkTypes, SwapperType } from '@shapeshiftoss/types'
+import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 import dotenv from 'dotenv'
 import readline from 'readline-sync'
 import Web3 from 'web3'
 
+import { SwapperType } from './api'
 import { SwapperManager } from './manager/SwapperManager'
 import { ZrxSwapper } from './swappers/zrx/ZrxSwapper'
-
 dotenv.config()
 
 const {

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -2,14 +2,13 @@ import { AssetId } from '@shapeshiftoss/caip'
 import {
   ApprovalNeededOutput,
   Asset,
-  ExecQuoteOutput,
   GetMinMaxInput,
   MinMaxOutput,
   SupportedChainIds,
   SwapperType
 } from '@shapeshiftoss/types'
 
-import { BuyAssetBySellIdInput, Swapper, Trade, TradeQuote } from '../../api'
+import { BuyAssetBySellIdInput, Swapper, Trade, TradeQuote, TradeResult } from '../../api'
 
 /**
  * Playground for testing different scenarios of multiple swappers in the manager.
@@ -70,7 +69,7 @@ export class TestSwapper implements Swapper {
     throw new Error('TestSwapper: getTradeQuote unimplemented')
   }
 
-  async executeTrade(): Promise<ExecQuoteOutput> {
+  async executeTrade(): Promise<TradeResult> {
     throw new Error('TestSwapper: executeTrade unimplemented')
   }
 }

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -1,14 +1,16 @@
 import { AssetId } from '@shapeshiftoss/caip'
+import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+
 import {
   ApprovalNeededOutput,
-  Asset,
+  BuyAssetBySellIdInput,
   GetMinMaxInput,
   MinMaxOutput,
-  SupportedChainIds,
-  SwapperType
-} from '@shapeshiftoss/types'
-
-import { BuyAssetBySellIdInput, Swapper, Trade, TradeQuote, TradeResult } from '../../api'
+  Swapper,
+  Trade,
+  TradeQuote,
+  TradeResult
+} from '../../api'
 
 /**
  * Playground for testing different scenarios of multiple swappers in the manager.

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -1,5 +1,5 @@
 import { AssetId } from '@shapeshiftoss/caip'
-import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 
 import {
   ApprovalNeededOutput,
@@ -7,6 +7,7 @@ import {
   GetMinMaxInput,
   MinMaxOutput,
   Swapper,
+  SwapperType,
   Trade,
   TradeQuote,
   TradeResult

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -1,14 +1,15 @@
 import { AssetId } from '@shapeshiftoss/caip'
+import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+
 import {
   ApprovalNeededOutput,
-  Asset,
   GetMinMaxInput,
   MinMaxOutput,
-  SupportedChainIds,
-  SwapperType
-} from '@shapeshiftoss/types'
-
-import { Swapper, Trade, TradeQuote, TradeResult } from '../../api'
+  Swapper,
+  Trade,
+  TradeQuote,
+  TradeResult
+} from '../../api'
 export class ThorchainSwapper implements Swapper {
   getType() {
     return SwapperType.Thorchain

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -1,11 +1,12 @@
 import { AssetId } from '@shapeshiftoss/caip'
-import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 
 import {
   ApprovalNeededOutput,
   GetMinMaxInput,
   MinMaxOutput,
   Swapper,
+  SwapperType,
   Trade,
   TradeQuote,
   TradeResult

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -2,14 +2,13 @@ import { AssetId } from '@shapeshiftoss/caip'
 import {
   ApprovalNeededOutput,
   Asset,
-  ExecQuoteOutput,
   GetMinMaxInput,
   MinMaxOutput,
   SupportedChainIds,
   SwapperType
 } from '@shapeshiftoss/types'
 
-import { Swapper, Trade, TradeQuote } from '../../api'
+import { Swapper, Trade, TradeQuote, TradeResult } from '../../api'
 export class ThorchainSwapper implements Swapper {
   getType() {
     return SwapperType.Thorchain
@@ -53,7 +52,7 @@ export class ThorchainSwapper implements Swapper {
     throw new Error('ThorchainSwapper: getTradeQuote unimplemented')
   }
 
-  async executeTrade(): Promise<ExecQuoteOutput> {
+  async executeTrade(): Promise<TradeResult> {
     throw new Error('ThorchainSwapper: executeTrade unimplemented')
   }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
@@ -1,7 +1,7 @@
 import { fromAssetId, getFeeAssetIdFromAssetId } from '@shapeshiftoss/caip'
-import { ApprovalNeededOutput, SupportedChainIds } from '@shapeshiftoss/types'
+import { SupportedChainIds } from '@shapeshiftoss/types'
 
-import { ApprovalNeededInput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorTypes } from '../../../api'
 import { erc20AllowanceAbi } from '../utils/abi/erc20Allowance-abi'
 import { bnOrZero } from '../utils/bignumber'
 import { APPROVAL_GAS_LIMIT } from '../utils/constants'

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -1,6 +1,6 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import {
@@ -14,6 +14,7 @@ import {
   GetTradeQuoteInput,
   MinMaxOutput,
   Swapper,
+  SwapperType,
   TradeQuote,
   TradeResult,
   ZrxTrade

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -1,22 +1,18 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
-import {
-  ApprovalNeededOutput,
-  Asset,
-  GetMinMaxInput,
-  MinMaxOutput,
-  SupportedChainIds,
-  SwapperType
-} from '@shapeshiftoss/types'
+import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import {
   ApprovalNeededInput,
+  ApprovalNeededOutput,
   ApproveInfiniteInput,
   BuildTradeInput,
   BuyAssetBySellIdInput,
   ExecuteTradeInput,
+  GetMinMaxInput,
   GetTradeQuoteInput,
+  MinMaxOutput,
   Swapper,
   TradeQuote,
   TradeResult,

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -3,7 +3,6 @@ import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import {
   ApprovalNeededOutput,
   Asset,
-  ExecQuoteOutput,
   GetMinMaxInput,
   MinMaxOutput,
   SupportedChainIds,
@@ -20,6 +19,7 @@ import {
   GetTradeQuoteInput,
   Swapper,
   TradeQuote,
+  TradeResult,
   ZrxTrade
 } from '../../api'
 import { getZrxMinMax } from './getZrxMinMax/getZrxMinMax'
@@ -68,7 +68,7 @@ export class ZrxSwapper implements Swapper {
     return getZrxMinMax(input.sellAsset, input.buyAsset)
   }
 
-  async executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<ExecQuoteOutput> {
+  async executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<TradeResult> {
     return zrxExecuteTrade(this.deps, args)
   }
 

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -1,6 +1,6 @@
-import { Asset, MinMaxOutput } from '@shapeshiftoss/types'
+import { Asset } from '@shapeshiftoss/types'
 
-import { SwapError, SwapErrorTypes } from '../../../api'
+import { MinMaxOutput, SwapError, SwapErrorTypes } from '../../../api'
 import { bn, bnOrZero } from '../utils/bignumber'
 import { MAX_ZRX_TRADE } from '../utils/constants'
 import { getUsdRate } from '../utils/helpers/helpers'

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,8 +1,7 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
-import { SwapSource } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 
-import { GetTradeQuoteInput, SwapError, SwapErrorTypes, TradeQuote } from '../../../api'
+import { GetTradeQuoteInput, SwapError, SwapErrorTypes, SwapSource, TradeQuote } from '../../../api'
 import { getZrxMinMax } from '../getZrxMinMax/getZrxMinMax'
 import { ZrxPriceResponse } from '../types'
 import { bn, bnOrZero } from '../utils/bignumber'

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -115,10 +115,6 @@ export type GetMinMaxInput = {
   buyAsset: Asset
 }
 
-export type ExecQuoteOutput = {
-  txid: string
-}
-
 export type ApprovalNeededOutput = {
   approvalNeeded: boolean
   gas?: string

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -93,7 +93,7 @@ export type BaseAsset = AbstractAsset & { tokens?: TokenAsset[] }
 export type Asset = AbstractAsset & Partial<TokenAssetFields>
 
 // swapper
-
+// TODO remove this once web is using the type from swapper
 export enum SwapperType {
   Zrx = '0x',
   Thorchain = 'Thorchain',

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -99,24 +99,3 @@ export enum SwapperType {
   Thorchain = 'Thorchain',
   Test = 'Test'
 }
-
-export type SwapSource = {
-  name: string
-  proportion: string
-}
-
-export interface MinMaxOutput {
-  minimum: string
-  maximum: string
-}
-
-export type GetMinMaxInput = {
-  sellAsset: Asset
-  buyAsset: Asset
-}
-
-export type ApprovalNeededOutput = {
-  approvalNeeded: boolean
-  gas?: string
-  gasPrice?: string
-}


### PR DESCRIPTION
- Replace usages of ExecQuoteOutput with TradeResult and remove ExecQuoteOutput
- Move swapper types from types package to swapper

This PR is only moving types around and does not have any functional changes. It is safe for web because web does not refernce any of the moved types