### PR TITLE
feat: quote trade input string union discrimination

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -68,7 +68,7 @@ export type GetBtcTradeQuoteInput = CommonTradeInput & {
 
 export type GetTradeQuoteInput = GetEthTradeQuoteInput | GetBtcTradeQuoteInput
 
-export type BuildTradeInput = CommonTradeInput & {
+export type BuildTradeInput = GetTradeQuoteInput & {
   buyAssetAccountNumber: number
   slippage?: string
   wallet: HDWallet

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -1,7 +1,13 @@
 import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { createErrorClass } from '@shapeshiftoss/errors'
 import { BTCSignTx, ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { Asset, ChainSpecific, KnownChainIds } from '@shapeshiftoss/types'
+import {
+  Asset,
+  BIP44Params,
+  ChainSpecific,
+  KnownChainIds,
+  UtxoAccountType
+} from '@shapeshiftoss/types'
 
 export const SwapError = createErrorClass('SwapError')
 
@@ -46,9 +52,21 @@ export type CommonTradeInput = {
   sellAmount: string
   sendMax: boolean
   sellAssetAccountNumber: number
-  wallet?: HDWallet
+  wallet?: HDWallet // TODO remove this in a followup PR
 }
-export type GetTradeQuoteInput = CommonTradeInput
+
+export type GetEthTradeQuoteInput = CommonTradeInput & {
+  chainId: 'eip155:1'
+}
+
+export type GetBtcTradeQuoteInput = CommonTradeInput & {
+  chainId: 'bip122:000000000019d6689c085ae165831e93'
+  accountType: UtxoAccountType
+  bip44Params: BIP44Params
+  wallet: HDWallet
+}
+
+export type GetTradeQuoteInput = GetEthTradeQuoteInput | GetBtcTradeQuoteInput
 
 export type BuildTradeInput = CommonTradeInput & {
   buyAssetAccountNumber: number

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -133,6 +133,7 @@ const main = async (): Promise<void> => {
   )
   if (answer === 'y') {
     const trade = await swapper.buildTrade({
+      chainId: 'eip155:1',
       wallet,
       buyAsset,
       sendMax: false,

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -107,11 +107,11 @@ const main = async (): Promise<void> => {
   let quote
   try {
     quote = await swapper.getTradeQuote({
+      chainId: 'eip155:1',
       sellAsset,
       buyAsset,
       sellAmount: sellAmountBase,
       sellAssetAccountNumber: 0,
-      wallet,
       sendMax: false
     })
   } catch (e) {

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -21,6 +21,7 @@ export const setupQuote = () => {
   }
 
   const quoteInput: GetTradeQuoteInput = {
+    chainId: 'eip155:1',
     sellAmount: '1000000000000000000',
     sellAsset,
     buyAsset,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-"@shapeshiftoss/chain-adapters@^6.0.0", "@shapeshiftoss/chain-adapters@^6.0.1":
+"@shapeshiftoss/chain-adapters@^6.0.0":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-6.0.1.tgz#07c4d658055e17ac262ab2f1eab06b2c099168d8"
   integrity sha512-0qafOakDY8kwxYtcBJau5hfE/LaLhetLmFNpckNof40iUxS2sCmsXkVX+HF+HU3OjASBjBznvOCtlxTCFnOy7w==


### PR DESCRIPTION
We need bitcoin to have some special fields for getting quotes and building trades

Modifies `GetTradeQuoteInput` and `BuildTradeInput` to accept `accountType`, `bip44Params` and `wallet` for chainId == bitcoin
