### PR TITLE
feat(chain-adapters): export `EvmChainIds` type

### DIFF
--- a/packages/chain-adapters/src/evm/index.ts
+++ b/packages/chain-adapters/src/evm/index.ts
@@ -1,2 +1,4 @@
+export { EvmChainIds } from './EvmBaseAdapter'
+
 export * as ethereum from './ethereum'
 export * as avalanche from './avalanche'


### PR DESCRIPTION
Exports `EvmChainIds` type for use in `web` to support EVM the work in https://github.com/shapeshift/web/pull/2164, allowing us to use tighter generics that are coupled with the `EvmBaseAdapter` types in `@shapeshiftoss/chain-adapters`.

[Example usage](https://github.com/shapeshift/web/blob/433824ea7438cb847243f8bac7bf90450bec73fd/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx#L54):

```ts
const fees = estimatedFees[feeType] as FeeData<EvmChainIds>
```

Contributes to https://github.com/shapeshift/web/issues/2156.