### PR TITLE
fix: expose asset-service utils in dist

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -7,9 +7,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/index.*",
-    "dist/service",
-    "dist/utils.ts"
+    "*.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/index.*",
-    "dist/service"
+    "dist/service",
+    "dist/utils.ts"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Description

This exposes the `utils` module of `asset-service` following 94f74495b.

It is currently not exposed in the built package and thus, its consumption produces a runtime error in:
https://github.com/shapeshift/lib/blob/ef77d1dfcbc969c390320dea38e9fa4c52513c17/packages/asset-service/src/service/AssetService.ts#L5

### Issue

Relates to https://github.com/shapeshift/lib/issues/444
Relates to https://github.com/shapeshift/lib/issues/556