### PR TITLE
fix(assetService): build fix

### DIFF
--- a/packages/asset-service/src/service/AssetService.ts
+++ b/packages/asset-service/src/service/AssetService.ts
@@ -1,6 +1,4 @@
-import { AssetId, fromAssetId } from '@shapeshiftoss/caip'
-import { AssetReference } from '@shapeshiftoss/caip/src/assetId/assetId'
-import { ASSET_REFERENCE } from '@shapeshiftoss/caip/src/constants'
+import { ASSET_REFERENCE, AssetId, AssetReference, fromAssetId } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
 import axios from 'axios'
 


### PR DESCRIPTION
This fixes the build after 3baca79252326e3bb97b047bd53a6444dc03aea8, which builds fine in lib, but actually breaks web when installing `@shapeshiftoss/asset-service@latest`.