### PR TITLE
feat(types): remove Asset properties for normalization

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/types",
-  "version": "4.3.2",
+  "version": "5.0.0",
   "description": "Common types shared across packages",
   "repository": "https://github.com/shapeshift/lib",
   "license": "MIT",

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -62,25 +62,15 @@ export type Asset = {
   description?: string
   isTrustedDescription?: boolean
   /** @deprecated: do not use. This will be removed once consumers have handled it */
-  dataSource?: AssetDataSource
-  /** @deprecated: do not use. This will be removed once consumers have handled it */
   network: NetworkTypes
   symbol: string
   name: string
   precision: number
-  /** @deprecated: do not use. This will be removed once consumers have handled it */
-  slip44?: number
   color: string
-  /** @deprecated: do not use. This will be removed once consumers have handled it */
-  secondaryColor?: string
   icon: string
   explorer: string
   explorerTxLink: string
   explorerAddressLink: string
-  /** @deprecated: do not use. This will be removed once consumers have handled it */
-  sendSupport?: boolean
-  /** @deprecated: do not use. This will be removed once consumers have handled it */
-  receiveSupport?: boolean
 }
 
 // swapper

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -22,6 +22,13 @@ const supportedChainIds = [
   'cosmos:osmosis-1'
 ] as const
 
+// export enum SUPPORTED_CHAIN_IDS {
+//   EthereumMainnet = 'eip155:1',
+//   BitcoinMainnet = 'bip122:000000000019d6689c085ae165831e93',
+//   CosmosMainnet = 'cosmos:cosmoshub-4',
+//   OsmosisMainnet = 'cosmos:osmosis-1'
+// }
+
 export type SupportedChainIds = typeof supportedChainIds[number]
 
 export enum NetworkTypes {
@@ -54,43 +61,34 @@ export enum AssetDataSource {
 }
 
 // asset-service
-
-type AbstractAsset = {
+export type Asset = {
   assetId: string
   chainId: string
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
   chain: ChainTypes
   description?: string
   isTrustedDescription?: boolean
-  dataSource: AssetDataSource
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
+  dataSource?: AssetDataSource
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
   network: NetworkTypes
   symbol: string
   name: string
   precision: number
-  slip44: number
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
+  slip44?: number
   color: string
-  secondaryColor: string
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
+  secondaryColor?: string
   icon: string
   explorer: string
   explorerTxLink: string
   explorerAddressLink: string
-  sendSupport: boolean
-  receiveSupport: boolean
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
+  sendSupport?: boolean
+  /** @deprecated: do not use. This will be removed once consumers have handled it */
+  receiveSupport?: boolean
 }
-
-type OmittedTokenAssetFields =
-  | 'chain'
-  | 'network'
-  | 'slip44'
-  | 'explorer'
-  | 'explorerTxLink'
-  | 'explorerAddressLink'
-type TokenAssetFields = {
-  tokenId: string
-  contractType: 'erc20' | 'erc721' // Don't want to import caip here to prevent circular dependencies
-}
-export type TokenAsset = Omit<AbstractAsset, OmittedTokenAssetFields> & TokenAssetFields
-export type BaseAsset = AbstractAsset & { tokens?: TokenAsset[] }
-export type Asset = AbstractAsset & Partial<TokenAssetFields>
 
 // swapper
 // TODO remove this once web is using the type from swapper

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -22,13 +22,6 @@ const supportedChainIds = [
   'cosmos:osmosis-1'
 ] as const
 
-// export enum SUPPORTED_CHAIN_IDS {
-//   EthereumMainnet = 'eip155:1',
-//   BitcoinMainnet = 'bip122:000000000019d6689c085ae165831e93',
-//   CosmosMainnet = 'cosmos:cosmoshub-4',
-//   OsmosisMainnet = 'cosmos:osmosis-1'
-// }
-
 export type SupportedChainIds = typeof supportedChainIds[number]
 
 export enum NetworkTypes {


### PR DESCRIPTION
- Nomalizes `Asset` data
- Removes `BaseAsset` and `TokenAsset`, consolidated with `Asset`

This is the first of many PRs that will follow across `lib` packages and `web` to consume this change.

Contributes to https://github.com/shapeshift/lib/issues/711

This is an extract from the work started by @0xdef1cafe in https://github.com/shapeshift/lib/pull/712

This PR contains breaking changes to `@shapeshiftoss/types`.