### PR TITLE
feat(types): add CoingeckoAssetPlatform enum

### DIFF
--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -15,6 +15,13 @@ export enum KnownChainIds {
   OsmosisMainnet = 'cosmos:osmosis-1'
 }
 
+// https://api.coingecko.com/api/v3/asset_platforms
+export enum CoingeckoAssetPlatforms {
+  Ethereum = 'ethereum',
+  Cosmos = 'cosmos',
+  Osmosis = 'osmosis'
+}
+
 export enum WithdrawType {
   DELAYED,
   INSTANT

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -16,7 +16,7 @@ export enum KnownChainIds {
 }
 
 // https://api.coingecko.com/api/v3/asset_platforms
-export enum CoingeckoAssetPlatforms {
+export enum CoingeckoAssetPlatform {
   Ethereum = 'ethereum',
   Cosmos = 'cosmos',
   Osmosis = 'osmosis'


### PR DESCRIPTION
`CoingeckoAssetPlatform` was going initially going to be introduced in https://github.com/shapeshift/lib/pull/794/files, but it's actually a shared type as it'll be used in both `asset-service` and `market-service`.

- https://github.com/shapeshift/lib/pull/799 to be updated once published
- https://github.com/shapeshift/lib/pull/793 to use the enum in tests, as per https://github.com/shapeshift/lib/pull/793#discussion_r895824260