### PR TITLE
feat: replace '/api/v1/market' call with '/api/v1/quote' in getUsdRate

### DIFF
--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -11,7 +11,7 @@ import { ETH, FOX, WBTC, WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowTrade } from '../types'
 import { cowService } from '../utils/cowService'
-import { CowSwapQuoteApiInput } from '../utils/helpers/helpers'
+import { CowSwapSellQuoteApiInput } from '../utils/helpers/helpers'
 import { cowBuildTrade } from './cowBuildTrade'
 
 jest.mock('@shapeshiftoss/chain-adapters')
@@ -73,7 +73,7 @@ const feeData: FeeDataEstimate<KnownChainIds.EthereumMainnet> = {
   }
 }
 
-const expectedApiInputWethToFox: CowSwapQuoteApiInput = {
+const expectedApiInputWethToFox: CowSwapSellQuoteApiInput = {
   appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
   buyToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
   from: 'address11',
@@ -85,7 +85,7 @@ const expectedApiInputWethToFox: CowSwapQuoteApiInput = {
   validTo: 1656797787
 }
 
-const expectedApiInputWbtcToWeth: CowSwapQuoteApiInput = {
+const expectedApiInputWbtcToWeth: CowSwapSellQuoteApiInput = {
   appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
   buyToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   from: 'address11',

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -19,7 +19,7 @@ const DEPS = {
 describe('getCowSwapMinMax', () => {
   it('returns minimum and maximum', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, WETH)
-    expect(minMax.minimum).toBe('40')
+    expect(minMax.minimum).toBe('80')
     expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
   })
 

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -8,7 +8,7 @@ import { GetTradeQuoteInput, TradeQuote } from '../../../api'
 import { ETH, FOX, WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
 import { cowService } from '../utils/cowService'
-import { CowSwapQuoteApiInput } from '../utils/helpers/helpers'
+import { CowSwapSellQuoteApiInput } from '../utils/helpers/helpers'
 import { getCowSwapTradeQuote } from './getCowSwapTradeQuote'
 
 jest.mock('@shapeshiftoss/chain-adapters')
@@ -63,7 +63,7 @@ const feeData: FeeDataEstimate<KnownChainIds.EthereumMainnet> = {
   }
 }
 
-const expectedApiInputWethToFox: CowSwapQuoteApiInput = {
+const expectedApiInputWethToFox: CowSwapSellQuoteApiInput = {
   appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
   buyToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
   from: '0x0000000000000000000000000000000000000000',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -77,7 +77,7 @@ const expectedApiInputWethToFox: CowSwapSellQuoteApiInput = {
 
 const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
-  minimum: '0.00810596500550730736',
+  minimum: '0.01621193001101461472',
   maximum: '100000000000000000000000000',
   feeData: {
     fee: '0',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/constants'
 import { cowService } from '../utils/cowService'
 import {
-  CowSwapQuoteApiInput,
+  CowSwapSellQuoteApiInput,
   getNowPlusThirtyMinutesTimestamp,
   getUsdRate
 } from '../utils/helpers/helpers'
@@ -52,7 +52,7 @@ export async function getCowSwapTradeQuote(
       bnOrZero(sellAmount).lt(minQuoteSellAmount) ? minQuoteSellAmount : sellAmount
     )
 
-    const apiInput: CowSwapQuoteApiInput = {
+    const apiInput: CowSwapSellQuoteApiInput = {
       sellToken: sellAssetErc20Address,
       buyToken: buyAssetErc20Address,
       receiver: DEFAULT_ADDRESS,

--- a/packages/swapper/src/swappers/cow/types.ts
+++ b/packages/swapper/src/swappers/cow/types.ts
@@ -2,11 +2,6 @@ import { ChainId } from '@shapeshiftoss/caip'
 
 import { Trade } from '../../api'
 
-export type CowSwapPriceResponse = {
-  amount: string
-  token: string
-}
-
 export type CowSwapQuoteResponse = {
   quote: {
     sellToken: string

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -11,6 +11,7 @@ export const COW_SWAP_SETTLEMENT_ADDRESS = '0x9008D19f58AAbD9eD0D60971565AA85105
 export const WETH_ASSET_ID = 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 export const ORDER_KIND_SELL = 'sell'
+export const ORDER_KIND_BUY = 'buy'
 export const SIGNING_SCHEME = 'ethsign'
 export const ERC20_TOKEN_BALANCE = 'erc20'
 export const ORDER_STATUS_FULFILLED = 'fulfilled'

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -2,7 +2,7 @@ import { AddressZero, HashZero } from '@ethersproject/constants'
 
 export const MAX_ALLOWANCE = '100000000000000000000000000'
 export const MAX_COWSWAP_TRADE = '100000000000000000000000000'
-export const MIN_COWSWAP_VALUE_USD = 10
+export const MIN_COWSWAP_VALUE_USD = 20
 export const DEFAULT_SOURCE = [{ name: 'CowSwap', proportion: '1' }]
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = HashZero

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
@@ -3,6 +3,7 @@ import Web3 from 'web3'
 
 import { BTC, ETH, FOX, USDC, WBTC } from '../../../utils/test-data/assets'
 import { CowSwapperDeps } from '../../CowSwapper'
+import { DEFAULT_ADDRESS, DEFAULT_APP_DATA, ORDER_KIND_BUY } from '../constants'
 import { cowService } from '../cowService'
 import {
   CowSwapOrder,
@@ -14,62 +15,80 @@ import {
 
 jest.mock('../cowService')
 
+const expectedQuoteInputForUsdRate = {
+  receiver: DEFAULT_ADDRESS,
+  appData: DEFAULT_APP_DATA,
+  partiallyFillable: false,
+  from: DEFAULT_ADDRESS,
+  kind: ORDER_KIND_BUY,
+  buyAmountAfterFee: '1000000000'
+}
+
 describe('utils', () => {
   const cowSwapperDeps: CowSwapperDeps = {
-    apiUrl: 'https://api.cow.fi/mainnet/api/',
+    apiUrl: 'https://api.cow.fi/mainnet/api',
     adapter: {} as ethereum.ChainAdapter,
     web3: {} as Web3
   }
 
   describe('getUsdRate', () => {
     it('gets the usd rate of FOX', async () => {
-      ;(cowService.get as jest.Mock<unknown>).mockReturnValue(
+      ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
         Promise.resolve({
           data: {
-            amount: '7702130994619175777719',
-            token: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+            quote: {
+              sellAmount: '7702130994619175777719'
+            }
           }
         })
       )
+
       const rate = await getUsdRate(cowSwapperDeps, FOX)
       expect(parseFloat(rate)).toBeCloseTo(0.129834198, 9)
-      expect(cowService.get).toHaveBeenCalledWith(
-        'https://api.cow.fi/mainnet/api//v1/markets/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-0xc770eefad204b5180df6a14ee197d99d808ee52d/buy/1000000000'
-      )
+      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
+        ...expectedQuoteInputForUsdRate,
+        sellToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      }))
     })
 
     it('gets the usd rate of WBTC', async () => {
-      ;(cowService.get as jest.Mock<unknown>).mockReturnValue(
+      ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
         Promise.resolve({
           data: {
-            amount: '3334763',
-            token: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+            quote: {
+              sellAmount: '3334763'
+            }
           }
         })
       )
       const rate = await getUsdRate(cowSwapperDeps, WBTC)
       expect(parseFloat(rate)).toBeCloseTo(29987.13851629, 9)
-      expect(cowService.get).toHaveBeenCalledWith(
-        'https://api.cow.fi/mainnet/api//v1/markets/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/buy/1000000000'
-      )
+      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
+        ...expectedQuoteInputForUsdRate,
+        sellToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      }))
     })
 
     it('should get the rate of WETH when called with ETH', async () => {
-      ;(cowService.get as jest.Mock<unknown>).mockReturnValue(
+      ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
         Promise.resolve({
           data: {
-            amount: '913757780947770826',
-            token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+            quote: {
+              sellAmount: '913757780947770826'
+            }
           }
         })
       )
 
       const rate = await getUsdRate(cowSwapperDeps, ETH)
       expect(parseFloat(rate)).toBeCloseTo(1094.381925769, 9)
-
-      expect(cowService.get).toHaveBeenCalledWith(
-        'https://api.cow.fi/mainnet/api//v1/markets/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/buy/1000000000'
-      )
+      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
+        ...expectedQuoteInputForUsdRate,
+        sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      }))
     })
 
     it('gets the usd rate of USDC without calling api', async () => {
@@ -85,16 +104,17 @@ describe('utils', () => {
     })
 
     it('should fail when api is returning 0 as token amount', async () => {
-      ;(cowService.get as jest.Mock<unknown>).mockReturnValue(
+      ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
         Promise.resolve({
           data: {
-            amount: '0',
-            token: '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+            quote: {
+              sellAmount: '0'
+            }
           }
         })
       )
       await expect(getUsdRate(cowSwapperDeps, FOX)).rejects.toThrow(
-        '[getUsdRate] - Failed to get token amount'
+        '[getUsdRate] - Failed to get sell token amount'
       )
     })
 

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.test.ts
@@ -45,11 +45,14 @@ describe('utils', () => {
 
       const rate = await getUsdRate(cowSwapperDeps, FOX)
       expect(parseFloat(rate)).toBeCloseTo(0.129834198, 9)
-      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
-        ...expectedQuoteInputForUsdRate,
-        sellToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-      }))
+      expect(cowService.post).toHaveBeenCalledWith(
+        'https://api.cow.fi/mainnet/api/v1/quote/',
+        expect.objectContaining({
+          ...expectedQuoteInputForUsdRate,
+          sellToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+          buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+        })
+      )
     })
 
     it('gets the usd rate of WBTC', async () => {
@@ -64,11 +67,14 @@ describe('utils', () => {
       )
       const rate = await getUsdRate(cowSwapperDeps, WBTC)
       expect(parseFloat(rate)).toBeCloseTo(29987.13851629, 9)
-      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
-        ...expectedQuoteInputForUsdRate,
-        sellToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-      }))
+      expect(cowService.post).toHaveBeenCalledWith(
+        'https://api.cow.fi/mainnet/api/v1/quote/',
+        expect.objectContaining({
+          ...expectedQuoteInputForUsdRate,
+          sellToken: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+          buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+        })
+      )
     })
 
     it('should get the rate of WETH when called with ETH', async () => {
@@ -84,11 +90,14 @@ describe('utils', () => {
 
       const rate = await getUsdRate(cowSwapperDeps, ETH)
       expect(parseFloat(rate)).toBeCloseTo(1094.381925769, 9)
-      expect(cowService.post).toHaveBeenCalledWith('https://api.cow.fi/mainnet/api/v1/quote/', expect.objectContaining({
-        ...expectedQuoteInputForUsdRate,
-        sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-        buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-      }))
+      expect(cowService.post).toHaveBeenCalledWith(
+        'https://api.cow.fi/mainnet/api/v1/quote/',
+        expect.objectContaining({
+          ...expectedQuoteInputForUsdRate,
+          sellToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          buyToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+        })
+      )
     })
 
     it('gets the usd rate of USDC without calling api', async () => {


### PR DESCRIPTION
This changes the endpoint used in `getUsdRate` method, because the one currently used has been deprecated.
I tested it in web, checked rates there and performed a swap.
closes https://github.com/shapeshift/lib/issues/759

Steps to test : 

- Link with web locally
- Start swap with ERC20 tokens (not ETH)
- Verify rates are consistent with current market
- Perform swap