### PR TITLE
fix: prevent user from cow swapping with small sell amount

### DIFF
--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -114,6 +114,12 @@ export async function getCowSwapTradeQuote(
       .multipliedBy(bnOrZero(sellAssetUsdRate))
       .toString()
 
+    // If original sellAmount is < minQuoteSellAmount, we don't want to replace it with normalizedSellAmount
+    // The purpose of this was to get a quote from CowSwap even with small amounts
+    const quoteSellAmount = bnOrZero(sellAmount).lt(minQuoteSellAmount)
+      ? sellAmount
+      : normalizedSellAmount
+
     return {
       rate,
       minimum,
@@ -129,7 +135,7 @@ export async function getCowSwapTradeQuote(
         },
         tradeFee: tradeFeeFiat
       },
-      sellAmount: normalizedSellAmount,
+      sellAmount: quoteSellAmount,
       buyAmount: quote.buyAmount,
       sources: DEFAULT_SOURCE,
       allowanceContract: COW_SWAP_VAULT_RELAYER_ADDRESS,


### PR DESCRIPTION
This fixes an issue where user was still able to swap with an amount inferior to the minimum allowed amount for cowswap.
This issue was outlined by @gomesalexandre in this PR : https://github.com/shapeshift/lib/pull/916#pullrequestreview-1055963328

Steps to verify : 

- Launch web with local lib
- Try to perform a swap with a small amount > 0 for ERC-20 (not ETH)
- Notice the toast error, user is not able to proceed further in the swap

![trade](https://user-images.githubusercontent.com/5720927/181926399-099aa045-75e7-466d-91fa-1bbb8e0da70f.png)

