### PR TITLE
feat: chain adapters getDisplayName

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -23,6 +23,10 @@ import {
 export type ChainAdapterManager = Map<ChainId, ChainAdapter<ChainId>>
 
 export type ChainAdapter<T extends ChainId> = {
+  /**
+   * A user-friendly name for the chain.
+   */
+  getDisplayName(): string
   getChainId(): ChainId
 
   /**

--- a/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/bitcoin/BitcoinChainAdapter.ts
@@ -83,6 +83,10 @@ export class ChainAdapter
     this.parser = new unchained.bitcoin.TransactionParser({ chainId: this.chainId })
   }
 
+  getDisplayName() {
+    return 'Bitcoin'
+  }
+
   getType(): KnownChainIds.BitcoinMainnet {
     return KnownChainIds.BitcoinMainnet
   }

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -76,6 +76,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosChainIds> implements 
   }
 
   abstract getType(): T
+  abstract getDisplayName(): string
 
   getChainId(): ChainId {
     return this.chainId

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -54,6 +54,10 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
     this.parser = new unchained.cosmos.TransactionParser({ chainId: this.chainId })
   }
 
+  getDisplayName() {
+    return 'Cosmos'
+  }
+
   getType(): KnownChainIds.CosmosMainnet {
     return KnownChainIds.CosmosMainnet
   }

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -61,6 +61,11 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
   getFeeAssetId(): AssetId {
     return 'cosmos:osmosis-1/slip44:118'
   }
+
+  getDisplayName() {
+    return 'Osmosis'
+  }
+
   getType(): KnownChainIds.OsmosisMainnet {
     return KnownChainIds.OsmosisMainnet
   }

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -85,6 +85,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainIds> implements IChainAda
   abstract getFeeAssetId(): AssetId
   abstract getFeeData(input: Partial<GetFeeDataInput<T>>): Promise<FeeDataEstimate<T>>
   abstract buildSendTransaction(tx: BuildSendTxInput<T>): Promise<{ txToSign: ChainTxType<T> }>
+  abstract getDisplayName(): string
 
   getChainId(): ChainId {
     return this.chainId

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -39,6 +39,10 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
     })
   }
 
+  getDisplayName() {
+    return 'Avalanche'
+  }
+
   getType(): KnownChainIds.AvalancheMainnet {
     return KnownChainIds.AvalancheMainnet
   }

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -43,6 +43,10 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
     })
   }
 
+  getDisplayName() {
+    return 'Ethereum'
+  }
+
   getType(): KnownChainIds.EthereumMainnet {
     return KnownChainIds.EthereumMainnet
   }

--- a/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UTXOBaseAdapter.ts
@@ -91,6 +91,8 @@ export abstract class UTXOBaseAdapter<T extends UTXOChainIds> implements IChainA
 
   abstract signTransaction(signTxInput: SignTxInput<ChainTxType<T>>): Promise<string>
 
+  abstract getDisplayName(): string
+
   /* public methods */
 
   getChainId(): ChainId {


### PR DESCRIPTION
chain adapters should be the source of truth - this allows web to ask each chain adapter for a
display name to be used in the view layer, rather than maintaining a map of id -> name in the
consumer.
