### PR TITLE
feat: chainadapters signMessage method

### DIFF
--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -210,7 +210,7 @@ const testEthereum = async (wallet: NativeHDWallet, broadcast = false) => {
         addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
       }
     })
-    console.log('ethereum: signMessage', signedMessage)
+    console.log('ethereum: signedMessage', signedMessage)
   } catch (err) {
     console.log('ethereum: signMessage error:', err.message)
   }

--- a/packages/chain-adapters/src/ChainAdapterCLI.ts
+++ b/packages/chain-adapters/src/ChainAdapterCLI.ts
@@ -201,6 +201,19 @@ const testEthereum = async (wallet: NativeHDWallet, broadcast = false) => {
   } catch (err) {
     console.log('ethereum: tx error:', err.message)
   }
+
+  try {
+    const signedMessage = await chainAdapter.signMessage({
+      wallet,
+      messageToSign: {
+        message: 'Hello world 222',
+        addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
+      }
+    })
+    console.log('ethereum: signMessage', signedMessage)
+  } catch (err) {
+    console.log('ethereum: signMessage error:', err.message)
+  }
 }
 
 // @ts-ignore:nextLine

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -425,11 +425,6 @@ describe('EthereumChainAdapter', () => {
       const args = makeChainAdapterArgs()
       const adapter = new ethereum.ChainAdapter(args)
       const wallet = await getWallet()
-      wallet.ethSignMessage = async () => ({
-        address: '0x41e5560054824ea6b0732e656e3ad64e20e94e45',
-        signature:
-          '0xf77391e26e80101e0126c5da3225693b3c84c25f6669460603a8eec1c876748572bf180fbdae3f0f93bca331c4c5d0ad6abe8da025249de976b162d0d1b1c0181c'
-      })
 
       const message = {
         wallet,
@@ -437,10 +432,10 @@ describe('EthereumChainAdapter', () => {
           message: 'Hello world 111',
           addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
         }
-      } as unknown as SignMessageInput<ETHSignMessage>
+      } as SignMessageInput<ETHSignMessage>
 
       await expect(adapter.signMessage(message)).resolves.toEqual(
-        '0xf77391e26e80101e0126c5da3225693b3c84c25f6669460603a8eec1c876748572bf180fbdae3f0f93bca331c4c5d0ad6abe8da025249de976b162d0d1b1c0181c'
+        '0x05a0edb4b98fe6b6ed270bf55aef84ddcb641512e19e340bf9eed3427854a7a4734fe45551dc24f1843cf2c823a73aa2454e3785eb15120573c522cc114e472d1c'
       )
     })
 
@@ -455,9 +450,11 @@ describe('EthereumChainAdapter', () => {
           message: 'Hello world 111',
           addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
         }
-      } as unknown as SignMessageInput<ETHSignMessage>
+      } as SignMessageInput<ETHSignMessage>
 
-      await expect(adapter.signMessage(message)).rejects.toThrow(/Error signing message/)
+      await expect(adapter.signMessage(message)).rejects.toThrow(
+        /EthereumChainAdapter: error signing message/
+      )
     })
   })
 

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.test.ts
@@ -426,13 +426,13 @@ describe('EthereumChainAdapter', () => {
       const adapter = new ethereum.ChainAdapter(args)
       const wallet = await getWallet()
 
-      const message = {
+      const message: SignMessageInput<ETHSignMessage> = {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
           addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
         }
-      } as SignMessageInput<ETHSignMessage>
+      }
 
       await expect(adapter.signMessage(message)).resolves.toEqual(
         '0x05a0edb4b98fe6b6ed270bf55aef84ddcb641512e19e340bf9eed3427854a7a4734fe45551dc24f1843cf2c823a73aa2454e3785eb15120573c522cc114e472d1c'
@@ -444,13 +444,13 @@ describe('EthereumChainAdapter', () => {
       const adapter = new ethereum.ChainAdapter(args)
       const wallet = await getWallet()
       wallet.ethSignMessage = async () => null
-      const message = {
+      const message: SignMessageInput<ETHSignMessage> = {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
           addressNList: [2147483692, 2147483708, 2147483648, 0, 0]
         }
-      } as SignMessageInput<ETHSignMessage>
+      }
 
       await expect(adapter.signMessage(message)).rejects.toThrow(
         /EthereumChainAdapter: error signing message/

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -376,7 +376,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.EthereumMainnet
       const { messageToSign, wallet } = signMessageInput
       const signedMessage = await (wallet as ETHWallet).ethSignMessage(messageToSign)
 
-      if (!signedMessage) throw new Error('Error signing message')
+      if (!signedMessage) throw new Error('EthereumChainAdapter: error signing message')
 
       return signedMessage.signature
     } catch (err) {

--- a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts
@@ -8,6 +8,7 @@ import {
   fromChainId,
   toAssetId
 } from '@shapeshiftoss/caip'
+import { ETHSignMessage } from '@shapeshiftoss/hdwallet-core'
 import { bip32ToAddressNList, ETHSignTx, ETHWallet, HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -25,6 +26,7 @@ import {
   GasFeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
+  SignMessageInput,
   SignTxInput,
   SubscribeError,
   SubscribeTxsInput,
@@ -367,6 +369,19 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.EthereumMainnet
   async broadcastTransaction(hex: string) {
     const { data } = await this.providers.http.sendTx({ sendTxBody: { hex } })
     return data
+  }
+
+  async signMessage(signMessageInput: SignMessageInput<ETHSignMessage>): Promise<string> {
+    try {
+      const { messageToSign, wallet } = signMessageInput
+      const signedMessage = await (wallet as ETHWallet).ethSignMessage(messageToSign)
+
+      if (!signedMessage) throw new Error('Error signing message')
+
+      return signedMessage.signature
+    } catch (err) {
+      return ErrorHandler(err)
+    }
   }
 
   async getGasFeeData(): Promise<GasFeeDataEstimate> {

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -210,6 +210,11 @@ export type SignTxInput<TxType> = {
   wallet: HDWallet
 }
 
+export type SignMessageInput<MessageType> = {
+  messageToSign: MessageType
+  wallet: HDWallet
+}
+
 export interface TxHistoryInput {
   readonly cursor?: string
   readonly pubkey: string


### PR DESCRIPTION
This implements the signMessage method in `EthereumChainAdapter`. This is needed in order to be able to sign messages for `CowSwap` (will be used in https://github.com/shapeshift/lib/issues/726)

`ChainAdapterCLI` can be ran in order to verify signMessage is working.