### PR TITLE
chore: cleanup swappers, remove buy & sell account number

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -53,9 +53,9 @@ type CommonTradeInput = {
   buyAsset: Asset
   sellAmount: string
   sendMax: boolean
-  sellAssetAccountNumber: number
   wallet: HDWallet
   receiveAddress: string
+  bip44Params: BIP44Params
 }
 
 export type EvmSupportedChainIds = KnownChainIds.EthereumMainnet | KnownChainIds.AvalancheMainnet
@@ -77,7 +77,6 @@ export type GetCosmosSdkTradeQuoteInput = CommonTradeInput & {
 type GetBtcTradeQuoteInput = CommonTradeInput & {
   chainId: KnownChainIds.BitcoinMainnet
   accountType: UtxoAccountType
-  bip44Params: BIP44Params
   wallet: HDWallet
 }
 
@@ -100,7 +99,6 @@ interface TradeBase<C extends ChainId> {
   buyAsset: Asset
   sellAsset: Asset
   receiveAddress: string
-  sellAssetAccountNumber: number
 }
 
 export interface TradeQuote<C extends ChainId> extends TradeBase<C> {

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -107,7 +107,9 @@ export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
   maximum: string
 }
 
-export type Trade<C extends ChainId> = TradeBase<C>
+export interface Trade<C extends ChainId> extends TradeBase<C> {
+  bip44Params: BIP44Params
+}
 
 export type ExecuteTradeInput<C extends ChainId> = {
   trade: Trade<C>
@@ -121,6 +123,7 @@ export type TradeResult = {
 export type ApproveInfiniteInput<C extends ChainId> = {
   quote: TradeQuote<C>
   wallet: HDWallet
+  bip44Params: BIP44Params
 }
 
 export type ApprovalNeededInput<C extends ChainId> = {

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -87,7 +87,6 @@ export type GetTradeQuoteInput =
   | GetCosmosSdkTradeQuoteInput
 
 export type BuildTradeInput = GetTradeQuoteInput & {
-  buyAssetAccountNumber: number
   slippage?: string
   wallet: HDWallet
 }
@@ -100,6 +99,7 @@ interface TradeBase<C extends ChainId> {
   sources: Array<SwapSource>
   buyAsset: Asset
   sellAsset: Asset
+  receiveAddress: string
   sellAssetAccountNumber: number
 }
 
@@ -109,9 +109,7 @@ export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
   maximum: string
 }
 
-export interface Trade<C extends ChainId> extends TradeBase<C> {
-  receiveAddress: string
-}
+export type Trade<C extends ChainId> = TradeBase<C>
 
 export type ExecuteTradeInput<C extends ChainId> = {
   trade: Trade<C>

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -142,7 +142,6 @@ const main = async (): Promise<void> => {
       sellAmount: sellAmountBase,
       sellAsset,
       sellAssetAccountNumber: 0,
-      buyAssetAccountNumber: 0,
       receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
     })
     const txid = await swapper.executeTrade({ trade, wallet })

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -106,15 +106,16 @@ const main = async (): Promise<void> => {
 
   let quote
   try {
+    const bip44Params = ethChainAdapter.buildBIP44Params({ accountNumber: 0 })
     quote = await swapper.getTradeQuote({
       chainId: KnownChainIds.EthereumMainnet,
       sellAsset,
       buyAsset,
       sellAmount: sellAmountBase,
-      sellAssetAccountNumber: 0,
       sendMax: false,
       receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-      wallet
+      wallet,
+      bip44Params
     })
   } catch (e) {
     console.error(e)
@@ -134,6 +135,7 @@ const main = async (): Promise<void> => {
     } on ${swapper.getType()}? (y/n): `
   )
   if (answer === 'y') {
+    const bip44Params = ethChainAdapter.buildBIP44Params({ accountNumber: 0 })
     const trade = await swapper.buildTrade({
       chainId: KnownChainIds.EthereumMainnet,
       wallet,
@@ -141,8 +143,8 @@ const main = async (): Promise<void> => {
       sendMax: false,
       sellAmount: sellAmountBase,
       sellAsset,
-      sellAssetAccountNumber: 0,
-      receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+      receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+      bip44Params
     })
     const txid = await swapper.executeTrade({ trade, wallet })
     console.info('broadcast tx with id: ', txid)

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -207,7 +207,8 @@ describe('CowSwapper', () => {
           },
           tradeFee: '0'
         },
-        sellAmountWithoutFee: '985442057341242012'
+        sellAmountWithoutFee: '985442057341242012',
+        sellAssetAccountNumber: 0
       }
       const args = { trade: cowSwapTrade, wallet }
       await swapper.executeTrade(args)

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -181,7 +181,11 @@ describe('CowSwapper', () => {
   describe('cowApproveInfinite', () => {
     it('calls cowApproveInfinite on swapper.approveInfinite', async () => {
       const { tradeQuote } = setupQuote()
-      const args = { quote: tradeQuote, wallet }
+      const args = {
+        quote: tradeQuote,
+        wallet,
+        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+      }
       await swapper.approveInfinite(args)
       expect(cowApproveInfinite).toHaveBeenCalledTimes(1)
       expect(cowApproveInfinite).toHaveBeenCalledWith(COW_SWAPPER_DEPS, args)
@@ -207,7 +211,8 @@ describe('CowSwapper', () => {
           },
           tradeFee: '0'
         },
-        sellAmountWithoutFee: '985442057341242012'
+        sellAmountWithoutFee: '985442057341242012',
+        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
       }
       const args = { trade: cowSwapTrade, wallet }
       await swapper.executeTrade(args)

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -207,8 +207,7 @@ describe('CowSwapper', () => {
           },
           tradeFee: '0'
         },
-        sellAmountWithoutFee: '985442057341242012',
-        sellAssetAccountNumber: 0
+        sellAmountWithoutFee: '985442057341242012'
       }
       const args = { trade: cowSwapTrade, wallet }
       await swapper.executeTrade(args)

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -196,7 +196,6 @@ describe('CowSwapper', () => {
         sources: [{ name: 'CowSwap', proportion: '1' }],
         buyAsset: FOX,
         sellAsset: WETH,
-        sellAssetAccountNumber: 0,
         receiveAddress: 'address11',
         feeAmountInSellToken: '14557942658757988',
         rate: '14716.04718939437505555958',

--- a/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.test.ts
+++ b/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.test.ts
@@ -35,6 +35,12 @@ describe('cowApproveInfinite', () => {
     const deps = { web3, adapter, apiUrl: '', feeAsset }
     const quote = { ...tradeQuote }
 
-    expect(await cowApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
+    expect(
+      await cowApproveInfinite(deps, {
+        quote,
+        wallet,
+        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+      })
+    ).toEqual('grantAllowanceTxId')
   })
 })

--- a/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.ts
+++ b/packages/swapper/src/swappers/cow/cowApproveInfinite/cowApproveInfinite.ts
@@ -8,7 +8,7 @@ import { MAX_ALLOWANCE } from '../utils/constants'
 
 export async function cowApproveInfinite(
   { adapter, web3 }: CowSwapperDeps,
-  { quote, wallet }: ApproveInfiniteInput<KnownChainIds.EthereumMainnet>
+  { quote, wallet, bip44Params }: ApproveInfiniteInput<KnownChainIds.EthereumMainnet>
 ) {
   try {
     const allowanceGrantRequired = await grantAllowance<KnownChainIds.EthereumMainnet>({
@@ -19,7 +19,8 @@ export async function cowApproveInfinite(
       wallet,
       adapter,
       erc20Abi,
-      web3
+      web3,
+      bip44Params
     })
 
     return allowanceGrantRequired

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -114,7 +114,8 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '985442057341242012'
+  sellAmountWithoutFee: '985442057341242012',
+  sellAssetAccountNumber: 0
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -135,7 +136,8 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   sellAsset: WBTC,
   receiveAddress: 'address11',
   feeAmountInSellToken: '17238',
-  sellAmountWithoutFee: '99982762'
+  sellAmountWithoutFee: '99982762',
+  sellAssetAccountNumber: 0
 }
 
 const defaultDeps: CowSwapperDeps = {
@@ -153,7 +155,8 @@ describe('cowBuildTrade', () => {
       sellAmount: '11111',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: '',
+      sellAssetAccountNumber: 0
     }
 
     await expect(cowBuildTrade(defaultDeps, tradeInput)).rejects.toThrow(
@@ -165,7 +168,6 @@ describe('cowBuildTrade', () => {
     const deps: CowSwapperDeps = {
       apiUrl: 'https://api.cow.fi/mainnet/api',
       adapter: {
-        getAddress: jest.fn(() => Promise.resolve('address11')),
         getFeeData: jest.fn(() => Promise.resolve(feeData))
       } as unknown as ethereum.ChainAdapter,
       web3: {} as Web3
@@ -179,7 +181,7 @@ describe('cowBuildTrade', () => {
       sendMax: true,
       sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: 'address11'
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -211,7 +213,6 @@ describe('cowBuildTrade', () => {
     const deps: CowSwapperDeps = {
       apiUrl: 'https://api.cow.fi/mainnet/api',
       adapter: {
-        getAddress: jest.fn(() => Promise.resolve('address11')),
         getFeeData: jest.fn(() => Promise.resolve(feeData))
       } as unknown as ethereum.ChainAdapter,
       web3: {} as Web3
@@ -225,7 +226,7 @@ describe('cowBuildTrade', () => {
       sendMax: true,
       sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: 'address11'
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -114,8 +114,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '985442057341242012',
-  sellAssetAccountNumber: 0
+  sellAmountWithoutFee: '985442057341242012'
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -136,8 +135,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   sellAsset: WBTC,
   receiveAddress: 'address11',
   feeAmountInSellToken: '17238',
-  sellAmountWithoutFee: '99982762',
-  sellAssetAccountNumber: 0
+  sellAmountWithoutFee: '99982762'
 }
 
 const defaultDeps: CowSwapperDeps = {
@@ -155,8 +153,7 @@ describe('cowBuildTrade', () => {
       sellAmount: '11111',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: '',
-      sellAssetAccountNumber: 0
+      receiveAddress: ''
     }
 
     await expect(cowBuildTrade(defaultDeps, tradeInput)).rejects.toThrow(
@@ -179,7 +176,6 @@ describe('cowBuildTrade', () => {
       buyAsset: FOX,
       sellAmount: '1000000000000000000',
       sendMax: true,
-      sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
       receiveAddress: 'address11'
     }
@@ -224,7 +220,6 @@ describe('cowBuildTrade', () => {
       buyAsset: WETH,
       sellAmount: '100000000',
       sendMax: true,
-      sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
       receiveAddress: 'address11'
     }

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -112,7 +112,6 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'CowSwap', proportion: '1' }],
   buyAsset: FOX,
   sellAsset: WETH,
-  sellAssetAccountNumber: 0,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
   sellAmountWithoutFee: '985442057341242012'
@@ -134,7 +133,6 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   sources: [{ name: 'CowSwap', proportion: '1' }],
   buyAsset: WETH,
   sellAsset: WBTC,
-  sellAssetAccountNumber: 0,
   receiveAddress: 'address11',
   feeAmountInSellToken: '17238',
   sellAmountWithoutFee: '99982762'
@@ -154,8 +152,6 @@ describe('cowBuildTrade', () => {
       buyAsset: FOX,
       sellAmount: '11111',
       sendMax: true,
-      sellAssetAccountNumber: 1,
-      buyAssetAccountNumber: 2,
       wallet: <HDWallet>{},
       receiveAddress: ''
     }
@@ -182,7 +178,6 @@ describe('cowBuildTrade', () => {
       sellAmount: '1000000000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
-      buyAssetAccountNumber: 0,
       wallet: <HDWallet>{},
       receiveAddress: ''
     }
@@ -229,7 +224,6 @@ describe('cowBuildTrade', () => {
       sellAmount: '100000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
-      buyAssetAccountNumber: 0,
       wallet: <HDWallet>{},
       receiveAddress: ''
     }

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -114,7 +114,8 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '985442057341242012'
+  sellAmountWithoutFee: '985442057341242012',
+  bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -135,7 +136,8 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   sellAsset: WBTC,
   receiveAddress: 'address11',
   feeAmountInSellToken: '17238',
-  sellAmountWithoutFee: '99982762'
+  sellAmountWithoutFee: '99982762',
+  bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
 }
 
 const defaultDeps: CowSwapperDeps = {

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -153,7 +153,8 @@ describe('cowBuildTrade', () => {
       sellAmount: '11111',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: '',
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
     }
 
     await expect(cowBuildTrade(defaultDeps, tradeInput)).rejects.toThrow(
@@ -177,7 +178,8 @@ describe('cowBuildTrade', () => {
       sellAmount: '1000000000000000000',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: 'address11'
+      receiveAddress: 'address11',
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -221,7 +223,8 @@ describe('cowBuildTrade', () => {
       sellAmount: '100000000',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: 'address11'
+      receiveAddress: 'address11',
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -26,7 +26,7 @@ export async function cowBuildTrade(
   input: BuildTradeInput
 ): Promise<CowTrade<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -118,8 +118,7 @@ export async function cowBuildTrade(
       sellAsset,
       receiveAddress,
       feeAmountInSellToken: quote.feeAmount,
-      sellAmountWithoutFee: quote.sellAmount,
-      sellAssetAccountNumber
+      sellAmountWithoutFee: quote.sellAmount
     }
 
     const allowanceRequired = await getAllowanceRequired({

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -26,7 +26,7 @@ export async function cowBuildTrade(
   input: BuildTradeInput
 ): Promise<CowTrade<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress, bip44Params } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -118,7 +118,8 @@ export async function cowBuildTrade(
       sellAsset,
       receiveAddress,
       feeAmountInSellToken: quote.feeAmount,
-      sellAmountWithoutFee: quote.sellAmount
+      sellAmountWithoutFee: quote.sellAmount,
+      bip44Params
     }
 
     const allowanceRequired = await getAllowanceRequired({

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -26,7 +26,7 @@ export async function cowBuildTrade(
   input: BuildTradeInput
 ): Promise<CowTrade<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, wallet } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -42,7 +42,6 @@ export async function cowBuildTrade(
       })
     }
 
-    const receiveAddress = await adapter.getAddress({ wallet })
     const normalizedSellAmount = normalizeAmount(sellAmount)
 
     /**
@@ -117,10 +116,10 @@ export async function cowBuildTrade(
       sources: DEFAULT_SOURCE,
       buyAsset,
       sellAsset,
-      sellAssetAccountNumber,
       receiveAddress,
       feeAmountInSellToken: quote.feeAmount,
-      sellAmountWithoutFee: quote.sellAmount
+      sellAmountWithoutFee: quote.sellAmount,
+      sellAssetAccountNumber
     }
 
     const allowanceRequired = await getAllowanceRequired({

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -65,8 +65,7 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: ETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '111111',
-  sellAssetAccountNumber: 0
+  sellAmountWithoutFee: '111111'
 }
 
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -86,8 +85,7 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '3514395197690019',
-  sellAmountWithoutFee: '16685605000000000',
-  sellAssetAccountNumber: 0
+  sellAmountWithoutFee: '16685605000000000'
 }
 
 const expectedOrderToSign: CowSwapOrder = {

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -65,7 +65,8 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: ETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '111111'
+  sellAmountWithoutFee: '111111',
+  sellAssetAccountNumber: 0
 }
 
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -85,7 +86,9 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '3514395197690019',
-  sellAmountWithoutFee: '16685605000000000'
+  sellAmountWithoutFee: '16685605000000000',
+  sellAssetAccountNumber: 0
+
 }
 
 const expectedOrderToSign: CowSwapOrder = {

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -65,7 +65,8 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: ETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
-  sellAmountWithoutFee: '111111'
+  sellAmountWithoutFee: '111111',
+  bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
 }
 
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -85,7 +86,8 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sellAsset: WETH,
   receiveAddress: 'address11',
   feeAmountInSellToken: '3514395197690019',
-  sellAmountWithoutFee: '16685605000000000'
+  sellAmountWithoutFee: '16685605000000000',
+  bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
 }
 
 const expectedOrderToSign: CowSwapOrder = {

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -63,7 +63,6 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'CowSwap', proportion: '1' }],
   buyAsset: FOX,
   sellAsset: ETH,
-  sellAssetAccountNumber: 0,
   receiveAddress: 'address11',
   feeAmountInSellToken: '14557942658757988',
   sellAmountWithoutFee: '111111'
@@ -84,7 +83,6 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'CowSwap', proportion: '1' }],
   buyAsset: FOX,
   sellAsset: WETH,
-  sellAssetAccountNumber: 0,
   receiveAddress: 'address11',
   feeAmountInSellToken: '3514395197690019',
   sellAmountWithoutFee: '16685605000000000'

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -88,7 +88,6 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellToken: '3514395197690019',
   sellAmountWithoutFee: '16685605000000000',
   sellAssetAccountNumber: 0
-
 }
 
 const expectedOrderToSign: CowSwapOrder = {

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -94,8 +94,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,
   sellAsset: WETH,
-  receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
-  sellAssetAccountNumber: 0
+  receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
 }
 
 const defaultDeps: CowSwapperDeps = {
@@ -112,7 +111,6 @@ describe('getCowTradeQuote', () => {
       buyAsset: FOX,
       sellAmount: '11111',
       sendMax: true,
-      sellAssetAccountNumber: 1,
       wallet: <HDWallet>{},
       receiveAddress: ''
     }
@@ -140,7 +138,6 @@ describe('getCowTradeQuote', () => {
       buyAsset: FOX,
       sellAmount: '1000000000000000000',
       sendMax: true,
-      sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
       receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
     }

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -93,7 +93,9 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'CowSwap', proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,
-  sellAsset: WETH
+  sellAsset: WETH,
+  receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
+  sellAssetAccountNumber: 0
 }
 
 const defaultDeps: CowSwapperDeps = {
@@ -140,7 +142,7 @@ describe('getCowTradeQuote', () => {
       sendMax: true,
       sellAssetAccountNumber: 0,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -112,7 +112,8 @@ describe('getCowTradeQuote', () => {
       sellAmount: '11111',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: ''
+      receiveAddress: '',
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
     }
 
     await expect(getCowSwapTradeQuote(defaultDeps, input)).rejects.toThrow(
@@ -139,7 +140,8 @@ describe('getCowTradeQuote', () => {
       sellAmount: '1000000000000000000',
       sendMax: true,
       wallet: <HDWallet>{},
-      receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
+      receiveAddress: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -93,8 +93,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'CowSwap', proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,
-  sellAsset: WETH,
-  sellAssetAccountNumber: 0
+  sellAsset: WETH
 }
 
 const defaultDeps: CowSwapperDeps = {

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -27,7 +27,7 @@ export async function getCowSwapTradeQuote(
   input: GetTradeQuoteInput
 ): Promise<TradeQuote<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -133,8 +133,7 @@ export async function getCowSwapTradeQuote(
       allowanceContract: COW_SWAP_VAULT_RELAYER_ADDRESS,
       buyAsset,
       sellAsset,
-      receiveAddress,
-      sellAssetAccountNumber
+      receiveAddress
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -134,7 +134,7 @@ export async function getCowSwapTradeQuote(
       buyAsset,
       sellAsset,
       receiveAddress,
-      sellAssetAccountNumber,
+      sellAssetAccountNumber
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -27,7 +27,7 @@ export async function getCowSwapTradeQuote(
   input: GetTradeQuoteInput
 ): Promise<TradeQuote<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, wallet } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -89,8 +89,6 @@ export async function getCowSwapTradeQuote(
     const sellCryptoAmount = bn(quote.sellAmount).div(bn(10).exponentiatedBy(sellAsset.precision))
     const rate = buyCryptoAmount.div(sellCryptoAmount).toString()
 
-    const receiveAddress = wallet ? await adapter.getAddress({ wallet }) : DEFAULT_ADDRESS
-
     const data = getApproveContractData({
       web3,
       spenderAddress: COW_SWAP_VAULT_RELAYER_ADDRESS,
@@ -135,7 +133,8 @@ export async function getCowSwapTradeQuote(
       allowanceContract: COW_SWAP_VAULT_RELAYER_ADDRESS,
       buyAsset,
       sellAsset,
-      sellAssetAccountNumber
+      receiveAddress,
+      sellAssetAccountNumber,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -120,7 +120,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
   }
 
   async buildTrade(args: BuildTradeInput): Promise<Trade<ChainId>> {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = args
+    const { sellAsset, buyAsset, sellAmount, receiveAddress } = args
 
     if (!sellAmount) {
       throw new SwapError('sellAmount is required', {
@@ -158,13 +158,12 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       receiveAddress,
       sellAmount: amountBaseSell,
       sellAsset,
-      sources: [{ name: 'Osmosis', proportion: '100' }],
-      sellAssetAccountNumber
+      sources: [{ name: 'Osmosis', proportion: '100' }]
     }
   }
 
   async getTradeQuote(input: GetTradeQuoteInput): Promise<TradeQuote<ChainId>> {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress } = input
     if (!sellAmount) {
       throw new SwapError('sellAmount is required', {
         code: SwapErrorTypes.RESPONSE_ERROR
@@ -202,13 +201,12 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       buyAmount,
       sources: DEFAULT_SOURCE,
       allowanceContract: '',
-      receiveAddress,
-      sellAssetAccountNumber
+      receiveAddress
     }
   }
 
   async executeTrade({ trade, wallet }: ExecuteTradeInput<ChainId>): Promise<TradeResult> {
-    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, receiveAddress } = trade
+    const { sellAsset, buyAsset, sellAmount, receiveAddress } = trade
 
     const isFromOsmo = sellAsset.assetId === osmosisAssetId
     const sellAssetDenom = symbolDenomMapping[sellAsset.symbol as keyof SymbolDenomMapping]
@@ -234,7 +232,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
     if (!isFromOsmo) {
       const sellBip44Params = cosmosAdapter.buildBIP44Params({
-        accountNumber: Number(sellAssetAccountNumber)
+        accountNumber: Number(0) // TODO
       })
 
       sellAddress = await cosmosAdapter.getAddress({ wallet, bip44Params: sellBip44Params })
@@ -277,7 +275,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       ibcSellAmount = await pollForAtomChannelBalance(receiveAddress, this.deps.osmoUrl)
     } else {
       const sellBip44Params = osmosisAdapter.buildBIP44Params({
-        accountNumber: Number(sellAssetAccountNumber)
+        accountNumber: Number(0) // TODO
       })
       sellAddress = await osmosisAdapter.getAddress({ wallet, bip44Params: sellBip44Params })
 

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -120,7 +120,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
   }
 
   async buildTrade(args: BuildTradeInput): Promise<Trade<ChainId>> {
-    const { sellAsset, buyAsset, sellAmount, receiveAddress } = args
+    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = args
 
     if (!sellAmount) {
       throw new SwapError('sellAmount is required', {
@@ -158,13 +158,13 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       receiveAddress,
       sellAmount: amountBaseSell,
       sellAsset,
-      sellAssetAccountNumber: 0,
-      sources: [{ name: 'Osmosis', proportion: '100' }]
+      sources: [{ name: 'Osmosis', proportion: '100' }],
+      sellAssetAccountNumber
     }
   }
 
   async getTradeQuote(input: GetTradeQuoteInput): Promise<TradeQuote<ChainId>> {
-    const { sellAsset, buyAsset, sellAmount } = input
+    const { sellAsset, buyAsset, sellAmount, receiveAddress, sellAssetAccountNumber } = input
     if (!sellAmount) {
       throw new SwapError('sellAmount is required', {
         code: SwapErrorTypes.RESPONSE_ERROR
@@ -196,13 +196,14 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       feeData: { fee, tradeFee },
       maximum,
       minimum,
-      sellAssetAccountNumber: 0,
       rate,
       sellAsset,
       sellAmount,
       buyAmount,
       sources: DEFAULT_SOURCE,
-      allowanceContract: ''
+      allowanceContract: '',
+      receiveAddress,
+      sellAssetAccountNumber
     }
   }
 

--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { CHAIN_REFERENCE, ChainId } from '@shapeshiftoss/caip'
 import { osmosis, toPath } from '@shapeshiftoss/chain-adapters'
 import { bip32ToAddressNList, HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { BIP44Params } from '@shapeshiftoss/types'
 import axios from 'axios'
 import { find } from 'lodash'
 
@@ -203,7 +204,8 @@ export const performIbcTransfer = async (
   feeAmount: string,
   accountNumber: string,
   sequence: string,
-  gas: string
+  gas: string,
+  bip44Params: BIP44Params
 ): Promise<TradeResult> => {
   const { sender, receiver, amount } = input
 
@@ -217,9 +219,7 @@ export const performIbcTransfer = async (
     }
   })()
   const latestBlock = responseLatestBlock.data.block.header.height
-  const bip44Params = adapter.buildBIP44Params({
-    accountNumber: 0 // TODO: Use real accountNumbers
-  })
+
   const path = toPath(bip44Params)
   const addressNList = bip32ToAddressNList(path)
 
@@ -282,7 +282,8 @@ export const buildTradeTx = async ({
   sellAssetDenom,
   sellAmount,
   gas,
-  wallet
+  wallet,
+  bip44Params
 }: {
   osmoAddress: string
   adapter: osmosis.ChainAdapter
@@ -292,15 +293,13 @@ export const buildTradeTx = async ({
   sellAmount: string
   gas: string
   wallet: HDWallet
+  bip44Params: BIP44Params
 }) => {
   const responseAccount = await adapter.getAccount(osmoAddress)
 
   const accountNumber = responseAccount.chainSpecific.accountNumber || '0'
   const sequence = responseAccount.chainSpecific.sequence || '0'
 
-  const bip44Params = adapter.buildBIP44Params({
-    accountNumber: 0 // TODO: Use real accountNumbers
-  })
   const path = toPath(bip44Params)
   const osmoAddressNList = bip32ToAddressNList(path)
 

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -64,7 +64,8 @@ export const buildTrade = async ({
         chainId: KnownChainIds.EthereumMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: ethTradeTx.txToSign
+        txData: ethTradeTx.txToSign,
+        sellAssetAccountNumber
       }
     } else if (input.chainId === KnownChainIds.BitcoinMainnet) {
       const { vault, opReturnData } = await getBtcThorTxInfo({
@@ -98,7 +99,8 @@ export const buildTrade = async ({
         chainId: KnownChainIds.BitcoinMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: buildTxResponse.txToSign
+        txData: buildTxResponse.txToSign,
+        sellAssetAccountNumber
       }
     } else {
       throw new SwapError('[buildTrade]: unsupported chain id', {

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -23,7 +23,8 @@ export const buildTrade = async ({
       sellAmount,
       wallet,
       slippage: slippageTolerance = DEFAULT_SLIPPAGE,
-      receiveAddress: destinationAddress
+      receiveAddress: destinationAddress,
+      bip44Params: sellAssetBip44Params
     } = input
 
     const quote = await getThorTradeQuote({ deps, input })
@@ -35,9 +36,6 @@ export const buildTrade = async ({
         fn: 'buildTrade',
         details: { sellAsset }
       })
-    const sellAssetBip44Params = sellAdapter.buildBIP44Params({
-      accountNumber: 0 // TODO
-    })
 
     if (input.chainId === KnownChainIds.EthereumMainnet) {
       const ethTradeTx = await makeTradeTx({
@@ -63,7 +61,8 @@ export const buildTrade = async ({
         chainId: KnownChainIds.EthereumMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: ethTradeTx.txToSign
+        txData: ethTradeTx.txToSign,
+        bip44Params: sellAssetBip44Params
       }
     } else if (input.chainId === KnownChainIds.BitcoinMainnet) {
       const { vault, opReturnData } = await getBtcThorTxInfo({
@@ -97,7 +96,8 @@ export const buildTrade = async ({
         chainId: KnownChainIds.BitcoinMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: buildTxResponse.txToSign
+        txData: buildTxResponse.txToSign,
+        bip44Params: sellAssetBip44Params
       }
     } else {
       throw new SwapError('[buildTrade]: unsupported chain id', {

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -20,7 +20,6 @@ export const buildTrade = async ({
     const {
       buyAsset,
       sellAsset,
-      sellAssetAccountNumber,
       sellAmount,
       wallet,
       slippage: slippageTolerance = DEFAULT_SLIPPAGE,
@@ -37,7 +36,7 @@ export const buildTrade = async ({
         details: { sellAsset }
       })
     const sellAssetBip44Params = sellAdapter.buildBIP44Params({
-      accountNumber: sellAssetAccountNumber
+      accountNumber: 0 // TODO
     })
 
     if (input.chainId === KnownChainIds.EthereumMainnet) {
@@ -64,8 +63,7 @@ export const buildTrade = async ({
         chainId: KnownChainIds.EthereumMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: ethTradeTx.txToSign,
-        sellAssetAccountNumber
+        txData: ethTradeTx.txToSign
       }
     } else if (input.chainId === KnownChainIds.BitcoinMainnet) {
       const { vault, opReturnData } = await getBtcThorTxInfo({
@@ -76,7 +74,7 @@ export const buildTrade = async ({
         slippageTolerance,
         destinationAddress,
         wallet,
-        bip44Params: sellAssetBip44Params,
+        bip44Params: input.bip44Params,
         accountType: input.accountType,
         tradeFee: quote.feeData.tradeFee
       })
@@ -99,8 +97,7 @@ export const buildTrade = async ({
         chainId: KnownChainIds.BitcoinMainnet,
         ...quote,
         receiveAddress: destinationAddress,
-        txData: buildTxResponse.txToSign,
-        sellAssetAccountNumber
+        txData: buildTxResponse.txToSign
       }
     } else {
       throw new SwapError('[buildTrade]: unsupported chain id', {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -43,7 +43,9 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '12755.10204081632653061224',
   sources: [{ name: 'thorchain', proportion: '1' }],
   buyAsset: ETH,
-  sellAsset: FOX
+  sellAsset: FOX,
+  receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+  sellAssetAccountNumber: 0
 }
 
 describe('getTradeQuote', () => {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -44,8 +44,7 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   sources: [{ name: 'thorchain', proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,
-  receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-  sellAssetAccountNumber: 0
+  receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 }
 
 describe('getTradeQuote', () => {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -43,8 +43,7 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '12755.10204081632653061224',
   sources: [{ name: 'thorchain', proportion: '1' }],
   buyAsset: ETH,
-  sellAsset: FOX,
-  sellAssetAccountNumber: 0
+  sellAsset: FOX
 }
 
 describe('getTradeQuote', () => {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -29,10 +29,10 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
     sellAsset,
     buyAsset,
     sellAmount,
-    sellAssetAccountNumber,
     wallet,
     chainId,
-    receiveAddress
+    receiveAddress,
+    sellAssetAccountNumber
   } = input
 
   if (!wallet)
@@ -82,8 +82,9 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       sources: [{ name: 'thorchain', proportion: '1' }],
       buyAsset,
       sellAsset,
-      sellAssetAccountNumber,
-      minimum
+      minimum,
+      receiveAddress,
+      sellAssetAccountNumber
     }
 
     switch (chainId) {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -25,15 +25,7 @@ type GetThorTradeQuoteReturn = Promise<TradeQuote<ChainId>>
 type GetThorTradeQuote = (args: GetThorTradeQuoteInput) => GetThorTradeQuoteReturn
 
 export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
-  const {
-    sellAsset,
-    buyAsset,
-    sellAmount,
-    wallet,
-    chainId,
-    receiveAddress,
-    sellAssetAccountNumber
-  } = input
+  const { sellAsset, buyAsset, sellAmount, wallet, chainId, receiveAddress } = input
 
   if (!wallet)
     throw new SwapError('[getThorTradeQuote] - wallet is required', {
@@ -83,8 +75,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       buyAsset,
       sellAsset,
       minimum,
-      receiveAddress,
-      sellAssetAccountNumber
+      receiveAddress
     }
 
     switch (chainId) {

--- a/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
@@ -20,7 +20,7 @@ export const thorTradeApprovalNeeded = async ({
   input: ApprovalNeededInput<KnownChainIds.EthereumMainnet>
 }): Promise<ApprovalNeededOutput> => {
   try {
-    const { quote, wallet } = input
+    const { quote } = input
     const { sellAsset } = quote
     const { adapterManager, web3 } = deps
 
@@ -34,8 +34,6 @@ export const thorTradeApprovalNeeded = async ({
       return { approvalNeeded: false }
     }
 
-    const accountNumber = quote.sellAssetAccountNumber
-
     const adapter = adapterManager.get(sellAsset.chainId)
 
     if (!adapter)
@@ -46,9 +44,6 @@ export const thorTradeApprovalNeeded = async ({
           details: { chainId: sellAsset.chainId }
         }
       )
-
-    const bip44Params = adapter.buildBIP44Params({ accountNumber })
-    const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
 
     if (!quote.allowanceContract) {
       throw new SwapError('[thorTradeApprovalNeeded] - allowanceTarget is required', {
@@ -62,7 +57,7 @@ export const thorTradeApprovalNeeded = async ({
       erc20AllowanceAbi,
       sellAssetErc20Address,
       spenderAddress: quote.allowanceContract,
-      ownerAddress: receiveAddress
+      ownerAddress: quote.receiveAddress
     })
     const allowanceOnChain = bnOrZero(allowanceResult)
 

--- a/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
@@ -17,7 +17,7 @@ export const thorTradeApproveInfinite = async ({
 }): Promise<string> => {
   try {
     const { adapterManager, web3 } = deps
-    const { quote, wallet } = input
+    const { quote, wallet, bip44Params } = input
 
     const approvalQuote = {
       ...quote,
@@ -52,7 +52,8 @@ export const thorTradeApproveInfinite = async ({
       wallet,
       adapter,
       erc20Abi,
-      web3
+      web3,
+      bip44Params
     })
 
     return allowanceGrantRequired

--- a/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveinfinite.test.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveinfinite.test.ts
@@ -15,6 +15,12 @@ describe('thorTradeApproveInfinite', () => {
   const input = { wallet, quote }
 
   it('should return a broadcastedTxId', async () => {
-    expect(await thorTradeApproveInfinite({ deps, input })).toEqual('grantAllowanceTxId')
+    expect(
+      await thorTradeApproveInfinite({
+        deps,
+        input,
+        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+      })
+    ).toEqual('grantAllowanceTxId')
   })
 })

--- a/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveinfinite.test.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveinfinite.test.ts
@@ -12,14 +12,13 @@ describe('thorTradeApproveInfinite', () => {
   const deps = setupThorswapDeps()
   const { tradeQuote: quote } = setupQuote()
   const wallet = <HDWallet>{}
-  const input = { wallet, quote }
+  const input = { wallet, quote, bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 } }
 
   it('should return a broadcastedTxId', async () => {
     expect(
       await thorTradeApproveInfinite({
         deps,
-        input,
-        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+        input
       })
     ).toEqual('grantAllowanceTxId')
   })

--- a/packages/swapper/src/swappers/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/utils/helpers/helpers.test.ts
@@ -136,9 +136,16 @@ describe('utils', () => {
       }))
       ;(adapter.buildSendTransaction as jest.Mock).mockResolvedValueOnce({ txToSign: {} })
       ;(adapter.broadcastTransaction as jest.Mock).mockResolvedValueOnce('broadcastedTx')
-      expect(await grantAllowance({ quote, wallet, adapter, erc20Abi, web3 })).toEqual(
-        'broadcastedTx'
-      )
+      expect(
+        await grantAllowance({
+          quote,
+          wallet,
+          adapter,
+          erc20Abi,
+          web3,
+          bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+        })
+      ).toEqual('broadcastedTx')
     })
   })
 

--- a/packages/swapper/src/swappers/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/utils/helpers/helpers.ts
@@ -118,7 +118,7 @@ export const grantAllowance = async <T extends EvmSupportedChainIds>({
       .approve(quote.allowanceContract, quote.sellAmount)
       .encodeABI()
 
-    const accountNumber = quote.sellAssetAccountNumber
+    const accountNumber = 0 // TODO
     const bip44Params = adapter.buildBIP44Params({ accountNumber })
 
     const { txToSign } = await adapter.buildSendTransaction({

--- a/packages/swapper/src/swappers/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/utils/helpers/helpers.ts
@@ -1,6 +1,7 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { BIP44Params } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
 import { AbiItem, numberToHex } from 'web3-utils'
@@ -46,6 +47,7 @@ type GrantAllowanceArgs<T extends EvmSupportedChainIds> = {
   adapter: EvmSupportedChainAdapters
   erc20Abi: AbiItem[]
   web3: Web3
+  bip44Params: BIP44Params
 }
 
 export const getERC20Allowance = async ({
@@ -108,7 +110,8 @@ export const grantAllowance = async <T extends EvmSupportedChainIds>({
   wallet,
   adapter,
   erc20Abi,
-  web3
+  web3,
+  bip44Params
 }: GrantAllowanceArgs<T>): Promise<string> => {
   try {
     const { assetReference: sellAssetErc20Address } = fromAssetId(quote.sellAsset.assetId)
@@ -117,9 +120,6 @@ export const grantAllowance = async <T extends EvmSupportedChainIds>({
     const approveTx = erc20Contract.methods
       .approve(quote.allowanceContract, quote.sellAmount)
       .encodeABI()
-
-    const accountNumber = 0 // TODO
-    const bip44Params = adapter.buildBIP44Params({ accountNumber })
 
     const { txToSign } = await adapter.buildSendTransaction({
       wallet,

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -1,6 +1,6 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 
 import { BuildTradeInput, GetTradeQuoteInput, TradeQuote } from '../../../api'
 import { FOX, WETH } from './assets'
@@ -14,7 +14,6 @@ export const setupQuote = () => {
     sellAsset,
     buyAsset,
     allowanceContract: 'allowanceContractAddress',
-    sellAssetAccountNumber: 0,
     minimum: '0',
     maximum: '999999999999',
     feeData: { fee: '0', tradeFee: '0', chainSpecific: {} },
@@ -23,15 +22,16 @@ export const setupQuote = () => {
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   }
 
+  const bip44Params: BIP44Params = { purpose: 44, coinType: 60, accountNumber: 0 }
   const quoteInput: GetTradeQuoteInput = {
     chainId: KnownChainIds.EthereumMainnet,
     sellAmount: '1000000000000000000',
     sellAsset,
     buyAsset,
-    sellAssetAccountNumber: 0,
     sendMax: false,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-    wallet: {} as HDWallet
+    wallet: {} as HDWallet,
+    bip44Params
   }
   return { quoteInput, tradeQuote, buyAsset, sellAsset }
 }
@@ -39,15 +39,16 @@ export const setupQuote = () => {
 export const setupBuildTrade = () => {
   const sellAsset: Asset = { ...FOX }
   const buyAsset: Asset = { ...WETH }
+  const bip44Params: BIP44Params = { purpose: 44, coinType: 60, accountNumber: 0 }
   const buildTradeInput: BuildTradeInput = {
     chainId: KnownChainIds.EthereumMainnet,
     sellAmount: '1000000000000000000',
     buyAsset,
     sendMax: false,
-    sellAssetAccountNumber: 0,
     sellAsset,
     wallet: <HDWallet>{},
-    receiveAddress: ''
+    receiveAddress: '',
+    bip44Params
   }
   return { buildTradeInput, buyAsset, sellAsset }
 }

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -19,7 +19,8 @@ export const setupQuote = () => {
     maximum: '999999999999',
     feeData: { fee: '0', tradeFee: '0', chainSpecific: {} },
     rate: '1',
-    sources: []
+    sources: [],
+    receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   }
 
   const quoteInput: GetTradeQuoteInput = {
@@ -44,7 +45,6 @@ export const setupBuildTrade = () => {
     buyAsset,
     sendMax: false,
     sellAssetAccountNumber: 0,
-    buyAssetAccountNumber: 0,
     sellAsset,
     wallet: <HDWallet>{},
     receiveAddress: ''

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -72,7 +72,10 @@ describe('ZrxSwapper', () => {
   it('calls ZrxExecuteTrade on swapper.executeTrade', async () => {
     const { executeTradeInput } = setupExecuteTrade()
     const swapper = new ZrxSwapper(zrxEthereumSwapperDeps)
-    const args = { trade: executeTradeInput, wallet }
+    const args = {
+      trade: executeTradeInput,
+      wallet
+    }
     await swapper.executeTrade(args)
     expect(zrxExecuteTrade).toHaveBeenCalled()
   })
@@ -93,7 +96,11 @@ describe('ZrxSwapper', () => {
   it('calls zrxApproveInfinite on swapper.approveInfinite', async () => {
     const swapper = new ZrxSwapper(zrxEthereumSwapperDeps)
     const { tradeQuote } = setupQuote()
-    const args = { quote: tradeQuote, wallet }
+    const args = {
+      quote: tradeQuote,
+      wallet,
+      bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+    }
     await swapper.approveInfinite(args)
     expect(zrxApproveInfinite).toHaveBeenCalled()
   })

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -22,7 +22,7 @@ export async function getZrxTradeQuote<T extends EvmSupportedChainIds>(
   input: GetEvmTradeQuoteInput
 ): Promise<TradeQuote<T>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber } = input
+    const { sellAsset, buyAsset, sellAmount } = input
     if (buyAsset.chainId !== input.chainId || sellAsset.chainId !== input.chainId) {
       throw new SwapError(
         '[getZrxTradeQuote] - Both assets need to be on the same supported EVM chain to use Zrx',
@@ -111,8 +111,7 @@ export async function getZrxTradeQuote<T extends EvmSupportedChainIds>(
       sources: sources?.filter((s: SwapSource) => parseFloat(s.proportion) > 0) || DEFAULT_SOURCE,
       allowanceContract: allowanceTarget,
       buyAsset,
-      sellAsset,
-      sellAssetAccountNumber
+      sellAsset
     } as TradeQuote<T>
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
@@ -35,7 +35,6 @@ export const setupExecuteTrade = () => {
     sellAsset,
     sendMax: false,
     sellAssetAccountNumber: 0,
-    buyAssetAccountNumber: 0,
     txData: '0x0',
     depositAddress: '0x0',
     receiveAddress: '0x0',

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
@@ -39,7 +39,8 @@ export const setupExecuteTrade = () => {
     receiveAddress: '0x0',
     feeData: { fee: '0', chainSpecific: {}, tradeFee: '0' },
     rate: '0',
-    sources: []
+    sources: [],
+    bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
   }
   return { executeTradeInput, buyAsset, sellAsset }
 }

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
@@ -34,7 +34,6 @@ export const setupExecuteTrade = () => {
     buyAsset,
     sellAsset,
     sendMax: false,
-    sellAssetAccountNumber: 0,
     txData: '0x0',
     depositAddress: '0x0',
     receiveAddress: '0x0',

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
@@ -33,7 +33,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
       return { approvalNeeded: false }
     }
 
-    const accountNumber = quote.sellAssetAccountNumber
+    const accountNumber = 0 // TODO
 
     const bip44Params = adapter.buildBIP44Params({ accountNumber })
     const receiveAddress = await adapter.getAddress({ wallet, bip44Params })

--- a/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.test.ts
@@ -46,6 +46,12 @@ describe('zrxApproveInfinite', () => {
     const quote = { ...tradeQuote }
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
 
-    expect(await zrxApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
+    expect(
+      await zrxApproveInfinite(deps, {
+        quote,
+        wallet,
+        bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
+      })
+    ).toEqual('grantAllowanceTxId')
   })
 })

--- a/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApproveInfinite/zrxApproveInfinite.ts
@@ -7,7 +7,7 @@ import { MAX_ALLOWANCE } from '../utils/constants'
 
 export async function zrxApproveInfinite<T extends EvmSupportedChainIds>(
   { adapter, web3 }: ZrxSwapperDeps,
-  { quote, wallet }: ApproveInfiniteInput<T>
+  { quote, wallet, bip44Params }: ApproveInfiniteInput<T>
 ) {
   try {
     const approvalQuote = {
@@ -28,7 +28,8 @@ export async function zrxApproveInfinite<T extends EvmSupportedChainIds>(
       wallet,
       adapter,
       erc20Abi,
-      web3
+      web3,
+      bip44Params
     })
 
     return allowanceGrantRequired

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -73,7 +73,6 @@ describe('zrxBuildTrade', () => {
     buyAsset,
     sellAmount: '1000000000000000000',
     sellAssetAccountNumber: 0,
-    buyAssetAccountNumber: 0,
     wallet,
     receiveAddress: ''
   }

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -73,7 +73,8 @@ describe('zrxBuildTrade', () => {
     buyAsset,
     sellAmount: '1000000000000000000',
     wallet,
-    receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+    receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
   }
 
   const buildTradeResponse = {

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -74,7 +74,7 @@ describe('zrxBuildTrade', () => {
     sellAmount: '1000000000000000000',
     sellAssetAccountNumber: 0,
     wallet,
-    receiveAddress: ''
+    receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   }
 
   const buildTradeResponse = {
@@ -83,7 +83,6 @@ describe('zrxBuildTrade', () => {
     buyAmount: '',
     depositAddress: quoteResponse.to,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-    sellAssetAccountNumber: 0,
     txData: quoteResponse.data,
     rate: quoteResponse.price,
     feeData: {

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -72,7 +72,6 @@ describe('zrxBuildTrade', () => {
     sellAsset,
     buyAsset,
     sellAmount: '1000000000000000000',
-    sellAssetAccountNumber: 0,
     wallet,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
   }

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -23,15 +23,7 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
   { adapter, web3 }: ZrxSwapperDeps,
   input: BuildTradeInput
 ): Promise<ZrxTrade<T>> {
-  const {
-    sellAsset,
-    buyAsset,
-    sellAmount,
-    slippage,
-    sellAssetAccountNumber,
-    buyAssetAccountNumber,
-    wallet
-  } = input
+  const { sellAsset, buyAsset, sellAmount, slippage, receiveAddress } = input
   try {
     const { assetReference: buyAssetErc20Address, assetNamespace: buyAssetNamespace } = fromAssetId(
       buyAsset.assetId
@@ -49,9 +41,6 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
         details: { chainId: sellAsset.chainId }
       })
     }
-
-    const bip44Params = adapter.buildBIP44Params({ accountNumber: Number(buyAssetAccountNumber) })
-    const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
 
     const slippagePercentage = slippage ? bnOrZero(slippage).div(100).toString() : DEFAULT_SLIPPAGE
 
@@ -104,7 +93,6 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
     const trade = {
       sellAsset,
       buyAsset,
-      sellAssetAccountNumber,
       receiveAddress,
       rate: data.price,
       depositAddress: data.to,

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -37,7 +37,8 @@ describe('ZrxExecuteTrade', () => {
       chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' },
       tradeFee: '0'
     },
-    sources: []
+    sources: [],
+    bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 }
   }
 
   const execTradeInput: ZrxExecuteTradeInput<KnownChainIds.EthereumMainnet> = {

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -30,7 +30,6 @@ describe('ZrxExecuteTrade', () => {
     buyAmount: '',
     depositAddress: '0x123',
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-    sellAssetAccountNumber: 0,
     txData: '0x123',
     rate: '1',
     feeData: {

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
@@ -14,7 +14,7 @@ export async function zrxExecuteTrade<T extends EvmSupportedChainIds>(
     // value is 0 for erc20s
     const value = isNativeEvmAsset(sellAsset.assetId) ? trade.sellAmount : '0'
     const bip44Params = adapter.buildBIP44Params({
-      accountNumber: trade.sellAssetAccountNumber
+      accountNumber: 0 // TODO
     })
 
     const buildTxResponse = await adapter.buildSendTransaction({


### PR DESCRIPTION
- Remove sellAssetAccountNumber and buyAssetAccountNumber from swapper interface.
- Added bip44 params to be required for all quotes & trades

Corresponding web PR:

https://github.com/shapeshift/web/pull/2256