### PR TITLE
feat(market-service): removed usage of ChainAdapterManager

### DIFF
--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/market-service",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "ShapeShift market data service",
   "homepage": "",
   "license": "MIT",
@@ -33,17 +33,21 @@
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.2",
     "dayjs": "^1.10.6",
-    "p-ratelimit": "^1.0.1",
-    "@shapeshiftoss/chain-adapters": "^5.0.0",
-    "@shapeshiftoss/investor-foxy": "^3.4.0"
+    "p-ratelimit": "^1.0.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^5.2.2",
-    "@shapeshiftoss/types": "^4.4.0"
+    "@shapeshiftoss/caip": "^5.3.0",
+    "@shapeshiftoss/chain-adapters": "^6.0.0",
+    "@shapeshiftoss/investor-foxy": "^4.0.0",
+    "@shapeshiftoss/types": "^5.0.0",
+    "@shapeshiftoss/unchained-client": "^9.0.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^5.2.2",
-    "@shapeshiftoss/types": "^4.4.0",
+    "@shapeshiftoss/caip": "^5.3.0",
+    "@shapeshiftoss/types": "^5.0.0",
+    "@shapeshiftoss/chain-adapters": "^6.0.0",
+    "@shapeshiftoss/investor-foxy": "^4.0.0",
+    "@shapeshiftoss/unchained-client": "^9.0.0",
     "limiter": "^2.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,19 +2559,6 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
-"@shapeshiftoss/investor-foxy@^3.4.0":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-foxy/-/investor-foxy-3.4.2.tgz#3389f1f7aa5cb1346b6d4d6d0ac4ed34ca8d09b6"
-  integrity sha512-HOLSOnR4T41yguyadb3cyrdsypARSt0CRW1zdf/4U/eypv9c+PHKg/26ht0cm56j40/VwK67zJJFjjAa64oOcA==
-  dependencies:
-    "@ethersproject/providers" "^5.5.3"
-    axios "^0.26.1"
-    bignumber.js "^9.0.2"
-    lodash "^4.17.21"
-    web3 "^1.7.3"
-    web3-core "^1.7.3"
-    web3-utils "^1.7.3"
-
 "@shapeshiftoss/proto-tx-builder@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/proto-tx-builder/-/proto-tx-builder-0.2.1.tgz#82106d45adcec0d5d215a6098b52d16ef3db3dc8"


### PR DESCRIPTION
We just instantiate the `EthereumChainAdapter` that we need

BREAKING CHANGE: Requires updated `peerDependencies`