### PR TITLE
chore: cowswap remove feeAsset

### DIFF
--- a/packages/swapper/src/manager/SwapperManager.test.ts
+++ b/packages/swapper/src/manager/SwapperManager.test.ts
@@ -8,7 +8,6 @@ import { Swapper, SwapperType } from '../api'
 import { CowSwapper, ThorchainSwapper, ZrxSwapper } from '../swappers'
 import { CowSwapperDeps } from '../swappers/cow/CowSwapper'
 import { ThorchainSwapperDeps } from '../swappers/thorchain/types'
-import { WETH } from '../swappers/utils/test-data/assets'
 import { ZrxSwapperDeps } from '../swappers/zrx/types'
 import { SwapperManager } from './SwapperManager'
 
@@ -32,8 +31,7 @@ describe('SwapperManager', () => {
     adapter: <ethereum.ChainAdapter>{
       getChainId: () => KnownChainIds.EthereumMainnet
     },
-    web3: <Web3>{},
-    feeAsset: WETH
+    web3: <Web3>{}
   }
 
   const thorchainSwapperDeps: ThorchainSwapperDeps = {

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -29,8 +29,7 @@ jest.mock('./cowApproveInfinite/cowApproveInfinite', () => ({
 const COW_SWAPPER_DEPS: CowSwapperDeps = {
   apiUrl: 'https://api.cow.fi/mainnet/api/',
   adapter: {} as ethereum.ChainAdapter,
-  web3: {} as Web3,
-  feeAsset: WETH
+  web3: {} as Web3
 }
 
 jest.mock('./getCowSwapTradeQuote/getCowSwapTradeQuote', () => ({

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -35,7 +35,6 @@ export type CowSwapperDeps = {
   apiUrl: string
   adapter: ethereum.ChainAdapter
   web3: Web3
-  feeAsset: Asset // should be WETH asset
 }
 
 export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -142,8 +142,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
 const defaultDeps: CowSwapperDeps = {
   apiUrl: '',
   adapter: {} as ethereum.ChainAdapter,
-  web3: {} as Web3,
-  feeAsset: WETH
+  web3: {} as Web3
 }
 
 describe('cowBuildTrade', () => {
@@ -172,8 +171,7 @@ describe('cowBuildTrade', () => {
         getAddress: jest.fn(() => Promise.resolve('address11')),
         getFeeData: jest.fn(() => Promise.resolve(feeData))
       } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const tradeInput: BuildTradeInput = {
@@ -220,8 +218,7 @@ describe('cowBuildTrade', () => {
         getAddress: jest.fn(() => Promise.resolve('address11')),
         getFeeData: jest.fn(() => Promise.resolve(feeData))
       } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const tradeInput: BuildTradeInput = {

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -108,8 +108,7 @@ const expectedOrderToSign: CowSwapOrder = {
 const defaultDeps: CowSwapperDeps = {
   apiUrl: '',
   adapter: {} as ethereum.ChainAdapter,
-  web3: {} as Web3,
-  feeAsset: WETH
+  web3: {} as Web3
 }
 
 describe('cowExecuteTrade', () => {
@@ -128,8 +127,7 @@ describe('cowExecuteTrade', () => {
     const deps: CowSwapperDeps = {
       apiUrl: 'https://api.cow.fi/mainnet/api',
       adapter: ethereumMock.ChainAdapter as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const tradeInput: ExecuteTradeInput<KnownChainIds.EthereumMainnet> = {

--- a/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.test.ts
+++ b/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.test.ts
@@ -2,7 +2,6 @@ import { ethereum } from '@shapeshiftoss/chain-adapters'
 import Web3 from 'web3'
 
 import { TradeResult } from '../../../api'
-import { WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
 import { cowService } from '../utils/cowService'
 import { cowGetTradeTxs } from './cowGetTradeTxs'
@@ -14,8 +13,7 @@ describe('cowGetTradeTxs', () => {
     const deps: CowSwapperDeps = {
       apiUrl: 'https://api.cow.fi/mainnet/api',
       adapter: {} as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const input: TradeResult = {
@@ -43,8 +41,7 @@ describe('cowGetTradeTxs', () => {
     const deps: CowSwapperDeps = {
       apiUrl: 'https://api.cow.fi/mainnet/api',
       adapter: {} as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const input: TradeResult = {

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -99,8 +99,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
 const defaultDeps: CowSwapperDeps = {
   apiUrl: '',
   adapter: {} as ethereum.ChainAdapter,
-  web3: {} as Web3,
-  feeAsset: WETH
+  web3: {} as Web3
 }
 
 describe('getCowTradeQuote', () => {
@@ -130,8 +129,7 @@ describe('getCowTradeQuote', () => {
           Promise.resolve(feeData)
         )
       } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3,
-      feeAsset: WETH
+      web3: {} as Web3
     }
 
     const input: GetTradeQuoteInput = {

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = HashZero
 export const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
 export const COW_SWAP_SETTLEMENT_ADDRESS = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'
+export const WETH_ASSET_ID = 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 export const ORDER_KIND_SELL = 'sell'
 export const SIGNING_SCHEME = 'ethsign'

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
@@ -1,7 +1,7 @@
 import { ethereum } from '@shapeshiftoss/chain-adapters'
 import Web3 from 'web3'
 
-import { BTC, ETH, FOX, USDC, WBTC, WETH } from '../../../utils/test-data/assets'
+import { BTC, ETH, FOX, USDC, WBTC } from '../../../utils/test-data/assets'
 import { CowSwapperDeps } from '../../CowSwapper'
 import { cowService } from '../cowService'
 import {
@@ -18,8 +18,7 @@ describe('utils', () => {
   const cowSwapperDeps: CowSwapperDeps = {
     apiUrl: 'https://api.cow.fi/mainnet/api/',
     adapter: {} as ethereum.ChainAdapter,
-    web3: {} as Web3,
-    feeAsset: WETH
+    web3: {} as Web3
   }
 
   describe('getUsdRate', () => {

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
@@ -1,4 +1,5 @@
 import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer'
+import { AssetService } from '@shapeshiftoss/asset-service'
 import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
@@ -8,6 +9,7 @@ import { SwapError, SwapErrorTypes } from '../../../../api'
 import { bn, bnOrZero } from '../../../utils/bignumber'
 import { CowSwapperDeps } from '../../CowSwapper'
 import { CowSwapPriceResponse } from '../../types'
+import { WETH_ASSET_ID } from '../constants'
 import { cowService } from '../cowService'
 
 const USDC_CONTRACT_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
@@ -60,12 +62,9 @@ export type CowSwapQuoteApiInput = {
   validTo: number
 }
 
-export const getUsdRate = async (
-  { apiUrl, feeAsset }: CowSwapperDeps,
-  input: Asset
-): Promise<string> => {
+export const getUsdRate = async ({ apiUrl }: CowSwapperDeps, input: Asset): Promise<string> => {
   // Replacing ETH by WETH specifically for CowSwap in order to get an usd rate when called with ETH as feeAsset
-  const asset = input.assetId !== ethAssetId ? input : feeAsset
+  const asset = input.assetId !== ethAssetId ? input : new AssetService().getAll()[WETH_ASSET_ID]
   const { assetReference: erc20Address, assetNamespace } = fromAssetId(asset.assetId)
 
   if (assetNamespace !== 'erc20') {


### PR DESCRIPTION
cowswap only supports erc20s, not ETH itself.

previously we were passing in a feeAsset to check for this case, and unnecessarily polluting the
interface and making the consumption of cowswapper messier.

given this is a swapper specific issue, and not going to change based on the fundamental design of
cowswap, and we already depend on the asset service, we can safely hardcode WETH in place of ETH
here to handle this specific case and expose a cleaner interface.

closes #844

- chore: don't require feeAsset in cow swapper dependencies
- test: fix cowswap tests to remove feeAsset
