### PR TITLE
feat(swapper): support all evm chains in `getZrxMinMax`

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -44,6 +44,14 @@ import { getErc20Data } from './utils'
 
 export type EvmChainIds = KnownChainIds.EthereumMainnet | KnownChainIds.AvalancheMainnet
 
+export const isEvmChainId = (
+  maybeEvmChainId: string | EvmChainIds
+): maybeEvmChainId is EvmChainIds => {
+  return [KnownChainIds.EthereumMainnet, KnownChainIds.AvalancheMainnet].includes(
+    maybeEvmChainId as EvmChainIds
+  )
+}
+
 export interface ChainAdapterArgs {
   chainId?: ChainId
   providers: {

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -42,13 +42,13 @@ import { bnOrZero } from '../utils/bignumber'
 import { Fees } from './types'
 import { getErc20Data } from './utils'
 
-export type EvmChainIds = KnownChainIds.EthereumMainnet | KnownChainIds.AvalancheMainnet
+export type EvmChainId = KnownChainIds.EthereumMainnet | KnownChainIds.AvalancheMainnet
 
 export const isEvmChainId = (
-  maybeEvmChainId: string | EvmChainIds
-): maybeEvmChainId is EvmChainIds => {
+  maybeEvmChainId: string | EvmChainId
+): maybeEvmChainId is EvmChainId => {
   return [KnownChainIds.EthereumMainnet, KnownChainIds.AvalancheMainnet].includes(
-    maybeEvmChainId as EvmChainIds
+    maybeEvmChainId as EvmChainId
   )
 }
 
@@ -66,7 +66,7 @@ export interface EvmBaseAdapterArgs extends ChainAdapterArgs {
   chainId: ChainId
 }
 
-export abstract class EvmBaseAdapter<T extends EvmChainIds> implements IChainAdapter<T> {
+export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdapter<T> {
   protected readonly chainId: ChainId
   protected readonly supportedChainIds: Array<ChainId>
   protected readonly providers: {

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -42,14 +42,14 @@ import { bnOrZero } from '../utils/bignumber'
 import { Fees } from './types'
 import { getErc20Data } from './utils'
 
-export type EvmChainId = KnownChainIds.EthereumMainnet | KnownChainIds.AvalancheMainnet
+const evmChainIds = [KnownChainIds.EthereumMainnet, KnownChainIds.AvalancheMainnet] as const
+
+export type EvmChainId = typeof evmChainIds[number]
 
 export const isEvmChainId = (
   maybeEvmChainId: string | EvmChainId
 ): maybeEvmChainId is EvmChainId => {
-  return [KnownChainIds.EthereumMainnet, KnownChainIds.AvalancheMainnet].includes(
-    maybeEvmChainId as EvmChainId
-  )
+  return evmChainIds.includes(maybeEvmChainId as EvmChainId)
 }
 
 export interface ChainAdapterArgs {

--- a/packages/chain-adapters/src/evm/index.ts
+++ b/packages/chain-adapters/src/evm/index.ts
@@ -1,4 +1,4 @@
-export { EvmChainIds } from './EvmBaseAdapter'
+export { EvmChainIds, isEvmChainId } from './EvmBaseAdapter'
 
 export * as ethereum from './ethereum'
 export * as avalanche from './avalanche'

--- a/packages/chain-adapters/src/evm/index.ts
+++ b/packages/chain-adapters/src/evm/index.ts
@@ -1,4 +1,4 @@
-export { EvmChainIds, isEvmChainId, EvmBaseAdapter } from './EvmBaseAdapter'
+export { EvmChainId, isEvmChainId, EvmBaseAdapter } from './EvmBaseAdapter'
 
 export * as ethereum from './ethereum'
 export * as avalanche from './avalanche'

--- a/packages/chain-adapters/src/evm/index.ts
+++ b/packages/chain-adapters/src/evm/index.ts
@@ -1,4 +1,4 @@
-export { EvmChainIds, isEvmChainId } from './EvmBaseAdapter'
+export { EvmChainIds, isEvmChainId, EvmBaseAdapter } from './EvmBaseAdapter'
 
 export * as ethereum from './ethereum'
 export * as avalanche from './avalanche'

--- a/packages/swapper/src/swappers/utils/test-data/assets.ts
+++ b/packages/swapper/src/swappers/utils/test-data/assets.ts
@@ -1,4 +1,4 @@
-import { avalancheAssetId, avalancheChainId } from '@shapeshiftoss/caip/src'
+import { avalancheAssetId, avalancheChainId, ethAssetId, ethChainId } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
 
 export const BTC: Asset = {
@@ -16,7 +16,7 @@ export const BTC: Asset = {
 
 export const WETH: Asset = {
   assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  chainId: 'eip155:1',
+  chainId: ethChainId,
   name: 'WETH',
   precision: 18,
   color: '#FFFFFF',
@@ -29,7 +29,7 @@ export const WETH: Asset = {
 
 export const FOX: Asset = {
   assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
-  chainId: 'eip155:1',
+  chainId: ethChainId,
   name: 'FOX',
   precision: 18,
   color: '#FFFFFF',
@@ -42,7 +42,7 @@ export const FOX: Asset = {
 
 export const WBTC: Asset = {
   assetId: 'eip155:1/erc20:0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-  chainId: 'eip155:1',
+  chainId: ethChainId,
   color: '#FFFFFF',
   explorer: 'https://etherscan.io',
   explorerAddressLink: 'https://etherscan.io/address/',
@@ -54,8 +54,8 @@ export const WBTC: Asset = {
 }
 
 export const ETH: Asset = {
-  assetId: 'eip155:1/slip44:60',
-  chainId: 'eip155:1',
+  assetId: ethAssetId,
+  chainId: ethChainId,
   symbol: 'ETH',
   name: 'Ethereum',
   precision: 18,
@@ -68,7 +68,7 @@ export const ETH: Asset = {
 
 export const UNSUPPORTED: Asset = {
   assetId: 'eip155:1/slip44:420',
-  chainId: 'eip155:1',
+  chainId: ethChainId,
   symbol: 'ETH',
   name: 'Ethereum',
   precision: 18,
@@ -81,7 +81,7 @@ export const UNSUPPORTED: Asset = {
 
 export const USDC: Asset = {
   assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  chainId: 'eip155:1',
+  chainId: ethChainId,
   symbol: 'USDC',
   name: 'USD Coin',
   precision: 6,

--- a/packages/swapper/src/swappers/utils/test-data/assets.ts
+++ b/packages/swapper/src/swappers/utils/test-data/assets.ts
@@ -1,3 +1,4 @@
+import { avalancheAssetId, avalancheChainId } from '@shapeshiftoss/caip/src'
 import { Asset } from '@shapeshiftoss/types'
 
 export const BTC: Asset = {
@@ -89,4 +90,17 @@ export const USDC: Asset = {
   explorer: 'https://etherscan.io',
   explorerAddressLink: 'https://etherscan.io/address/',
   explorerTxLink: 'https://etherscan.io/tx/'
+}
+
+export const AVAX: Asset = {
+  assetId: avalancheAssetId,
+  chainId: avalancheChainId,
+  name: 'Avalanche',
+  symbol: 'AVAX',
+  precision: 18,
+  color: '#FFFFFF',
+  icon: 'https://rawcdn.githack.com/trustwallet/assets/32e51d582a890b3dd3135fe3ee7c20c2fd699a6d/blockchains/avalanchec/info/logo.png',
+  explorer: 'https://snowtrace.io',
+  explorerAddressLink: 'https://snowtrace.io/address/',
+  explorerTxLink: 'https://snowtrace.io/tx/'
 }

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../utils/zrxService')
 jest.mock('../utils/helpers/helpers')
 
-import { BTC, FOX, WETH } from '../../utils/test-data/assets'
+import { AVAX, BTC, FOX, WETH } from '../../utils/test-data/assets'
 import { MAX_ZRX_TRADE } from '../utils/constants'
 import { getZrxMinMax } from './getZrxMinMax'
 
@@ -16,7 +16,12 @@ describe('getZrxMinMax', () => {
     expect(minMax.minimum).toBe('1')
     expect(minMax.maximum).toBe(MAX_ZRX_TRADE)
   })
-  it('fails on non eth asset', async () => {
+
+  it('fails on invalid evm asset', async () => {
     await expect(getZrxMinMax(BTC, WETH)).rejects.toThrow('[getZrxMinMax]')
+  })
+
+  it('fails on cross-chain swap', async () => {
+    await expect(getZrxMinMax(AVAX, WETH)).rejects.toThrow('[getZrxMinMax]')
   })
 })

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -10,8 +10,9 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
   try {
     if (
       !(
-        (isEvmChainId(sellAsset.chainId) && isEvmChainId(buyAsset.chainId)) ||
-        buyAsset.chainId !== sellAsset.chainId
+        isEvmChainId(sellAsset.chainId) &&
+        isEvmChainId(buyAsset.chainId) &&
+        buyAsset.chainId === sellAsset.chainId
       )
     ) {
       throw new SwapError('[getZrxMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -1,3 +1,4 @@
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import { Asset } from '@shapeshiftoss/types'
 
 import { MinMaxOutput, SwapError, SwapErrorTypes } from '../../../api'
@@ -7,7 +8,7 @@ import { getUsdRate } from '../utils/helpers/helpers'
 
 export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<MinMaxOutput> => {
   try {
-    if (sellAsset.chainId !== 'eip155:1' || buyAsset.chainId !== 'eip155:1') {
+    if (!isEvmChainId(sellAsset.chainId) || !isEvmChainId(buyAsset.chainId)) {
       throw new SwapError('[getZrxMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })
     }
 

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -8,7 +8,12 @@ import { getUsdRate } from '../utils/helpers/helpers'
 
 export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<MinMaxOutput> => {
   try {
-    if (!isEvmChainId(sellAsset.chainId) || !isEvmChainId(buyAsset.chainId)) {
+    if (
+      !(
+        (isEvmChainId(sellAsset.chainId) && isEvmChainId(buyAsset.chainId)) ||
+        buyAsset.chainId !== sellAsset.chainId
+      )
+    ) {
       throw new SwapError('[getZrxMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })
     }
 


### PR DESCRIPTION
Add a type guard and check that buy and sell asset args for `getZrxMinMax` are both (a) on the same chain and (b) of type `EvmChainIds`.

Note, in a future PR I'd like to rename the new `EvmChainIds` type to the singular, `EvmChainId`.

Contributes to https://github.com/shapeshift/web/issues/2156