### PR TITLE
feat(caip): add Avalanche mapping to chainIdToAssetId

### DIFF
--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -3,6 +3,8 @@ import { AssetId, fromAssetId, toAssetId } from './assetId/assetId'
 import { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 import {
   ASSET_REFERENCE,
+  avalancheAssetId,
+  avalancheChainId,
   btcAssetId,
   btcChainId,
   CHAIN_NAMESPACE,
@@ -26,7 +28,8 @@ export const chainIdToAssetId: Record<ChainId, AssetId> = {
   [ethChainId]: ethAssetId,
   [btcChainId]: btcAssetId,
   [cosmosChainId]: cosmosAssetId,
-  [osmosisChainId]: osmosisAssetId
+  [osmosisChainId]: osmosisAssetId,
+  [avalancheChainId]: avalancheAssetId
 }
 
 export const accountIdToChainId = (accountId: AccountId): ChainId =>


### PR DESCRIPTION
Add Avalanche to the `chainIdToAssetId` mapping.

Supports https://github.com/shapeshift/web/issues/2156

Enables Avalanche accounts in `web`:

<img width="1267" alt="Screen Shot 2022-07-19 at 6 32 31 pm" src="https://user-images.githubusercontent.com/97164662/179705209-72d56d98-38c4-42d5-aaa1-546f1a00a0ab.png">

