### PR TITLE
refactor(investor-foxy): change contract param to contract address on canClaimWithdraw

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -39,7 +39,7 @@ import {
   RebaseHistory,
   SignAndBroadcastTx,
   StakingContract,
-  StakingContractWithUser,
+  StakingContractAddressWithUser,
   TokeClaimIpfs,
   TokenAddressInput,
   TxInput,
@@ -538,10 +538,11 @@ export class FoxyApi {
     return this.signAndBroadcastTx({ payload, wallet, dryRun })
   }
 
-  async canClaimWithdraw(input: StakingContractWithUser): Promise<boolean> {
-    const { userAddress, stakingContract } = input
+  async canClaimWithdraw(input: StakingContractAddressWithUser): Promise<boolean> {
+    const { userAddress, contractAddress } = input
     const tokeManagerContract = new this.web3.eth.Contract(tokeManagerAbi, tokeManagerAddress)
     const tokePoolContract = new this.web3.eth.Contract(tokePoolAbi, tokePoolAddress)
+    const stakingContract = this.getStakingContract(contractAddress)
 
     const coolDownInfo = await (async () => {
       try {
@@ -629,7 +630,7 @@ export class FoxyApi {
 
     const stakingContract = this.getStakingContract(contractAddress)
 
-    const canClaim = await this.canClaimWithdraw({ userAddress, stakingContract })
+    const canClaim = await this.canClaimWithdraw({ userAddress, contractAddress })
     if (!canClaim) throw new Error('Not ready to claim')
 
     const data: string = stakingContract.methods.claimWithdraw(addressToClaim).encodeABI({

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -28,6 +28,7 @@ import {
   AllowanceInput,
   ApproveInput,
   BalanceInput,
+  CanClaimWithdrawParams,
   ClaimWithdrawal,
   ContractAddressInput,
   EstimateGasApproveInput,
@@ -39,7 +40,6 @@ import {
   RebaseHistory,
   SignAndBroadcastTx,
   StakingContract,
-  StakingContractAddressWithUser,
   TokeClaimIpfs,
   TokenAddressInput,
   TxInput,
@@ -538,7 +538,7 @@ export class FoxyApi {
     return this.signAndBroadcastTx({ payload, wallet, dryRun })
   }
 
-  async canClaimWithdraw(input: StakingContractAddressWithUser): Promise<boolean> {
+  async canClaimWithdraw(input: CanClaimWithdrawParams): Promise<boolean> {
     const { userAddress, contractAddress } = input
     const tokeManagerContract = new this.web3.eth.Contract(tokeManagerAbi, tokeManagerAddress)
     const tokePoolContract = new this.web3.eth.Contract(tokePoolAbi, tokePoolAddress)

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -151,7 +151,7 @@ export type StakingContract = {
   stakingContract: Contract
 }
 
-export type StakingContractAddressWithUser = {
+export type CanClaimWithdrawParams = {
   contractAddress: string
   userAddress: string
 }

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -151,6 +151,7 @@ export type StakingContract = {
   stakingContract: Contract
 }
 
-export type StakingContractWithUser = StakingContract & {
+export type StakingContractAddressWithUser = {
+  contractAddress: string
   userAddress: string
 }


### PR DESCRIPTION
We don't want to ask for a `Contract` object as a parameter as we already have it inside `foxy-investor`. It still permits simplifying the usage of this method on web and any other projects using this dependency

It seems that we never used this method anywhere yet but we will need to use it in `web` https://github.com/shapeshift/web/pull/2225 as a safety