### PR TITLE
fix: bump osmosis gas limit

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -481,11 +481,11 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
     return {
       [FeeDataKey.Fast]: {
         txFee: '5000',
-        chainSpecific: { gasLimit: '700000' }
+        chainSpecific: { gasLimit: '300000' }
       },
       [FeeDataKey.Average]: {
         txFee: '3500',
-        chainSpecific: { gasLimit: '500000' }
+        chainSpecific: { gasLimit: '300000' }
       },
       [FeeDataKey.Slow]: {
         txFee: '2500',

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -481,15 +481,15 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
     return {
       [FeeDataKey.Fast]: {
         txFee: '5000',
-        chainSpecific: { gasLimit: '250000' }
+        chainSpecific: { gasLimit: '700000' }
       },
       [FeeDataKey.Average]: {
         txFee: '3500',
-        chainSpecific: { gasLimit: '250000' }
+        chainSpecific: { gasLimit: '500000' }
       },
       [FeeDataKey.Slow]: {
         txFee: '2500',
-        chainSpecific: { gasLimit: '250000' }
+        chainSpecific: { gasLimit: '300000' }
       }
     }
   }


### PR DESCRIPTION
This bumps the gas limit for osmosis Txs to 300000/500000/700000

Relevant discussion: https://github.com/shapeshift/web/pull/2067#issuecomment-1175100530

> WRT failed Txs for unstake, I've noticed that 300000 seems to be the sweet gas spot that consistently broadcasts Txs.
We should adjust the gas for Osmosis Txs to be higher than what it is currently, as unstake Txs consistently fail. Note that the needed gas can very depending on current network conditions, so we should probably not rely on this number but rather use e.g 500000 as medium gas.
This should be updated in OsmosisChainAdapter's getFeeData.