### PR TITLE
feat(caip): remove chainIdToFeeAssetId

### DIFF
--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -31,7 +31,6 @@ import {
 import {
   accountIdToChainId,
   accountIdToSpecifier,
-  chainIdToFeeAssetId,
   getFeeAssetIdFromAssetId,
   isValidChainPartsPair
 } from './utils'
@@ -63,18 +62,6 @@ describe('accountIdToSpecifier', () => {
     const accountId = 'bip122:000000000019d6689c085ae165831e93:xpubfoobarbaz'
     const result = accountIdToSpecifier(accountId)
     expect(result).toEqual(xpub)
-  })
-})
-
-describe('chainIdToFeeAssetId', () => {
-  it('returns a chain fee assetId for a given Ethereum chainId', () => {
-    const result = chainIdToFeeAssetId(ethChainId)
-    expect(result).toEqual(ethAssetId)
-  })
-
-  it('returns chain fee assetId (ATOM) for a given Cosmos chainId', () => {
-    const result = chainIdToFeeAssetId(cosmosChainId)
-    expect(result).toEqual(cosmosAssetId)
   })
 })
 

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -41,8 +41,6 @@ export const accountIdToChainId = (accountId: AccountId): ChainId =>
 export const accountIdToSpecifier = (accountId: AccountId): string =>
   fromAccountId(accountId).account
 
-export const chainIdToFeeAssetId = (chainId: ChainId): AssetId => chainIdToAssetId[chainId]
-
 // We make the assumption here that the fee assetIds are in `chainIdToAssetId` for each
 // chain we support.
 export const getFeeAssetIdFromAssetId = (assetId: AssetId): AssetId | undefined => {


### PR DESCRIPTION
### Description

This removes the `chainIdToFeeAssetId` function following https://github.com/shapeshift/web/pull/2159

### Issue

- partially tackles https://github.com/shapeshift/lib/issues/875