### PR TITLE
fix(chain-adapters): fix showOnDevice in EvmBaseAdapter.ts

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -218,7 +218,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainIds> implements IChainAda
     const addressNList = bip32ToAddressNList(path)
     const address = await (wallet as ETHWallet).ethGetAddress({
       addressNList,
-      showDisplay: showOnDevice
+      showDisplay: Boolean(showOnDevice)
     })
     return address as string
   }


### PR DESCRIPTION
Fix `showOnDevice` in `EvmBaseAdapter`.

The code was changed in v7.3.0.

The previous code:
```ts
showDisplay: Boolean(input.showOnDevice)
```

The current code:
```ts
showDisplay: showOnDevice
```

The problem here lies in that `showOnDevice` is typed as `boolean | undefined`. Passing `undefined` to HDWallet results in the default of `true` for `showOnDevice` instead of `false`.  The `Boolean()` wrapper converts `undefined` to `false`, thus keeping the expected behavior.