### PR TITLE
feat(swapper): remove deprecated getSwapper method

### DIFF
--- a/packages/swapper/README.md
+++ b/packages/swapper/README.md
@@ -37,7 +37,7 @@ manager
   .addSwapper(SwapperType.Thorchain, new ThorchainSwapper())
 
 // Get a swapper from the manager
-const swapper = manager.getSwapper(SwapperType.Zrx)
+const swapper = manager.swappers.get(SwapperType.Zrx)
 
 // Remove a swapper from the manager
 manager.removeSwapper(SwapperType.Zrx)
@@ -50,7 +50,7 @@ manager.removeSwapper(SwapperType.Zrx)
 const { swapperType, quote } = await manager.getBestQuote(...args)
 
 // Get the swapper and do stuff
-const swapper = manager.getSwapper(swapperType)
+const swapper = manager.swappers.get(swapperType)
 ```
 
 ### Working with a specific swapper

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -14,6 +14,7 @@ describe('SwapperManager', () => {
     web3: <Web3>{},
     adapter: <ethereum.ChainAdapter>{}
   }
+
   const cowSwapperDeps: CowSwapperDeps = {
     apiUrl: 'https://api.cow.fi/mainnet/api/',
     adapter: <ethereum.ChainAdapter>{},
@@ -38,7 +39,7 @@ describe('SwapperManager', () => {
     it('should add swapper', () => {
       const manager = new SwapperManager()
       manager.addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))
-      expect(manager.getSwapper(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
+      expect(manager.swappers.get(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
     })
 
     it('should be chainable', async () => {
@@ -46,7 +47,7 @@ describe('SwapperManager', () => {
       manager
         .addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))
         .addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
-      expect(manager.getSwapper(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
+      expect(manager.swappers.get(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
     })
 
     it('should throw an error if adding an existing chain', () => {
@@ -59,11 +60,11 @@ describe('SwapperManager', () => {
     })
   })
 
-  describe('getSwapper', () => {
+  describe('get', () => {
     it('should return a swapper that has been added', () => {
       const swapper = new SwapperManager()
       swapper.addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))
-      expect(swapper.getSwapper(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
+      expect(swapper.swappers.get(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
     })
 
     it('should return the correct swapper', () => {
@@ -73,24 +74,10 @@ describe('SwapperManager', () => {
         .addSwapper(SwapperType.Zrx, new ZrxSwapper(zrxSwapperDeps))
         .addSwapper(SwapperType.CowSwap, new CowSwapper(cowSwapperDeps))
 
-      expect(swapper.getSwapper(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
-      expect(swapper.getSwapper(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
-      expect(swapper.getSwapper(SwapperType.CowSwap)).toBeInstanceOf(CowSwapper)
-    })
-
-    it('should throw an error if swapper is not set', () => {
-      const swapper = new SwapperManager()
-      expect(() => swapper.getSwapper(SwapperType.Thorchain)).toThrow(
-        '[getSwapper] - swapperType doesnt exist'
-      )
-    })
-
-    it('should throw an error if an invalid Swapper instance is passed', () => {
-      const manager = new SwapperManager()
-      // @ts-ignore
-      expect(() => manager.addSwapper(SwapperType.Thorchain, {})).toThrow(
-        '[validateSwapper] - invalid swapper instance'
-      )
+      expect(swapper.swappers.get(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
+      expect(swapper.swappers.get(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
+      expect(swapper.swappers.get(SwapperType.Zrx)).toBeInstanceOf(ZrxSwapper)
+      expect(swapper.swappers.get(SwapperType.CowSwap)).toBeInstanceOf(CowSwapper)
     })
   })
 
@@ -100,9 +87,7 @@ describe('SwapperManager', () => {
       swapper
         .addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))
         .removeSwapper(SwapperType.Thorchain)
-      expect(() => swapper.getSwapper(SwapperType.Thorchain)).toThrow(
-        `[getSwapper] - swapperType doesnt exist`
-      )
+      expect(swapper.swappers.get(SwapperType.Thorchain)).toBeUndefined()
     })
 
     it("should throw an error if swapper isn't set", () => {

--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -60,7 +60,7 @@ describe('SwapperManager', () => {
     })
   })
 
-  describe('get', () => {
+  describe('can get swapper instance from swappers', () => {
     it('should return a swapper that has been added', () => {
       const swapper = new SwapperManager()
       swapper.addSwapper(SwapperType.Thorchain, new ThorchainSwapper(thorchainSwapperDeps))

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -40,22 +40,6 @@ export class SwapperManager {
   /**
    *
    * @param swapperType swapper type {SwapperType|string}
-   * @returns {Swapper}
-   * @deprecated this will be removed, currently used in swapper tests
-   */
-  getSwapper(swapperType: SwapperType): Swapper<ChainId> {
-    const swapper = this.swappers.get(swapperType)
-    if (!swapper)
-      throw new SwapError('[getSwapper] - swapperType doesnt exist', {
-        code: SwapErrorTypes.MANAGER_ERROR,
-        details: { swapperType }
-      })
-    return swapper
-  }
-
-  /**
-   *
-   * @param swapperType swapper type {SwapperType|string}
    * @returns {SwapperManager}
    */
   removeSwapper(swapperType: SwapperType): this {


### PR DESCRIPTION
`getSwapper` is deprecated, and is now only used in tests.

This PR removes it and uses `Map.prototype.get()` in the tests instead.