### PR TITLE
fix: don't return zero value fiat exchange rates

### DIFF
--- a/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
+++ b/packages/market-service/src/exchange-rates-host/exchange-rates-host.ts
@@ -100,7 +100,8 @@ export class ExchangeRateHostService implements FiatMarketService {
         Object.entries(data.rates).forEach(([formattedDate, ratesObject]) => {
           const date = dayjs(formattedDate, 'YYYY-MM-DD').startOf('day').valueOf()
           const price = bnOrZero(ratesObject[symbol]).toNumber()
-          acc.push({ date, price })
+          // skip zero prices (current day rate gets returned as zero)
+          price > 0 && acc.push({ date, price })
         })
         return acc
       }, [])


### PR DESCRIPTION
the upstream fiat exchange rate data source will return 0 for the current day for timezones with a
positive offset, e.g. australia

this filters out these invalid results

the client consuming this data will use the most recent rate rather than zero, fixing charts
