### PR TITLE
fix: silently fail if a swapper has already been added instead of throwing

### DIFF
--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -64,13 +64,12 @@ describe('SwapperManager', () => {
       expect(manager.getSwapper(SwapperType.ZrxEthereum)).toBeInstanceOf(ZrxSwapper)
     })
 
-    it('should throw an error if adding an existing chain', () => {
-      const swapper = new SwapperManager()
-      expect(() => {
-        swapper
-          .addSwapper(new ThorchainSwapper(thorchainSwapperDeps))
-          .addSwapper(new ThorchainSwapper(thorchainSwapperDeps))
-      }).toThrow('already exists')
+    it('should return the existing swapper if trying to add the same one', () => {
+      const manager = new SwapperManager()
+      manager
+        .addSwapper(new ThorchainSwapper(thorchainSwapperDeps))
+        .addSwapper(new ThorchainSwapper(thorchainSwapperDeps))
+      expect(manager.getSwapper(SwapperType.Thorchain)).toBeInstanceOf(ThorchainSwapper)
     })
   })
 

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -28,12 +28,7 @@ export class SwapperManager {
     validateSwapper(swapperInstance)
     const swapperType = swapperInstance.getType()
     const swapper = this.swappers.get(swapperType)
-    if (swapper)
-      throw new SwapError('[addSwapper] - swapper already exists', {
-        code: SwapErrorTypes.MANAGER_ERROR,
-        details: { swapperType }
-      })
-    this.swappers.set(swapperType, swapperInstance)
+    if (!swapper) this.swappers.set(swapperType, swapperInstance)
     return this
   }
 

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -27,8 +27,7 @@ export class SwapperManager {
   addSwapper(swapperInstance: Swapper<ChainId>): this {
     validateSwapper(swapperInstance)
     const swapperType = swapperInstance.getType()
-    const swapper = this.swappers.get(swapperType)
-    if (!swapper) this.swappers.set(swapperType, swapperInstance)
+    this.swappers.set(swapperType, swapperInstance)
     return this
   }
 


### PR DESCRIPTION
fix: silently fail if a swapper has already been added instead of throwing

We need this in order to cleanly handle async swapper initialization without having to catch every error if a swapper has already been added