### PR TITLE
fix(unchained-client): assign this.provider in BaseTransactionParser

### DIFF
--- a/packages/unchained-client/src/evm/parser/index.ts
+++ b/packages/unchained-client/src/evm/parser/index.ts
@@ -28,6 +28,7 @@ export class BaseTransactionParser<T extends Tx> {
 
     const provider = new ethers.providers.JsonRpcProvider(args.rpcUrl)
 
+    this.provider = provider
     this.registerParser(new erc20.Parser({ chainId: this.chainId, provider }))
   }
 


### PR DESCRIPTION
This adds a missing `this.provider` assignment in `BaseTransactionParser`.

As a result of it being undefined, the Yearn SDK currently crashes on undefined provider.