### PR TITLE
chore: add bitcoin specific fee data and remove unused types

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -18,11 +18,16 @@ type ChainSpecificQuoteFeeData<T1> = ChainSpecific<
       approvalFee?: string
       totalFee?: string
     }
+    'bip122:000000000019d6689c085ae165831e93': {
+      byteCount: string
+      satsPerByte: string
+    }
   }
 >
 
 export type QuoteFeeData<T1 extends SupportedChainIds> = {
   fee: string
+  tradeFee: string // fee taken out of the trade from the buyAsset
 } & ChainSpecificQuoteFeeData<T1>
 
 export type ByPairInput = {
@@ -55,8 +60,6 @@ export type BuildTradeInput = CommonTradeInput & {
 }
 
 interface TradeBase<C extends SupportedChainIds> {
-  success: boolean // This will go away when we correctly handle errors
-  statusReason: string // This will go away when we correctly handle errors
   buyAmount: string
   sellAmount: string
   feeData: QuoteFeeData<C>

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -125,11 +125,6 @@ const main = async (): Promise<void> => {
 
   console.info('quote = ', JSON.stringify(quote))
 
-  if (!quote.success) {
-    console.error('Obtaining the quote failed: ', quote.statusReason)
-    return
-  }
-
   const buyAmount = fromBaseUnit(quote.buyAmount || '0', buyAsset.precision)
 
   const answer = readline.question(

--- a/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.ts
@@ -1,5 +1,4 @@
 import { fromAssetId, getFeeAssetIdFromAssetId } from '@shapeshiftoss/caip'
-import { SupportedChainIds } from '@shapeshiftoss/types'
 
 import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorTypes } from '../../../api'
 import { erc20AllowanceAbi } from '../utils/abi/erc20Allowance-abi'
@@ -9,7 +8,7 @@ import { ZrxSwapperDeps } from '../ZrxSwapper'
 
 export async function ZrxApprovalNeeded(
   { adapterManager, web3 }: ZrxSwapperDeps,
-  { quote, wallet }: ApprovalNeededInput<SupportedChainIds>
+  { quote, wallet }: ApprovalNeededInput<'eip155:1'>
 ): Promise<ApprovalNeededOutput> {
   const { sellAsset } = quote
 

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -59,13 +59,11 @@ export class ZrxSwapper implements Swapper {
     return getUsdRate(input)
   }
 
-  async executeTrade(args: ExecuteTradeInput<SupportedChainIds>): Promise<TradeResult> {
+  async executeTrade(args: ExecuteTradeInput<'eip155:1'>): Promise<TradeResult> {
     return zrxExecuteTrade(this.deps, args)
   }
 
-  async approvalNeeded(
-    args: ApprovalNeededInput<SupportedChainIds>
-  ): Promise<ApprovalNeededOutput> {
+  async approvalNeeded(args: ApprovalNeededInput<'eip155:1'>): Promise<ApprovalNeededOutput> {
     return ZrxApprovalNeeded(this.deps, args)
   }
 

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -25,11 +25,10 @@ describe('getZrxTradeQuote', () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve({
-        data: { success: true, price: '100', gasPrice: '1000', estimatedGas: '1000000' }
+        data: { price: '100', gasPrice: '1000', estimatedGas: '1000000' }
       })
     )
     const quote = await swapper.getTradeQuote(quoteInput)
-    expect(quote.success).toBeTruthy()
     expect(quote.feeData).toStrictEqual({
       fee: '1500000000',
       chainSpecific: {
@@ -68,11 +67,10 @@ describe('getZrxTradeQuote', () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve({
-        data: { success: true, price: '100' }
+        data: { price: '100' }
       })
     )
     const quote = await swapper.getTradeQuote(quoteInput)
-    expect(quote?.success).toBeTruthy()
     expect(quote?.feeData).toStrictEqual({
       fee: '0',
       chainSpecific: {
@@ -85,9 +83,7 @@ describe('getZrxTradeQuote', () => {
   it('fails on non ethereum chain for buyAsset', async () => {
     const { quoteInput, buyAsset } = setupQuote()
     const swapper = new ZrxSwapper(zrxSwapperDeps)
-    ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: { success: false } })
-    )
+    ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve())
     await expect(
       swapper.getTradeQuote({
         ...quoteInput,
@@ -98,9 +94,7 @@ describe('getZrxTradeQuote', () => {
   it('fails on non ethereum chain for sellAsset', async () => {
     const { quoteInput, sellAsset } = setupQuote()
     const swapper = new ZrxSwapper(zrxSwapperDeps)
-    ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: { success: false } })
-    )
+    ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve())
     await expect(
       swapper.getTradeQuote({
         ...quoteInput,

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -66,8 +66,6 @@ export async function getZrxTradeQuote(input: GetTradeQuoteInput): Promise<Trade
     const rate = useSellAmount ? data.price : bn(1).div(data.price).toString()
 
     return {
-      success: true,
-      statusReason: '',
       rate,
       minimum,
       maximum,
@@ -79,7 +77,8 @@ export async function getZrxTradeQuote(input: GetTradeQuoteInput): Promise<Trade
           approvalFee:
             sellAssetErc20Address &&
             bnOrZero(APPROVAL_GAS_LIMIT).multipliedBy(bnOrZero(data.gasPrice)).toString()
-        }
+        },
+        tradeFee: '0'
       },
       sellAmount: data.sellAmount,
       buyAmount: data.buyAmount,

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -164,8 +164,12 @@ export const grantAllowance = async ({
       value: '0',
       chainSpecific: {
         erc20ContractAddress: sellAssetErc20Address,
-        gasPrice: numberToHex(quote.feeData?.chainSpecific?.gasPrice || 0),
-        gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0)
+        gasPrice: numberToHex(
+          (quote as TradeQuote<'eip155:1'>).feeData?.chainSpecific?.gasPrice || 0
+        ),
+        gasLimit: numberToHex(
+          (quote as TradeQuote<'eip155:1'>).feeData?.chainSpecific?.estimatedGas || 0
+        )
       }
     })
 

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupSwapQuote.ts
@@ -8,8 +8,6 @@ export const setupQuote = () => {
   const sellAsset: Asset = { ...FOX }
   const buyAsset: Asset = { ...WETH }
   const tradeQuote: TradeQuote<SupportedChainIds> = {
-    success: true,
-    statusReason: '',
     buyAmount: '',
     sellAmount: '1000000000000000000',
     sellAsset,
@@ -18,7 +16,7 @@ export const setupQuote = () => {
     sellAssetAccountId: '0',
     minimum: '0',
     maximum: '999999999999',
-    feeData: { fee: '0' },
+    feeData: { fee: '0', tradeFee: '0' },
     rate: '1',
     sources: []
   }
@@ -86,9 +84,7 @@ export const setupExecuteTrade = () => {
     txData: '0x0',
     depositAddress: '0x0',
     receiveAddress: '0x0',
-    success: true,
-    statusReason: '',
-    feeData: { fee: '0', chainSpecific: {} },
+    feeData: { fee: '0', chainSpecific: {}, tradeFee: '0' },
     rate: '0',
     allowanceContract: '0x0',
     sources: []

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -77,8 +77,6 @@ describe('ZrxBuildTrade', () => {
 
   const buildTradeResponse = {
     sellAsset,
-    success: true,
-    statusReason: '',
     sellAmount: quoteResponse.sellAmount,
     buyAmount: '',
     depositAddress: quoteResponse.to,

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -99,8 +99,6 @@ export async function zrxBuildTrade(
     const trade: ZrxTrade<'eip155:1'> = {
       sellAsset,
       buyAsset,
-      success: true,
-      statusReason: '',
       sellAssetAccountId,
       receiveAddress,
       rate: data.price,
@@ -110,7 +108,8 @@ export async function zrxBuildTrade(
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),
           gasPrice: data.gasPrice
-        }
+        },
+        tradeFee: '0'
       },
       txData: data.data,
       sellAmount: data.sellAmount,
@@ -134,7 +133,8 @@ export async function zrxBuildTrade(
         chainSpecific: {
           ...trade.feeData?.chainSpecific,
           approvalFee: bnOrZero(APPROVAL_GAS_LIMIT).multipliedBy(bnOrZero(data.gasPrice)).toString()
-        }
+        },
+        tradeFee: '0'
       }
     }
     return trade

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -25,8 +25,6 @@ describe('ZrxExecuteTrade', () => {
   const trade: ZrxTrade<'eip155:1'> = {
     buyAsset,
     sellAsset,
-    success: true,
-    statusReason: '',
     sellAmount: '1',
     buyAmount: '',
     depositAddress: '0x123',


### PR DESCRIPTION
- Add bitcoin specific fee data
- Add tradeFee to account for trade fees taken out of the buy asset (needed for thor trades)
- Remove statusReason & success from swapper types