### PR TITLE
feat: implements cowswapper skeleton

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -137,6 +137,7 @@ export type ApprovalNeededOutput = {
 export enum SwapperType {
   Zrx = '0x',
   Thorchain = 'Thorchain',
+  CowSwap = 'CowSwap',
   Test = 'Test'
 }
 

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -4,6 +4,7 @@ import Web3 from 'web3'
 
 import { SwapperType } from '../api'
 import { ThorchainSwapper, ThorchainSwapperDeps, ZrxSwapper, ZrxSwapperDeps } from '../swappers'
+import { CowSwapper } from '../swappers/cow/CowSwapper'
 import { SwapperManager } from './SwapperManager'
 
 describe('SwapperManager', () => {
@@ -60,9 +61,11 @@ describe('SwapperManager', () => {
       swapper
         .addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))
         .addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
+        .addSwapper(SwapperType.CowSwap, new CowSwapper())
 
       expect(swapper.getSwapper(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
       expect(swapper.getSwapper(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
+      expect(swapper.getSwapper(SwapperType.CowSwap)).toBeInstanceOf(CowSwapper)
     })
 
     it('should throw an error if swapper is not set', () => {

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -1,0 +1,17 @@
+import { SwapperType } from '../../api'
+import { CowSwapper } from './CowSwapper'
+
+describe('CowSwapper', () => {
+  describe('static properties', () => {
+    it('returns the correct swapper name', async () => {
+      expect(CowSwapper.swapperName).toEqual('CowSwapper')
+    })
+  })
+
+  describe('getType', () => {
+    it('returns the correct type for CowSwapper', async () => {
+      const swapper = new CowSwapper()
+      await expect(swapper.getType()).toEqual(SwapperType.CowSwap)
+    })
+  })
+})

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -1,0 +1,82 @@
+import { AssetId } from '@shapeshiftoss/caip'
+import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
+
+import {
+  ApprovalNeededInput,
+  ApprovalNeededOutput,
+  ApproveInfiniteInput,
+  BuildTradeInput,
+  BuyAssetBySellIdInput,
+  ExecuteTradeInput,
+  GetMinMaxInput,
+  GetTradeQuoteInput,
+  MinMaxOutput,
+  Swapper,
+  SwapperType,
+  Trade,
+  TradeQuote,
+  TradeResult,
+  TradeTxs
+} from '../../api'
+
+export class CowSwapper implements Swapper {
+  public static swapperName = 'CowSwapper'
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async initialize() {}
+
+  getType() {
+    return SwapperType.CowSwap
+  }
+
+  async buildTrade(args: BuildTradeInput): Promise<Trade<SupportedChainIds>> {
+    console.info(args)
+    throw new Error('CowSwapper: buildTrade unimplemented')
+  }
+
+  async getTradeQuote(input: GetTradeQuoteInput): Promise<TradeQuote<SupportedChainIds>> {
+    console.info(input)
+    throw new Error('CowSwapper: getTradeQuote unimplemented')
+  }
+
+  getUsdRate(input: Pick<Asset, 'symbol' | 'assetId'>): Promise<string> {
+    console.info(input)
+    throw new Error('CowSwapper: getUsdRate unimplemented')
+  }
+
+  getMinMax(input: GetMinMaxInput): Promise<MinMaxOutput> {
+    console.info(input)
+    throw new Error('CowSwapper: getMinMax unimplemented')
+  }
+
+  async executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<TradeResult> {
+    console.info(args)
+    throw new Error('CowSwapper: executeTrade unimplemented')
+  }
+
+  async approvalNeeded(
+    args: ApprovalNeededInput<SupportedChainIds>
+  ): Promise<ApprovalNeededOutput> {
+    console.info(args)
+    throw new Error('CowSwapper: approvalNeeded unimplemented')
+  }
+
+  async approveInfinite(args: ApproveInfiniteInput<SupportedChainIds>): Promise<string> {
+    console.info(args)
+    throw new Error('CowSwapper: approveInfinite unimplemented')
+  }
+
+  filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
+    console.info(args)
+    return []
+  }
+
+  filterAssetIdsBySellable(assetIds: AssetId[]): AssetId[] {
+    console.info(assetIds)
+    return []
+  }
+
+  async getTradeTxs(): Promise<TradeTxs> {
+    throw new Error('CowSwapper: executeTrade unimplemented')
+  }
+}


### PR DESCRIPTION
This adds a skeleton for CowSwapper interface implementation of  `Swapper` api with dummy methods.
Not much to test for the moment except that the few unit tests are green.

Related issue : https://github.com/shapeshift/lib/issues/721