### PR TITLE
chore(swapper): un-deprecate getSwapper

### DIFF
--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -41,7 +41,6 @@ export class SwapperManager {
    *
    * @param swapperType swapper type {SwapperType|string}
    * @returns {Swapper}
-   * @deprecated this will be removed, currently used in swapper tests
    */
   getSwapper(swapperType: SwapperType): Swapper<ChainId> {
     const swapper = this.swappers.get(swapperType)


### PR DESCRIPTION
We don't actually want to deprecate `getSwapper` as we should continue to interact with the map via the `SwapperManager` helper abstractions.

Decided after removing in https://github.com/shapeshift/lib/pull/853, but then deduced that it didn't make sense to do so.