### PR TITLE
fix(swapper): use best practice naming conventions

### DIFF
--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -5,20 +5,20 @@ import Web3 from 'web3'
 import { SwapperType } from '../../api'
 import { BTC, ETH, FOX, WBTC, WETH } from '../utils/test-data/assets'
 import { setupQuote } from '../utils/test-data/setupSwapQuote'
-import { CowApprovalNeeded } from './CowApprovalNeeded/CowApprovalNeeded'
-import { CowApproveInfinite } from './CowApproveInfinite/CowApproveInfinite'
+import { cowApprovalNeeded } from './cowApprovalNeeded/cowApprovalNeeded'
+import { cowApproveInfinite } from './cowApproveInfinite/cowApproveInfinite'
 import { CowSwapper, CowSwapperDeps } from './CowSwapper'
 import { getCowSwapTradeQuote } from './getCowSwapTradeQuote/getCowSwapTradeQuote'
 import { getUsdRate } from './utils/helpers/helpers'
 
 jest.mock('./utils/helpers/helpers')
 
-jest.mock('./CowApprovalNeeded/CowApprovalNeeded', () => ({
-  CowApprovalNeeded: jest.fn()
+jest.mock('./cowApprovalNeeded/cowApprovalNeeded', () => ({
+  cowApprovalNeeded: jest.fn()
 }))
 
-jest.mock('./CowApproveInfinite/CowApproveInfinite', () => ({
-  CowApproveInfinite: jest.fn()
+jest.mock('./cowApproveInfinite/cowApproveInfinite', () => ({
+  cowApproveInfinite: jest.fn()
 }))
 
 const COW_SWAPPER_DEPS: CowSwapperDeps = {
@@ -142,23 +142,23 @@ describe('CowSwapper', () => {
     })
   })
 
-  describe('CowApprovalNeeded', () => {
-    it('calls CowApprovalNeeded on swapper.approvalNeeded', async () => {
+  describe('cowApprovalNeeded', () => {
+    it('calls cowApprovalNeeded on swapper.approvalNeeded', async () => {
       const { tradeQuote } = setupQuote()
       const args = { quote: tradeQuote, wallet }
       await swapper.approvalNeeded(args)
-      expect(CowApprovalNeeded).toHaveBeenCalledTimes(1)
-      expect(CowApprovalNeeded).toHaveBeenCalledWith(COW_SWAPPER_DEPS, args)
+      expect(cowApprovalNeeded).toHaveBeenCalledTimes(1)
+      expect(cowApprovalNeeded).toHaveBeenCalledWith(COW_SWAPPER_DEPS, args)
     })
   })
 
-  describe('CowApproveInfinite', () => {
-    it('calls CowApproveInfinite on swapper.approveInfinite', async () => {
+  describe('cowApproveInfinite', () => {
+    it('calls cowApproveInfinite on swapper.approveInfinite', async () => {
       const { tradeQuote } = setupQuote()
       const args = { quote: tradeQuote, wallet }
       await swapper.approveInfinite(args)
-      expect(CowApproveInfinite).toHaveBeenCalledTimes(1)
-      expect(CowApproveInfinite).toHaveBeenCalledWith(COW_SWAPPER_DEPS, args)
+      expect(cowApproveInfinite).toHaveBeenCalledTimes(1)
+      expect(cowApproveInfinite).toHaveBeenCalledWith(COW_SWAPPER_DEPS, args)
     })
   })
 })

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -18,8 +18,8 @@ import {
   TradeResult,
   TradeTxs
 } from '../../api'
-import { CowApprovalNeeded } from './CowApprovalNeeded/CowApprovalNeeded'
-import { CowApproveInfinite } from './CowApproveInfinite/CowApproveInfinite'
+import { cowApprovalNeeded } from './cowApprovalNeeded/cowApprovalNeeded'
+import { cowApproveInfinite } from './cowApproveInfinite/cowApproveInfinite'
 import { getCowSwapTradeQuote } from './getCowSwapTradeQuote/getCowSwapTradeQuote'
 import { COWSWAP_UNSUPPORTED_ASSETS } from './utils/blacklist'
 import { getUsdRate } from './utils/helpers/helpers'
@@ -69,11 +69,11 @@ export class CowSwapper implements Swapper<'eip155:1'> {
   }
 
   async approvalNeeded(args: ApprovalNeededInput<'eip155:1'>): Promise<ApprovalNeededOutput> {
-    return CowApprovalNeeded(this.deps, args)
+    return cowApprovalNeeded(this.deps, args)
   }
 
   async approveInfinite(args: ApproveInfiniteInput<'eip155:1'>): Promise<string> {
-    return CowApproveInfinite(this.deps, args)
+    return cowApproveInfinite(this.deps, args)
   }
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {

--- a/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.test.ts
@@ -4,7 +4,7 @@ import Web3 from 'web3'
 import { BTC, ETH } from '../../utils/test-data/assets'
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
-import { CowApprovalNeeded } from './CowApprovalNeeded'
+import { cowApprovalNeeded } from './cowApprovalNeeded'
 
 jest.mock('web3')
 
@@ -21,7 +21,7 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-describe('CowApprovalNeeded', () => {
+describe('cowApprovalNeeded', () => {
   const { web3, adapter, feeAsset } = setupDeps()
   const args = { web3, adapter, apiUrl: '', feeAsset }
   ;(adapter.getAddress as jest.Mock).mockResolvedValue('0xc770eefad204b5180df6a14ee197d99d808ee52d')
@@ -38,11 +38,11 @@ describe('CowApprovalNeeded', () => {
       wallet: <HDWallet>{}
     }
 
-    await expect(CowApprovalNeeded(args, input1)).rejects.toThrow(
-      '[CowApprovalNeeded] - unsupported asset namespace'
+    await expect(cowApprovalNeeded(args, input1)).rejects.toThrow(
+      '[cowApprovalNeeded] - unsupported asset namespace'
     )
-    await expect(CowApprovalNeeded(args, input2)).rejects.toThrow(
-      '[CowApprovalNeeded] - unsupported asset namespace'
+    await expect(cowApprovalNeeded(args, input2)).rejects.toThrow(
+      '[cowApprovalNeeded] - unsupported asset namespace'
     )
   })
 
@@ -64,7 +64,7 @@ describe('CowApprovalNeeded', () => {
       }
     }))
 
-    expect(await CowApprovalNeeded(args, input)).toEqual({
+    expect(await cowApprovalNeeded(args, input)).toEqual({
       approvalNeeded: false
     })
     expect(mockedAllowance).toHaveBeenCalledTimes(1)
@@ -93,7 +93,7 @@ describe('CowApprovalNeeded', () => {
       }
     }))
 
-    expect(await CowApprovalNeeded(args, input)).toEqual({
+    expect(await cowApprovalNeeded(args, input)).toEqual({
       approvalNeeded: true
     })
     expect(mockedAllowance).toHaveBeenCalledTimes(1)

--- a/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
@@ -8,7 +8,7 @@ import { CowSwapperDeps } from '../CowSwapper'
 
 const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
 
-export async function CowApprovalNeeded(
+export async function cowApprovalNeeded(
   { adapter, web3 }: CowSwapperDeps,
   { quote, wallet }: ApprovalNeededInput<'eip155:1'>
 ): Promise<ApprovalNeededOutput> {
@@ -18,7 +18,7 @@ export async function CowApprovalNeeded(
 
   try {
     if (assetNamespace !== 'erc20') {
-      throw new SwapError('[CowApprovalNeeded] - unsupported asset namespace', {
+      throw new SwapError('[cowApprovalNeeded] - unsupported asset namespace', {
         code: SwapErrorTypes.UNSUPPORTED_NAMESPACE,
         details: { assetNamespace }
       })
@@ -41,7 +41,7 @@ export async function CowApprovalNeeded(
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[CowApprovalNeeded]', {
+    throw new SwapError('[cowApprovalNeeded]', {
       cause: e,
       code: SwapErrorTypes.CHECK_APPROVAL_FAILED
     })

--- a/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.test.ts
+++ b/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.test.ts
@@ -3,7 +3,7 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
-import { CowApproveInfinite } from '../CowApproveInfinite/CowApproveInfinite'
+import { cowApproveInfinite } from './/cowApproveInfinite'
 
 jest.mock('web3')
 jest.mock('../../utils/helpers/helpers', () => ({
@@ -23,7 +23,7 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-describe('CowApproveInfinite', () => {
+describe('cowApproveInfinite', () => {
   const { web3, adapter, feeAsset } = setupDeps()
   const { tradeQuote } = setupQuote()
   const wallet = {
@@ -35,6 +35,6 @@ describe('CowApproveInfinite', () => {
     const deps = { web3, adapter, apiUrl: '', feeAsset }
     const quote = { ...tradeQuote }
 
-    expect(await CowApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
+    expect(await cowApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
   })
 })

--- a/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.ts
+++ b/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.ts
@@ -4,7 +4,7 @@ import { grantAllowance } from '../../utils/helpers/helpers'
 import { CowSwapperDeps } from '../CowSwapper'
 import { MAX_ALLOWANCE } from '../utils/constants'
 
-export async function CowApproveInfinite(
+export async function cowApproveInfinite(
   { adapter, web3 }: CowSwapperDeps,
   { quote, wallet }: ApproveInfiniteInput<'eip155:1'>
 ) {
@@ -23,7 +23,7 @@ export async function CowApproveInfinite(
     return allowanceGrantRequired
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[CowApproveInfinite]', {
+    throw new SwapError('[cowApproveInfinite]', {
       cause: e,
       code: SwapErrorTypes.APPROVE_INFINITE_FAILED
     })

--- a/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
@@ -46,7 +46,7 @@ export const thorTradeApproveInfinite = async ({
     return allowanceGrantRequired
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[ZrxApproveInfinite]', {
+    throw new SwapError('[zrxApproveInfinite]', {
       cause: e,
       code: SwapErrorTypes.APPROVE_INFINITE_FAILED
     })

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -10,8 +10,8 @@ import { zrxBuildTrade } from '../zrx/zrxBuildTrade/zrxBuildTrade'
 import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
 import { getUsdRate } from './utils/helpers/helpers'
 import { setupBuildTrade, setupExecuteTrade } from './utils/test-data/setupZrxSwapQuote'
-import { ZrxApprovalNeeded } from './ZrxApprovalNeeded/ZrxApprovalNeeded'
-import { ZrxApproveInfinite } from './ZrxApproveInfinite/ZrxApproveInfinite'
+import { zrxApprovalNeeded } from './zrxApprovalNeeded/zrxApprovalNeeded'
+import { zrxApproveInfinite } from './zrxApproveInfinite/zrxApproveInfinite'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
 jest.mock('./utils/helpers/helpers')
@@ -31,12 +31,12 @@ jest.mock('./getZrxMinMax/getZrxMinMax', () => ({
   getZrxMinMax: jest.fn()
 }))
 
-jest.mock('./ZrxApprovalNeeded/ZrxApprovalNeeded', () => ({
-  ZrxApprovalNeeded: jest.fn()
+jest.mock('./zrxApprovalNeeded/zrxApprovalNeeded', () => ({
+  zrxApprovalNeeded: jest.fn()
 }))
 
-jest.mock('./ZrxApproveInfinite/ZrxApproveInfinite', () => ({
-  ZrxApproveInfinite: jest.fn()
+jest.mock('./zrxApproveInfinite/zrxApproveInfinite', () => ({
+  zrxApproveInfinite: jest.fn()
 }))
 
 describe('ZrxSwapper', () => {
@@ -75,19 +75,19 @@ describe('ZrxSwapper', () => {
     expect(getUsdRate).toHaveBeenCalled()
   })
 
-  it('calls ZrxApprovalNeeded on swapper.approvalNeeded', async () => {
+  it('calls zrxApprovalNeeded on swapper.approvalNeeded', async () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)
     const { tradeQuote } = setupQuote()
     const args = { quote: tradeQuote, wallet }
     await swapper.approvalNeeded(args)
-    expect(ZrxApprovalNeeded).toHaveBeenCalled()
+    expect(zrxApprovalNeeded).toHaveBeenCalled()
   })
 
-  it('calls ZrxApproveInfinite on swapper.approveInfinite', async () => {
+  it('calls zrxApproveInfinite on swapper.approveInfinite', async () => {
     const swapper = new ZrxSwapper(zrxSwapperDeps)
     const { tradeQuote } = setupQuote()
     const args = { quote: tradeQuote, wallet }
     await swapper.approveInfinite(args)
-    expect(ZrxApproveInfinite).toHaveBeenCalled()
+    expect(zrxApproveInfinite).toHaveBeenCalled()
   })
 })

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -21,8 +21,8 @@ import {
 import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
 import { UNSUPPORTED_ASSETS } from './utils/blacklist'
 import { getUsdRate } from './utils/helpers/helpers'
-import { ZrxApprovalNeeded } from './ZrxApprovalNeeded/ZrxApprovalNeeded'
-import { ZrxApproveInfinite } from './ZrxApproveInfinite/ZrxApproveInfinite'
+import { zrxApprovalNeeded } from './zrxApprovalNeeded/zrxApprovalNeeded'
+import { zrxApproveInfinite } from './zrxApproveInfinite/zrxApproveInfinite'
 import { zrxBuildTrade } from './zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
@@ -64,11 +64,11 @@ export class ZrxSwapper implements Swapper<'eip155:1'> {
   }
 
   async approvalNeeded(args: ApprovalNeededInput<'eip155:1'>): Promise<ApprovalNeededOutput> {
-    return ZrxApprovalNeeded(this.deps, args)
+    return zrxApprovalNeeded(this.deps, args)
   }
 
   async approveInfinite(args: ApproveInfiniteInput<'eip155:1'>): Promise<string> {
-    return ZrxApproveInfinite(this.deps, args)
+    return zrxApproveInfinite(this.deps, args)
   }
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
@@ -3,13 +3,8 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
-<<<<<<< HEAD:packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.test.ts
 import { zrxService } from '../utils/zrxService'
-import { ZrxApprovalNeeded } from './ZrxApprovalNeeded'
-=======
-import { zrxServiceFactory } from '../utils/zrxService'
 import { zrxApprovalNeeded } from './zrxApprovalNeeded'
->>>>>>> 8bd959b3 (fix: zrx swapper naming conventions):packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
 
 jest.mock('web3')
 jest.mock('axios', () => ({

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
@@ -3,8 +3,13 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
+<<<<<<< HEAD:packages/swapper/src/swappers/zrx/ZrxApprovalNeeded/ZrxApprovalNeeded.test.ts
 import { zrxService } from '../utils/zrxService'
 import { ZrxApprovalNeeded } from './ZrxApprovalNeeded'
+=======
+import { zrxServiceFactory } from '../utils/zrxService'
+import { zrxApprovalNeeded } from './zrxApprovalNeeded'
+>>>>>>> 8bd959b3 (fix: zrx swapper naming conventions):packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
 
 jest.mock('web3')
 jest.mock('axios', () => ({
@@ -26,7 +31,7 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-describe('ZrxApprovalNeeded', () => {
+describe('zrxApprovalNeeded', () => {
   const deps = setupDeps()
   const walletAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   const wallet = {
@@ -41,7 +46,7 @@ describe('ZrxApprovalNeeded', () => {
       wallet
     }
 
-    expect(await ZrxApprovalNeeded(deps, input)).toEqual({ approvalNeeded: false })
+    expect(await zrxApprovalNeeded(deps, input)).toEqual({ approvalNeeded: false })
   })
 
   it('throws an error if sellAsset chain is not ETH', async () => {
@@ -50,7 +55,7 @@ describe('ZrxApprovalNeeded', () => {
       wallet
     }
 
-    await expect(ZrxApprovalNeeded(deps, input)).rejects.toThrow('[ZrxApprovalNeeded]')
+    await expect(zrxApprovalNeeded(deps, input)).rejects.toThrow('[zrxApprovalNeeded]')
   })
 
   it('returns false if allowanceOnChain is greater than quote.sellAmount', async () => {
@@ -73,7 +78,7 @@ describe('ZrxApprovalNeeded', () => {
     }))
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
 
-    expect(await ZrxApprovalNeeded(deps, input)).toEqual({
+    expect(await zrxApprovalNeeded(deps, input)).toEqual({
       approvalNeeded: false
     })
   })
@@ -98,7 +103,7 @@ describe('ZrxApprovalNeeded', () => {
     }))
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
 
-    expect(await ZrxApprovalNeeded(deps, input)).toEqual({
+    expect(await zrxApprovalNeeded(deps, input)).toEqual({
       approvalNeeded: true
     })
   })

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
@@ -6,7 +6,7 @@ import { bnOrZero } from '../../utils/bignumber'
 import { getERC20Allowance } from '../../utils/helpers/helpers'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
 
-export async function ZrxApprovalNeeded(
+export async function zrxApprovalNeeded(
   { adapter, web3 }: ZrxSwapperDeps,
   { quote, wallet }: ApprovalNeededInput<'eip155:1'>
 ): Promise<ApprovalNeededOutput> {
@@ -16,7 +16,7 @@ export async function ZrxApprovalNeeded(
 
   try {
     if (sellAsset.chainId !== 'eip155:1') {
-      throw new SwapError('[ZrxApprovalNeeded] - sellAsset chainId is not supported', {
+      throw new SwapError('[zrxApprovalNeeded] - sellAsset chainId is not supported', {
         code: SwapErrorTypes.UNSUPPORTED_CHAIN,
         details: { chainId: sellAsset.chainId }
       })
@@ -33,7 +33,7 @@ export async function ZrxApprovalNeeded(
     const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
 
     if (!quote.allowanceContract) {
-      throw new SwapError('[ZrxApprovalNeeded] - allowanceTarget is required', {
+      throw new SwapError('[zrxApprovalNeeded] - allowanceTarget is required', {
         code: SwapErrorTypes.VALIDATION_FAILED,
         details: { chainId: sellAsset.chainId }
       })
@@ -49,7 +49,7 @@ export async function ZrxApprovalNeeded(
     const allowanceOnChain = bnOrZero(allowanceResult)
 
     if (!quote.feeData.chainSpecific?.gasPrice)
-      throw new SwapError('[ZrxApprovalNeeded] - no gas price with quote', {
+      throw new SwapError('[zrxApprovalNeeded] - no gas price with quote', {
         code: SwapErrorTypes.RESPONSE_ERROR,
         details: { feeData: quote.feeData }
       })
@@ -58,7 +58,7 @@ export async function ZrxApprovalNeeded(
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[ZrxApprovalNeeded]', {
+    throw new SwapError('[zrxApprovalNeeded]', {
       cause: e,
       code: SwapErrorTypes.CHECK_APPROVAL_FAILED
     })

--- a/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
@@ -3,8 +3,13 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
+<<<<<<< HEAD:packages/swapper/src/swappers/zrx/ZrxApproveInfinite/ZrxApproveInfinite.test.ts
 import { zrxService } from '../utils/zrxService'
 import { ZrxApproveInfinite } from '../ZrxApproveInfinite/ZrxApproveInfinite'
+=======
+import { zrxServiceFactory } from '../utils/zrxService'
+import { zrxApproveInfinite } from './/zrxApproveInfinite'
+>>>>>>> 8bd959b3 (fix: zrx swapper naming conventions):packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
 
 jest.mock('web3')
 jest.mock('../../utils/helpers/helpers', () => ({
@@ -31,7 +36,7 @@ Web3.mockImplementation(() => ({
   }
 }))
 
-describe('ZrxApproveInfinite', () => {
+describe('zrxApproveInfinite', () => {
   const deps = setupDeps()
   const { tradeQuote } = setupQuote()
   const wallet = {
@@ -44,6 +49,6 @@ describe('ZrxApproveInfinite', () => {
     const quote = { ...tradeQuote }
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
 
-    expect(await ZrxApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
+    expect(await zrxApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
   })
 })

--- a/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
@@ -3,13 +3,8 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
-<<<<<<< HEAD:packages/swapper/src/swappers/zrx/ZrxApproveInfinite/ZrxApproveInfinite.test.ts
 import { zrxService } from '../utils/zrxService'
-import { ZrxApproveInfinite } from '../ZrxApproveInfinite/ZrxApproveInfinite'
-=======
-import { zrxServiceFactory } from '../utils/zrxService'
 import { zrxApproveInfinite } from './/zrxApproveInfinite'
->>>>>>> 8bd959b3 (fix: zrx swapper naming conventions):packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
 
 jest.mock('web3')
 jest.mock('../../utils/helpers/helpers', () => ({

--- a/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.ts
@@ -4,7 +4,7 @@ import { grantAllowance } from '../../utils/helpers/helpers'
 import { MAX_ALLOWANCE } from '../utils/constants'
 import { ZrxSwapperDeps } from '../ZrxSwapper'
 
-export async function ZrxApproveInfinite(
+export async function zrxApproveInfinite(
   { adapter, web3 }: ZrxSwapperDeps,
   { quote, wallet }: ApproveInfiniteInput<'eip155:1'>
 ) {
@@ -23,7 +23,7 @@ export async function ZrxApproveInfinite(
     return allowanceGrantRequired
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[ZrxApproveInfinite]', {
+    throw new SwapError('[zrxApproveInfinite]', {
       cause: e,
       code: SwapErrorTypes.APPROVE_INFINITE_FAILED
     })

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -58,7 +58,7 @@ const setup = () => {
   return { web3Instance, adapter }
 }
 
-describe('ZrxBuildTrade', () => {
+describe('zrxBuildTrade', () => {
   const { quoteResponse, sellAsset, buyAsset } = setupZrxTradeQuoteResponse()
   const { web3Instance, adapter } = setup()
   const walletAddress = '0xc770eefad204b5180df6a14ee197d99d808ee52d'

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -37,7 +37,7 @@ export async function zrxBuildTrade(
     const sellToken = sellAssetNamespace === 'erc20' ? sellAssetErc20Address : sellAsset.symbol
 
     if (buyAsset.chainId !== 'eip155:1') {
-      throw new SwapError('[ZrxBuildTrade] - buyAsset must be on chainId eip155:1', {
+      throw new SwapError('[zrxBuildTrade] - buyAsset must be on chainId eip155:1', {
         code: SwapErrorTypes.VALIDATION_FAILED,
         details: { chainId: sellAsset.chainId }
       })
@@ -134,7 +134,7 @@ export async function zrxBuildTrade(
     return trade
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[ZrxBuildTrade]', {
+    throw new SwapError('[zrxBuildTrade]', {
       code: SwapErrorTypes.BUILD_TRADE_FAILED
     })
   }


### PR DESCRIPTION
Some non-standard naming conventions for file names and functions have been used, and are starting to propagate.

This PR ensures:

1. [lowerCamelCasing is used for functions](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Code_guidelines/JavaScript#function_naming)
2. lowerCamelCasing is used for files exporting functions, or if the file exports a single class, the filename is exactly the name of the class