### PR TITLE
fix(swapper): fix filterBuyAssetsBySellAssetId for thorchain

### DIFF
--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -84,6 +84,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
     const { assetIds = [], sellAssetId } = args
+    if (!this.supportedAssetIds.includes(sellAssetId)) return []
     return assetIds.filter(
       (assetId) => this.supportedAssetIds.includes(assetId) && assetId !== sellAssetId
     )

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
@@ -33,7 +33,7 @@ export const getPriceRatio = async (
     return bnOrZero(buyUsdPrice).dividedBy(sellUsdPrice).toString()
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getUsdRate]: Thorchain getUsdRate failed', {
+    throw new SwapError('[getPriceRatio]: Thorchain getPriceRatio failed', {
       code: SwapErrorTypes.PRICE_RATIO_FAILED,
       cause: e
     })


### PR DESCRIPTION
- The `filterBuyAssetsBySellAssetId` for ThorchainSwapper is currently checking to see if the `sellAsset` is supported. 
- This fixes that issue by checking if the sellAsset is a supported asset and if not, remove the ThorchainSwapper from the available swappers for that given sellAsset.

also a small copy change to update the error message of `getPriceRatio` to help with debugging.