### PR TITLE
feat(swapper): repurpose 'swapperName' to be human readable name for each swapper

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -177,6 +177,9 @@ export enum SwapErrorTypes {
 }
 
 export interface Swapper<T extends ChainId> {
+  /** Human readable swapper name */
+  readonly name: string
+
   /** perform any necessary async initialization */
   initialize?(): Promise<void>
 

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -38,9 +38,9 @@ describe('CowSwapper', () => {
   const wallet = <HDWallet>{}
   const swapper = new CowSwapper(COW_SWAPPER_DEPS)
 
-  describe('static properties', () => {
-    it('returns the correct swapper name', () => {
-      expect(CowSwapper.swapperName).toEqual('CowSwapper')
+  describe('name', () => {
+    it('returns the correct human readable swapper name', () => {
+      expect(swapper.name).toEqual('CowSwap')
     })
   })
 

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -36,7 +36,7 @@ export type CowSwapperDeps = {
 }
 
 export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
-  public readonly name = 'CowSwap'
+  readonly name = 'CowSwap'
   deps: CowSwapperDeps
 
   constructor(deps: CowSwapperDeps) {

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -36,7 +36,7 @@ export type CowSwapperDeps = {
 }
 
 export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
-  public static swapperName = 'CowSwapper'
+  public readonly name = 'CowSwap'
   deps: CowSwapperDeps
 
   constructor(deps: CowSwapperDeps) {

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -17,6 +17,7 @@ import {
  * Meant for local testing only
  */
 export class TestSwapper implements Swapper<ChainId> {
+  public readonly name = 'Test'
   supportAssets: string[]
 
   // noop for test

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -17,7 +17,7 @@ import {
  * Meant for local testing only
  */
 export class TestSwapper implements Swapper<ChainId> {
-  public readonly name = 'Test'
+  readonly name = 'Test'
   supportAssets: string[]
 
   // noop for test

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.test.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.test.ts
@@ -10,14 +10,20 @@ jest.mock('./utils/thorService')
 const mockedAxios = thorService as jest.Mocked<typeof axios>
 
 describe('ThorchainSwapper', () => {
+  const swapper = new ThorchainSwapper({
+    midgardUrl: 'localhost:3000',
+    adapterManager: <ChainAdapterManager>{},
+    web3: <Web3>{}
+  })
+
+  describe('name', () => {
+    it('returns the correct human readable swapper name', () => {
+      expect(swapper.name).toEqual('Thorchain')
+    })
+  })
+
   describe('initialize', () => {
     it('throws when api response', async () => {
-      const swapper = new ThorchainSwapper({
-        midgardUrl: 'localhost:3000',
-        adapterManager: <ChainAdapterManager>{},
-        web3: <Web3>{}
-      })
-
       mockedAxios.get.mockImplementation(() => {
         throw new Error('midgard failed')
       })

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -28,7 +28,7 @@ import { getUsdRate } from './utils/getUsdRate/getUsdRate'
 import { thorService } from './utils/thorService'
 
 export class ThorchainSwapper implements Swapper<ChainId> {
-  public readonly name = 'Thorchain'
+  readonly name = 'Thorchain'
   private swapSupportedChainIds: Record<ChainId, boolean> = {
     'eip155:1': true,
     'bip122:000000000019d6689c085ae165831e93': true

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -28,6 +28,7 @@ import { getUsdRate } from './utils/getUsdRate/getUsdRate'
 import { thorService } from './utils/thorService'
 
 export class ThorchainSwapper implements Swapper<ChainId> {
+  public readonly name = 'Thorchain'
   private swapSupportedChainIds: Record<ChainId, boolean> = {
     'eip155:1': true,
     'bip122:000000000019d6689c085ae165831e93': true

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -54,6 +54,10 @@ describe('ZrxSwapper', () => {
     await swapper.getTradeQuote(quoteInput)
     expect(getZrxTradeQuote).toHaveBeenCalled()
   })
+  it('returns 0x name', () => {
+    const swapper = new ZrxSwapper(zrxEthereumSwapperDeps)
+    expect(swapper.name).toBe('0x')
+  })
   it('returns Zrx type', () => {
     const swapper = new ZrxSwapper(zrxEthereumSwapperDeps)
     const type = swapper.getType()

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -27,7 +27,7 @@ import { zrxBuildTrade } from './zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
 export class ZrxSwapper<T extends EvmSupportedChainIds> implements Swapper<T> {
-  public static swapperName = 'ZrxSwapper'
+  public readonly name = '0x'
   deps: ZrxSwapperDeps
   chainId: ChainId
 

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -27,7 +27,7 @@ import { zrxBuildTrade } from './zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
 export class ZrxSwapper<T extends EvmSupportedChainIds> implements Swapper<T> {
-  public readonly name = '0x'
+  readonly name = '0x'
   deps: ZrxSwapperDeps
   chainId: ChainId
 


### PR DESCRIPTION
- Since `swapperName` is not being used anywhere in lib or web, we will repurpose it to be used for Swapper's `tradeFeeSource` and anything else that would need a human readable swapper name.

**NOTE:** This is a breaking change, but nothing is currently using the code that is being changed.