### PR TITLE
fix: consistently use Foxy.methods.circulatingSupply for supply

### DIFF
--- a/packages/market-service/src/foxy/foxy.ts
+++ b/packages/market-service/src/foxy/foxy.ts
@@ -77,8 +77,8 @@ export class FoxyMarketService implements MarketService {
       })
 
       const tokenContractAddress = foxyAddresses[0].foxy
-      const foxyTotalSupply = await api.totalSupply({ tokenContractAddress })
-      const supply = await api.tvl({ tokenContractAddress })
+      const foxyTotalSupply = await api.tvl({ tokenContractAddress })
+      const supply = foxyTotalSupply
 
       return {
         price: marketData.priceUsd,

--- a/packages/market-service/src/foxy/foxyMockData.ts
+++ b/packages/market-service/src/foxy/foxyMockData.ts
@@ -21,7 +21,7 @@ export const mockFoxyMarketData = {
   price: '0.2794809217688426',
   volume: '0',
   supply: '52018758.965754575223841191',
-  maxSupply: '502526240.759422886301171305'
+  maxSupply: '52018758.965754575223841191'
 }
 
 export const mockFoxyPriceHistoryData = [


### PR DESCRIPTION
### Description

This calls the `circulatingSupply` method from the FOXy contract to get the data for both the `foxyTotalSupply` and `supply` properties of the FOXy market data.

Currently, the `totalSupply` method from the contract is called for `foxyTotalSupply`, and `circulatingSupply` for `supply`.

### Reference

https://github.com/shapeshift/web/issues/2024#issuecomment-1157086694

> So for FOXy the best way to get the actual totalSupply of tokens if the function [here](https://github.com/shapeshift/foxy/blob/f529540139865774384413433250e5e0ab01c99b/src/contracts/FOXy.sol#L187). This circulatingSupply is equivalent to the `Available Supply` as well.

### Issue

Partially tackles https://github.com/shapeshift/web/issues/2024