### PR TITLE
feat(swapper): make initialize swapper method optional

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -183,7 +183,7 @@ export enum SwapErrorTypes {
 
 export interface Swapper<T extends ChainId> {
   /** perform any necessary async initialization */
-  initialize(): Promise<void>
+  initialize?(): Promise<void>
 
   /** Returns the swapper type */
   getType(): SwapperType

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -43,9 +43,6 @@ export class CowSwapper implements Swapper<'eip155:1'> {
     this.deps = deps
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async initialize() {}
-
   getType() {
     return SwapperType.CowSwap
   }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -39,10 +39,6 @@ export class ZrxSwapper implements Swapper<'eip155:1'> {
     this.deps = deps
   }
 
-  // noop for zrx
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async initialize() {}
-
   getType() {
     return SwapperType.Zrx
   }


### PR DESCRIPTION
The `initialize()` method on a `Swapper` should be optional rather than no-opping it when it's not needed.