### PR TITLE
feat: switch EVM chains on buildSendTransaction

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -38,16 +38,16 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^6.2.0",
-    "@shapeshiftoss/hdwallet-core": "^1.23.0",
-    "@shapeshiftoss/hdwallet-native": "^1.23.0",
+    "@shapeshiftoss/hdwallet-core": "^1.26.0",
+    "@shapeshiftoss/hdwallet-native": "^1.26.0",
     "@shapeshiftoss/types": "^7.0.0",
     "@shapeshiftoss/unchained-client": "^9.0.1",
     "bs58check": "^2.0.2"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^6.2.0",
-    "@shapeshiftoss/hdwallet-core": "^1.23.0",
-    "@shapeshiftoss/hdwallet-native": "^1.23.0",
+    "@shapeshiftoss/hdwallet-core": "^1.26.0",
+    "@shapeshiftoss/hdwallet-native": "^1.26.0",
     "@shapeshiftoss/types": "^7.0.0",
     "@shapeshiftoss/unchained-client": "^9.0.1",
     "@types/bs58check": "^2.1.0",

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -3,26 +3,15 @@ import {
   AssetId,
   avalancheAssetId,
   avalancheChainId,
-  fromAssetId,
-  fromChainId
+  fromAssetId
 } from '@shapeshiftoss/caip'
-import {
-  bip32ToAddressNList,
-  ETHSignTx,
-  ETHWallet,
-  supportsEthSwitchChain
-} from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import BigNumber from 'bignumber.js'
-import { numberToHex } from 'web3-utils'
 
-import { ErrorHandler } from '../../error/ErrorHandler'
-import { BuildSendTxInput, FeeDataEstimate, GasFeeDataEstimate, GetFeeDataInput } from '../../types'
-import { toPath } from '../../utils'
+import { FeeDataEstimate, GasFeeDataEstimate, GetFeeDataInput } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
-import { Fees } from '../types'
 import { getErc20Data } from '../utils'
 
 const SUPPORTED_CHAIN_IDS = [avalancheChainId]
@@ -55,80 +44,6 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
 
   getFeeAssetId(): AssetId {
     return this.assetId
-  }
-
-  async buildSendTransaction(tx: BuildSendTxInput<KnownChainIds.AvalancheMainnet>): Promise<{
-    txToSign: ETHSignTx
-  }> {
-    try {
-      const { to, wallet, bip44Params = ChainAdapter.defaultBIP44Params, sendMax = false } = tx
-
-      // If there is a mismatch between the current wallet's EVM chain ID and the adapter's chainId?
-      // Switch the chain on wallet before building/sending the Tx
-      if (supportsEthSwitchChain(wallet)) {
-        const walletEvmChainId = await (wallet as ETHWallet).ethGetChainId?.()
-        const adapterEvmChainId = fromChainId(this.chainId).chainReference
-        if (!bnOrZero(walletEvmChainId).isEqualTo(adapterEvmChainId)) {
-          await (wallet as ETHWallet).ethSwitchChain?.(bnOrZero(adapterEvmChainId).toNumber())
-        }
-      }
-
-      const { erc20ContractAddress, gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas } =
-        tx.chainSpecific
-
-      if (!tx.to) throw new Error('AvalancheChainAdapter: to is required')
-      if (!tx.value) throw new Error('AvalancheChainAdapter: value is required')
-
-      const destAddress = erc20ContractAddress ?? to
-
-      const from = await this.getAddress({ bip44Params, wallet })
-      const account = await this.getAccount(from)
-
-      const isErc20Send = !!erc20ContractAddress
-
-      if (sendMax) {
-        if (isErc20Send) {
-          const erc20Balance = account?.chainSpecific?.tokens?.find((token) => {
-            return fromAssetId(token.assetId).assetReference === erc20ContractAddress.toLowerCase()
-          })?.balance
-          if (!erc20Balance) throw new Error('no balance')
-          tx.value = erc20Balance
-        } else {
-          if (bnOrZero(account.balance).isZero()) throw new Error('no balance')
-
-          // (The type system guarantees that either maxFeePerGas or gasPrice will be undefined, but not both)
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const fee = bnOrZero((maxFeePerGas ?? gasPrice)!).times(bnOrZero(gasLimit))
-          tx.value = bnOrZero(account.balance).minus(fee).toString()
-        }
-      }
-      const data = await getErc20Data(to, tx?.value, erc20ContractAddress)
-
-      const fees = ((): Fees => {
-        if (maxFeePerGas && maxPriorityFeePerGas) {
-          return {
-            maxFeePerGas: numberToHex(maxFeePerGas),
-            maxPriorityFeePerGas: numberToHex(maxPriorityFeePerGas)
-          }
-        }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return { gasPrice: numberToHex(tx.chainSpecific.gasPrice!) }
-      })()
-
-      const txToSign: ETHSignTx = {
-        addressNList: bip32ToAddressNList(toPath(bip44Params)),
-        value: numberToHex(isErc20Send ? '0' : tx?.value),
-        to: destAddress,
-        chainId: 43114,
-        data,
-        nonce: numberToHex(account.chainSpecific.nonce),
-        gasLimit: numberToHex(gasLimit),
-        ...fees
-      }
-      return { txToSign }
-    } catch (err) {
-      return ErrorHandler(err)
-    }
   }
 
   async getGasFeeData(): Promise<GasFeeDataEstimate> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,6 +2860,16 @@
     rxjs "^6.4.0"
     type-assertions "^1.1.0"
 
+"@shapeshiftoss/hdwallet-core@1.26.0", "@shapeshiftoss/hdwallet-core@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.26.0.tgz#c42e526fc4c5d4aea1c8df676a415df763bf18bd"
+  integrity sha512-CIm1eJVSOREsi0KNyBibAlEooAIEfLem7Bufe6I/6awNoUr8UdyjcrJni4A1hA+oWl9pgILCwNCzuH9W/N74SA==
+  dependencies:
+    eventemitter2 "^5.0.1"
+    lodash "^4.17.21"
+    rxjs "^6.4.0"
+    type-assertions "^1.1.0"
+
 "@shapeshiftoss/hdwallet-core@latest":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.19.0.tgz#7eeae9be9f90fff53887611c6ac02c334781baa3"
@@ -2878,6 +2888,33 @@
     "@shapeshiftoss/bitcoinjs-lib" "5.2.0-shapeshift.2"
     "@shapeshiftoss/fiosdk" "1.2.1-shapeshift.6"
     "@shapeshiftoss/hdwallet-core" "1.23.0"
+    "@shapeshiftoss/proto-tx-builder" "^0.2.1"
+    "@zxing/text-encoding" "^0.9.0"
+    bchaddrjs "^0.4.9"
+    bignumber.js "^9.0.1"
+    bip32 "^2.0.5"
+    bip39 "^3.0.2"
+    bnb-javascript-sdk-nobroadcast "^2.16.14"
+    crypto-js "^4.0.0"
+    ethers "5.6.5"
+    eventemitter2 "^5.0.1"
+    funtypes "^3.0.1"
+    lodash "^4.17.21"
+    node-fetch "^2.6.1"
+    p-lazy "^3.1.0"
+    scrypt-js "^3.0.1"
+    tendermint-tx-builder "^1.0.9"
+    tiny-secp256k1 "^1.1.6"
+    web-encoding "^1.1.0"
+
+"@shapeshiftoss/hdwallet-native@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-native/-/hdwallet-native-1.26.0.tgz#a6e85751feccb2c528a6e5570a7482b0958f4adc"
+  integrity sha512-PXR2W5RX6MsHLgj6BiN7M0aSJN59p1OXUyXqwjlQXm3frNDLd03WTdtjA1fiwRg43C812DoWLSUZ3k8LE5aGxg==
+  dependencies:
+    "@shapeshiftoss/bitcoinjs-lib" "5.2.0-shapeshift.2"
+    "@shapeshiftoss/fiosdk" "1.2.1-shapeshift.6"
+    "@shapeshiftoss/hdwallet-core" "1.26.0"
     "@shapeshiftoss/proto-tx-builder" "^0.2.1"
     "@zxing/text-encoding" "^0.9.0"
     bchaddrjs "^0.4.9"


### PR DESCRIPTION
## Description

Following https://github.com/shapeshift/web/pull/2165, we do disconnect nor switch to Mainnet on MM/XDEFI if the current chain isn't mainnet. Now that we have multiple EVM chains support, we actually do not need to be on any specific chain to show on-chain data, we only need to switch chains when calling `buildSendTransaction` if there is a mismatch between the adapter-expected EVM chainId and what the current's wallet EVM chainId is