### PR TITLE
feat(caip): implement Nominal types for ChainId and AssetId

### DIFF
--- a/packages/caip/src/accountId/accountId.ts
+++ b/packages/caip/src/accountId/accountId.ts
@@ -1,8 +1,9 @@
 import { ChainId, ChainNamespace, ChainReference, fromChainId, toChainId } from '../chainId/chainId'
 import { CHAIN_NAMESPACE } from '../constants'
 import { assertIsChainId, assertIsChainNamespace, assertIsChainReference } from '../typeGuards'
+import { Nominal } from '../utils'
 
-export type AccountId = string
+export type AccountId = Nominal<string, 'AccountId'>
 
 type ToAccountIdWithChainId = {
   chainId: ChainId

--- a/packages/caip/src/assetId/assetId.test.ts
+++ b/packages/caip/src/assetId/assetId.test.ts
@@ -648,14 +648,14 @@ describe('assetId', () => {
       expect(() => fromAssetId('invalid')).toThrow()
     })
 
-    it('errors for invalid chaintype', () => {
+    it('errors for invalid ChainNamespace', () => {
       expect(() => fromAssetId('invalid:cosmoshub-4/slip44:118')).toThrow()
     })
 
-    it('errors for invalid network type', () => {
+    it('errors for invalid ChainReference type', () => {
       expect(() => fromAssetId('cosmos:invalid/slip44:118')).toThrow()
     })
-    it('errors for invalid osmosis asset namespace', () => {
+    it('errors for invalid osmosis AssetNamespace', () => {
       expect(() => fromAssetId('cosmos:osmosis-1/invalid:118')).toThrow()
     })
   })

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -11,9 +11,9 @@ import {
   isAssetId,
   isAssetNamespace
 } from '../typeGuards'
-import { parseAssetIdRegExp } from '../utils'
+import { Nominal, parseAssetIdRegExp } from '../utils'
 
-export type AssetId = string
+export type AssetId = Nominal<string, 'AssetId'>
 
 export type AssetNamespace = typeof ASSET_NAMESPACE_STRINGS[number]
 

--- a/packages/caip/src/chainId/chainId.ts
+++ b/packages/caip/src/chainId/chainId.ts
@@ -7,8 +7,9 @@ import {
   assertIsChainReference,
   assertValidChainPartsPair
 } from '../typeGuards'
+import { Nominal } from '../utils'
 
-export type ChainId = string
+export type ChainId = Nominal<string, 'ChainId'>
 
 export type ChainNamespace = typeof CHAIN_NAMESPACE[keyof typeof CHAIN_NAMESPACE]
 export type ChainReference = typeof CHAIN_REFERENCE[keyof typeof CHAIN_REFERENCE]

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -1,15 +1,15 @@
-import { AssetNamespace } from './assetId/assetId'
-import { ChainNamespace, ChainReference } from './chainId/chainId'
+import { AssetId, AssetNamespace } from './assetId/assetId'
+import { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 
-export const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
-export const ethAssetId = 'eip155:1/slip44:60'
-export const cosmosAssetId = 'cosmos:cosmoshub-4/slip44:118'
-export const osmosisAssetId = 'cosmos:osmosis-1/slip44:118'
+export const btcAssetId: AssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+export const ethAssetId: AssetId = 'eip155:1/slip44:60'
+export const cosmosAssetId: AssetId = 'cosmos:cosmoshub-4/slip44:118'
+export const osmosisAssetId: AssetId = 'cosmos:osmosis-1/slip44:118'
 
-export const ethChainId = 'eip155:1'
-export const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
-export const cosmosChainId = 'cosmos:cosmoshub-4'
-export const osmosisChainId = 'cosmos:osmosis-1'
+export const ethChainId: ChainId = 'eip155:1'
+export const btcChainId: ChainId = 'bip122:000000000019d6689c085ae165831e93'
+export const cosmosChainId: ChainId = 'cosmos:cosmoshub-4'
+export const osmosisChainId: ChainId = 'cosmos:osmosis-1'
 
 export const CHAIN_NAMESPACE = {
   Ethereum: 'eip155',

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -84,3 +84,9 @@ export const makeOsmosisData = () => {
   })
   return { [assetId]: 'osmosis' }
 }
+
+interface Flavoring<FlavorT> {
+  _type?: FlavorT
+}
+
+export type Nominal<T, FlavorT> = T & Flavoring<FlavorT>


### PR DESCRIPTION
Currently both are defined as strings which means they can be used interchangeably.

Nominal types allows the compiler to be able to distinguish one string from another based on its type.

See https://www.typescriptlang.org/play#example/nominal-typing