### PR TITLE
feat(chain-adapters): add getRpcUrl to EVMBaseAdapter

### DIFF
--- a/packages/chain-adapters/src/evm/EVMBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EVMBaseAdapter.ts
@@ -58,6 +58,7 @@ export abstract class EVMBaseAdapter<T extends EVMChainIds> implements IChainAda
     ws: unchained.ws.Client<unchained.ethereum.EthereumTx>
   }
 
+  protected rpcUrl: string
   protected assetId: AssetId
   protected parser: unchained.ethereum.TransactionParser
 

--- a/packages/chain-adapters/src/evm/EVMBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EVMBaseAdapter.ts
@@ -69,6 +69,7 @@ export abstract class EVMBaseAdapter<T extends EVMChainIds> implements IChainAda
 
     this.supportedChainIds = args.supportedChainIds
     this.chainId = args.chainId
+    this.rpcUrl = args.rpcUrl
     this.providers = args.providers
 
     if (!this.supportedChainIds.includes(this.chainId)) {
@@ -83,6 +84,10 @@ export abstract class EVMBaseAdapter<T extends EVMChainIds> implements IChainAda
 
   getChainId(): ChainId {
     return this.chainId
+  }
+
+  getRpcUrl(): string {
+    return this.rpcUrl
   }
 
   buildBIP44Params(params: Partial<BIP44Params>): BIP44Params {

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -33,7 +33,6 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.AvalancheMainnet>
     super({ chainId: DEFAULT_CHAIN_ID, supportedChainIds: SUPPORTED_CHAIN_IDS, ...args })
 
     this.assetId = avalancheAssetId
-    this.rpcUrl = args.rpcUrl
     this.parser = new unchained.ethereum.TransactionParser({
       chainId: this.chainId,
       rpcUrl: this.rpcUrl
@@ -42,10 +41,6 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.AvalancheMainnet>
 
   getType(): KnownChainIds.AvalancheMainnet {
     return KnownChainIds.AvalancheMainnet
-  }
-
-  getRpcUrl(): string {
-    return this.rpcUrl
   }
 
   getFeeAssetId(): AssetId {

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -33,14 +33,19 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.AvalancheMainnet>
     super({ chainId: DEFAULT_CHAIN_ID, supportedChainIds: SUPPORTED_CHAIN_IDS, ...args })
 
     this.assetId = avalancheAssetId
+    this.rpcUrl = args.rpcUrl
     this.parser = new unchained.ethereum.TransactionParser({
       chainId: this.chainId,
-      rpcUrl: args.rpcUrl
+      rpcUrl: this.rpcUrl
     })
   }
 
   getType(): KnownChainIds.AvalancheMainnet {
     return KnownChainIds.AvalancheMainnet
+  }
+
+  getRpcUrl(): string {
+    return this.rpcUrl
   }
 
   getFeeAssetId(): AssetId {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -37,7 +37,6 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.EthereumMainnet> 
     super({ chainId: DEFAULT_CHAIN_ID, supportedChainIds: SUPPORTED_CHAIN_IDS, ...args })
 
     this.assetId = ethAssetId
-    this.rpcUrl = args.rpcUrl
     this.parser = new unchained.ethereum.TransactionParser({
       chainId: this.chainId,
       rpcUrl: this.rpcUrl
@@ -46,10 +45,6 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.EthereumMainnet> 
 
   getType(): KnownChainIds.EthereumMainnet {
     return KnownChainIds.EthereumMainnet
-  }
-
-  getRpcUrl(): string {
-    return this.rpcUrl
   }
 
   getFeeAssetId(): AssetId {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -37,14 +37,19 @@ export class ChainAdapter extends EVMBaseAdapter<KnownChainIds.EthereumMainnet> 
     super({ chainId: DEFAULT_CHAIN_ID, supportedChainIds: SUPPORTED_CHAIN_IDS, ...args })
 
     this.assetId = ethAssetId
+    this.rpcUrl = args.rpcUrl
     this.parser = new unchained.ethereum.TransactionParser({
       chainId: this.chainId,
-      rpcUrl: args.rpcUrl
+      rpcUrl: this.rpcUrl
     })
   }
 
   getType(): KnownChainIds.EthereumMainnet {
     return KnownChainIds.EthereumMainnet
+  }
+
+  getRpcUrl(): string {
+    return this.rpcUrl
   }
 
   getFeeAssetId(): AssetId {


### PR DESCRIPTION
## Description

This adds a `rpcUrl` class property in `EVMBaseAdapter`, and a `getRpcUrl` getter.

Note that this hasn't been added to the other adapters, as the current need for getting the rpcUrl is to add an ethereum chain in https://github.com/shapeshift/hdwallet/pull/547 - if we do end up architecturally needing it in other adapters, we could add it there, but IMO it shouldn't be added just for the sake of consistency.