### PR TITLE
fix(assetService): native asset description

### DIFF
--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -1,4 +1,6 @@
 import { AssetId, fromAssetId } from '@shapeshiftoss/caip'
+import { AssetReference } from '@shapeshiftoss/caip/src/assetId/assetId'
+import { ASSET_REFERENCE } from '@shapeshiftoss/caip/src/constants'
 import { Asset } from '@shapeshiftoss/types'
 import axios from 'axios'
 
@@ -41,9 +43,17 @@ export class AssetService {
       }
       // TODO(0xdef1cafe): this is dumb luck, add a coingecko specific map here
       const chain = this.assets[assetId].chain
-      const contractUrl = `/contract/${fromAssetId(assetId).assetReference.toLowerCase()}`
+      const assetReference = fromAssetId(assetId).assetReference.toLowerCase()
+      const maybeContractAddress = !Object.values(ASSET_REFERENCE).includes(
+        assetReference as AssetReference
+      )
+        ? assetReference
+        : undefined
+      const contractUrlOrNativeToken = maybeContractAddress
+        ? `/contract/${maybeContractAddress}`
+        : ''
       const { data } = await axios.get<CoinData>(
-        `https://api.coingecko.com/api/v3/coins/${chain}${contractUrl}`
+        `https://api.coingecko.com/api/v3/coins/${chain}${contractUrlOrNativeToken}`
       )
 
       return { description: data?.description?.en ?? '' }


### PR DESCRIPTION
This follows https://github.com/shapeshift/lib/pull/746 and makes sure we build the right URL for the description of a native asset in `asset-service`.

The rationale for this change is `assetReference` can now either be the contract's address (in the case of an actual contract), or the native token's "real" asset reference.

This breaks the description generation as a link such as `https://api.coingecko.com/api/v3/coins/ethereum/contract/60` will be built to fetch description, which are invalid: in the case of a native token, it should simply be `https://api.coingecko.com/api/v3/coins/ethereum`.

Fixes Ethereum and BTC native tokens. Cosmos has hardcoded description, and thus isn't affected. 