### PR TITLE
chore: add avalanche c chain asset reference

### DIFF
--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -79,5 +79,6 @@ export const ASSET_REFERENCE = {
   Bitcoin: '0',
   Ethereum: '60',
   Cosmos: '118',
-  Osmosis: '118'
+  Osmosis: '118',
+  AvalancheC: '9000'
 } as const


### PR DESCRIPTION
missed this on the previous PR into CAIP - adds avalanche c chain asset reference
