### PR TITLE
fix: enables ETH as buy asset for CowSwap

### DIFF
--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -120,19 +120,19 @@ describe('CowSwapper', () => {
           assetIds: ASSET_IDS,
           sellAssetId: WETH.assetId
         })
-      ).toEqual([WBTC.assetId, FOX.assetId])
+      ).toEqual([ETH.assetId, WBTC.assetId, FOX.assetId])
       expect(
         swapper.filterBuyAssetsBySellAssetId({
           assetIds: ASSET_IDS,
           sellAssetId: WBTC.assetId
         })
-      ).toEqual([WETH.assetId, FOX.assetId])
+      ).toEqual([ETH.assetId, WETH.assetId, FOX.assetId])
       expect(
         swapper.filterBuyAssetsBySellAssetId({
           assetIds: ASSET_IDS,
           sellAssetId: FOX.assetId
         })
-      ).toEqual([WBTC.assetId, WETH.assetId])
+      ).toEqual([ETH.assetId, WBTC.assetId, WETH.assetId])
     })
 
     it('returns array filtered out of unsupported tokens when called with a sellable sellAssetId', () => {

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -28,10 +28,6 @@ import { CowTrade } from './types'
 import { COWSWAP_UNSUPPORTED_ASSETS } from './utils/blacklist'
 import { getUsdRate } from './utils/helpers/helpers'
 
-/**
- * CowSwap only supports ERC-20 swaps, hence ETH is not supported
- * In order to get rates correctly, we need WETH asset to be passed as feeAsset
- */
 export type CowSwapperDeps = {
   apiUrl: string
   adapter: ethereum.ChainAdapter
@@ -90,9 +86,7 @@ export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
 
     return assetIds.filter(
       (id) =>
-        id !== sellAssetId &&
-        id.startsWith('eip155:1/erc20') &&
-        !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
+        id !== sellAssetId && id.startsWith('eip155:1') && !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
     )
   }
 

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -1,5 +1,5 @@
 import { Asset } from '@shapeshiftoss/asset-service'
-import { AssetId } from '@shapeshiftoss/caip'
+import { AssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { ethereum } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
@@ -79,20 +79,22 @@ export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
     const { assetIds = [], sellAssetId } = args
     if (
-      !sellAssetId?.startsWith('eip155:1/erc20') ||
+      fromAssetId(sellAssetId).assetNamespace !== 'erc20' ||
       COWSWAP_UNSUPPORTED_ASSETS.includes(sellAssetId)
     )
       return []
 
     return assetIds.filter(
       (id) =>
-        id !== sellAssetId && id.startsWith('eip155:1') && !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
+        id !== sellAssetId &&
+        fromAssetId(id).chainId === KnownChainIds.EthereumMainnet &&
+        !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
     )
   }
 
   filterAssetIdsBySellable(assetIds: AssetId[]): AssetId[] {
     return assetIds.filter(
-      (id) => id.startsWith('eip155:1/erc20') && !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
+      (id) => fromAssetId(id).assetNamespace === 'erc20' && !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
     )
   }
 

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -21,8 +21,12 @@ jest.mock('../utils/helpers/helpers', () => {
     ...jest.requireActual('../utils/helpers/helpers'),
     getNowPlusThirtyMinutesTimestamp: () => 1656797787,
     getUsdRate: (_args: CowSwapperDeps, input: Asset) => {
-      if (input.assetId === WETH.assetId) {
+      if (input.assetId === WETH.assetId || input.assetId === ETH.assetId) {
         return Promise.resolve('1233.65940923824103061992')
+      }
+
+      if (input.assetId === FOX.assetId) {
+        return Promise.resolve('0.0873')
       }
 
       return Promise.resolve('20978.38')
@@ -97,6 +101,18 @@ const expectedApiInputWbtcToWeth: CowSwapSellQuoteApiInput = {
   validTo: 1656797787
 }
 
+const expectedApiInputFoxToEth: CowSwapSellQuoteApiInput = {
+  appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  buyToken: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+  from: 'address11',
+  kind: 'sell',
+  partiallyFillable: false,
+  receiver: 'address11',
+  sellAmountBeforeFee: '1000000000000000000000',
+  sellToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+  validTo: 1656797787
+}
+
 const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
   feeData: {
@@ -140,9 +156,33 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   sellAmountWithoutFee: '99982762'
 }
 
-const defaultDeps: CowSwapperDeps = {
-  apiUrl: '',
-  adapter: {} as ethereum.ChainAdapter,
+const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
+  rate: '0.00004995640398295996',
+  feeData: {
+    fee: '0',
+    chainSpecific: {
+      estimatedGas: '100000',
+      gasPrice: '79036500000'
+    },
+    tradeFee: '5.3955565850972847808512'
+  },
+  sellAmount: '1000000000000000000000',
+  buyAmount: '46868859830863283',
+  sources: [{ name: 'CowSwap', proportion: '1' }],
+  buyAsset: ETH,
+  sellAsset: FOX,
+  sellAssetAccountNumber: 0,
+  receiveAddress: 'address11',
+  feeAmountInSellToken: '61804771879693983744',
+  sellAmountWithoutFee: '938195228120306016256'
+}
+
+const deps: CowSwapperDeps = {
+  apiUrl: 'https://api.cow.fi/mainnet/api',
+  adapter: {
+    getAddress: jest.fn(() => Promise.resolve('address11')),
+    getFeeData: jest.fn(() => Promise.resolve(feeData))
+  } as unknown as ethereum.ChainAdapter,
   web3: {} as Web3
 }
 
@@ -159,21 +199,12 @@ describe('cowBuildTrade', () => {
       receiveAddress: ''
     }
 
-    await expect(cowBuildTrade(defaultDeps, tradeInput)).rejects.toThrow(
-      '[cowBuildTrade] - Both assets need to be ERC-20 to use CowSwap'
+    await expect(cowBuildTrade(deps, tradeInput)).rejects.toThrow(
+      '[cowBuildTrade] - Sell asset needs to be ERC-20 to use CowSwap'
     )
   })
 
   it('should call cowService with correct parameters, handle the fees and return the correct trade when selling WETH', async () => {
-    const deps: CowSwapperDeps = {
-      apiUrl: 'https://api.cow.fi/mainnet/api',
-      adapter: {
-        getAddress: jest.fn(() => Promise.resolve('address11')),
-        getFeeData: jest.fn(() => Promise.resolve(feeData))
-      } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3
-    }
-
     const tradeInput: BuildTradeInput = {
       chainId: KnownChainIds.EthereumMainnet,
       sellAsset: WETH,
@@ -211,15 +242,6 @@ describe('cowBuildTrade', () => {
   })
 
   it('should call cowService with correct parameters, handle the fees and return the correct trade when selling WBTC with allowance being required', async () => {
-    const deps: CowSwapperDeps = {
-      apiUrl: 'https://api.cow.fi/mainnet/api',
-      adapter: {
-        getAddress: jest.fn(() => Promise.resolve('address11')),
-        getFeeData: jest.fn(() => Promise.resolve(feeData))
-      } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3
-    }
-
     const tradeInput: BuildTradeInput = {
       chainId: KnownChainIds.EthereumMainnet,
       sellAsset: WBTC,
@@ -253,6 +275,43 @@ describe('cowBuildTrade', () => {
     expect(cowService.post).toHaveBeenCalledWith(
       'https://api.cow.fi/mainnet/api/v1/quote/',
       expectedApiInputWbtcToWeth
+    )
+  })
+
+  it('should call cowService with correct parameters, handle the fees and return the correct trade when buying ETH', async () => {
+    const tradeInput: BuildTradeInput = {
+      chainId: KnownChainIds.EthereumMainnet,
+      sellAsset: FOX,
+      buyAsset: ETH,
+      sellAmount: '1000000000000000000000',
+      sendMax: true,
+      sellAssetAccountNumber: 0,
+      wallet: <HDWallet>{},
+      receiveAddress: ''
+    }
+
+    ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
+      Promise.resolve({
+        data: {
+          quote: {
+            ...expectedApiInputFoxToEth,
+            sellAmountBeforeFee: undefined,
+            sellAmount: '938195228120306016256',
+            buyAmount: '46868859830863283',
+            feeAmount: '61804771879693983744',
+            sellTokenBalance: 'erc20',
+            buyTokenBalance: 'erc20'
+          }
+        }
+      })
+    )
+
+    const trade = await cowBuildTrade(deps, tradeInput)
+
+    expect(trade).toEqual(expectedTradeQuoteFoxToEth)
+    expect(cowService.post).toHaveBeenCalledWith(
+      'https://api.cow.fi/mainnet/api/v1/quote/',
+      expectedApiInputFoxToEth
     )
   })
 })

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -1,4 +1,4 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 
@@ -13,6 +13,7 @@ import {
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowSwapQuoteResponse, CowTrade } from '../types'
 import {
+  COW_SWAP_ETH_BUY_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   DEFAULT_APP_DATA,
   DEFAULT_SOURCE,
@@ -31,17 +32,26 @@ export async function cowBuildTrade(
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
       fromAssetId(sellAsset.assetId)
-    const { assetReference: buyAssetErc20Address, assetNamespace: buyAssetNamespace } = fromAssetId(
+    const { assetReference: buyAssetErc20Address, chainId: buyAssetChainId } = fromAssetId(
       buyAsset.assetId
     )
 
-    if (buyAssetNamespace !== 'erc20' || sellAssetNamespace !== 'erc20') {
-      throw new SwapError('[cowBuildTrade] - Both assets need to be ERC-20 to use CowSwap', {
+    if (sellAssetNamespace !== 'erc20') {
+      throw new SwapError('[cowBuildTrade] - Sell asset needs to be ERC-20 to use CowSwap', {
         code: SwapErrorTypes.UNSUPPORTED_PAIR,
-        details: { buyAssetNamespace, sellAssetNamespace }
+        details: { sellAssetNamespace }
       })
     }
 
+    if (buyAssetChainId !== KnownChainIds.EthereumMainnet) {
+      throw new SwapError('[cowBuildTrade] - Buy asset needs to be on ETH mainnet to use CowSwap', {
+        code: SwapErrorTypes.UNSUPPORTED_PAIR,
+        details: { buyAssetChainId }
+      })
+    }
+
+    const buyToken =
+      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
     const receiveAddress = await adapter.getAddress({ wallet })
     const normalizedSellAmount = normalizeAmount(sellAmount)
 
@@ -62,7 +72,7 @@ export async function cowBuildTrade(
     const quoteResponse: AxiosResponse<CowSwapQuoteResponse> =
       await cowService.post<CowSwapQuoteResponse>(`${deps.apiUrl}/v1/quote/`, {
         sellToken: sellAssetErc20Address,
-        buyToken: buyAssetErc20Address,
+        buyToken,
         receiver: receiveAddress,
         validTo: getNowPlusThirtyMinutesTimestamp(),
         appData: DEFAULT_APP_DATA,

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -13,7 +13,7 @@ import {
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowSwapQuoteResponse, CowTrade } from '../types'
 import {
-  COW_SWAP_ETH_BUY_ADDRESS,
+  COW_SWAP_ETH_MARKER_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   DEFAULT_APP_DATA,
   DEFAULT_SOURCE,
@@ -51,7 +51,7 @@ export async function cowBuildTrade(
     }
 
     const buyToken =
-      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
+      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_MARKER_ADDRESS
     const receiveAddress = await adapter.getAddress({ wallet })
     const normalizedSellAmount = normalizeAmount(sellAmount)
 

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
@@ -9,7 +9,7 @@ import { ExecuteTradeInput, SwapError, SwapErrorTypes, TradeResult } from '../..
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowTrade } from '../types'
 import {
-  COW_SWAP_ETH_BUY_ADDRESS,
+  COW_SWAP_ETH_MARKER_ADDRESS,
   COW_SWAP_SETTLEMENT_ADDRESS,
   DEFAULT_APP_DATA,
   ERC20_TOKEN_BALANCE,
@@ -52,7 +52,8 @@ export async function cowExecuteTrade(
     })
   }
 
-  const buyToken = buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
+  const buyToken =
+    buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_MARKER_ADDRESS
 
   try {
     const orderToSign: CowSwapOrder = {

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
@@ -1,4 +1,4 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { ethereum, SignMessageInput, toRootDerivationPath } from '@shapeshiftoss/chain-adapters'
 import { bip32ToAddressNList, ETHSignMessage } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
@@ -9,6 +9,7 @@ import { ExecuteTradeInput, SwapError, SwapErrorTypes, TradeResult } from '../..
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowTrade } from '../types'
 import {
+  COW_SWAP_ETH_BUY_ADDRESS,
   COW_SWAP_SETTLEMENT_ADDRESS,
   DEFAULT_APP_DATA,
   ERC20_TOKEN_BALANCE,
@@ -33,21 +34,30 @@ export async function cowExecuteTrade(
   const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } = fromAssetId(
     sellAsset.assetId
   )
-  const { assetReference: buyAssetErc20Address, assetNamespace: buyAssetNamespace } = fromAssetId(
+  const { assetReference: buyAssetErc20Address, chainId: buyAssetChainId } = fromAssetId(
     buyAsset.assetId
   )
 
-  if (buyAssetNamespace !== 'erc20' || sellAssetNamespace !== 'erc20') {
-    throw new SwapError('[cowExecuteTrade] - Both assets need to be ERC-20 to use CowSwap', {
+  if (sellAssetNamespace !== 'erc20') {
+    throw new SwapError('[cowExecuteTrade] - Sell asset needs to be ERC-20 to use CowSwap', {
       code: SwapErrorTypes.UNSUPPORTED_PAIR,
-      details: { buyAssetNamespace, sellAssetNamespace }
+      details: { sellAssetNamespace }
     })
   }
+
+  if (buyAssetChainId !== KnownChainIds.EthereumMainnet) {
+    throw new SwapError('[cowExecuteTrade] - Buy asset needs to be on ETH mainnet to use CowSwap', {
+      code: SwapErrorTypes.UNSUPPORTED_PAIR,
+      details: { buyAssetChainId }
+    })
+  }
+
+  const buyToken = buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
 
   try {
     const orderToSign: CowSwapOrder = {
       sellToken: sellAssetErc20Address,
-      buyToken: buyAssetErc20Address,
+      buyToken,
       sellAmount: sellAmountWithoutFee,
       buyAmount: trade.buyAmount,
       validTo: getNowPlusThirtyMinutesTimestamp(),

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -23,8 +23,14 @@ describe('getCowSwapMinMax', () => {
     expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
   })
 
-  it('fails on non erc 20 assets', async () => {
-    await expect(getCowSwapMinMax(DEPS, BTC, WETH)).rejects.toThrow('[getCowSwapMinMax]')
-    await expect(getCowSwapMinMax(DEPS, FOX, ETH)).rejects.toThrow('[getCowSwapMinMax]')
+  it('returns minimum and maximum for ETH as buy asset', async () => {
+    const minMax = await getCowSwapMinMax(DEPS, FOX, ETH)
+    expect(minMax.minimum).toBe('80')
+    expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
+  })
+
+  it('fails on non erc 20 sell assets and non ETH-mainnet buy assets', async () => {
+    await expect(getCowSwapMinMax(DEPS, ETH, WETH)).rejects.toThrow('[getCowSwapMinMax]')
+    await expect(getCowSwapMinMax(DEPS, FOX, BTC)).rejects.toThrow('[getCowSwapMinMax]')
   })
 })

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -1,4 +1,6 @@
 import { Asset } from '@shapeshiftoss/asset-service'
+import { fromAssetId } from '@shapeshiftoss/caip'
+import { KnownChainIds } from '@shapeshiftoss/types'
 
 import { MinMaxOutput, SwapError, SwapErrorTypes } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
@@ -12,10 +14,10 @@ export const getCowSwapMinMax = async (
   buyAsset: Asset
 ): Promise<MinMaxOutput> => {
   try {
-    if (
-      !sellAsset.assetId.startsWith('eip155:1/erc20') ||
-      !buyAsset.assetId.startsWith('eip155:1/erc20')
-    ) {
+    const { assetNamespace: sellAssetNamespace } = fromAssetId(sellAsset.assetId)
+    const { chainId: buyAssetChainId } = fromAssetId(buyAsset.assetId)
+
+    if (sellAssetNamespace !== 'erc20' || buyAssetChainId !== KnownChainIds.EthereumMainnet) {
       throw new SwapError('[getCowSwapMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })
     }
 

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -17,8 +17,12 @@ jest.mock('../utils/helpers/helpers', () => {
   return {
     getNowPlusThirtyMinutesTimestamp: () => 1656797787,
     getUsdRate: (_args: CowSwapperDeps, input: Asset) => {
-      if (input.assetId === WETH.assetId) {
+      if (input.assetId === WETH.assetId || input.assetId === ETH.assetId) {
         return Promise.resolve('1233.65940923824103061992')
+      }
+
+      if (input.assetId === FOX.assetId) {
+        return Promise.resolve('0.0873')
       }
 
       return Promise.resolve('20978.38')
@@ -75,6 +79,18 @@ const expectedApiInputWethToFox: CowSwapSellQuoteApiInput = {
   validTo: 1656797787
 }
 
+const expectedApiInputFoxToEth: CowSwapSellQuoteApiInput = {
+  appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  buyToken: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+  from: '0x0000000000000000000000000000000000000000',
+  kind: 'sell',
+  partiallyFillable: false,
+  receiver: '0x0000000000000000000000000000000000000000',
+  sellAmountBeforeFee: '1000000000000000000000',
+  sellToken: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+  validTo: 1656797787
+}
+
 const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
   minimum: '0.01621193001101461472',
@@ -97,9 +113,36 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   sellAssetAccountNumber: 0
 }
 
-const defaultDeps: CowSwapperDeps = {
-  apiUrl: '',
-  adapter: {} as ethereum.ChainAdapter,
+const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
+  rate: '0.00004995640398295996',
+  minimum: '229.09507445589919816724',
+  maximum: '100000000000000000000000000',
+  feeData: {
+    fee: '0',
+    chainSpecific: {
+      estimatedGas: '100000',
+      gasPrice: '79036500000',
+      approvalFee: '7903650000000000'
+    },
+    tradeFee: '5.3955565850972847808512'
+  },
+  sellAmount: '1000000000000000000000',
+  buyAmount: '46868859830863283',
+  sources: [{ name: 'CowSwap', proportion: '1' }],
+  allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
+  buyAsset: ETH,
+  sellAsset: FOX,
+  sellAssetAccountNumber: 0
+}
+
+const deps: CowSwapperDeps = {
+  apiUrl: 'https://api.cow.fi/mainnet/api',
+  adapter: {
+    getAddress: jest.fn(() => Promise.resolve('address11')),
+    getFeeData: jest.fn<Promise<FeeDataEstimate<KnownChainIds.EthereumMainnet>>, []>(() =>
+      Promise.resolve(feeData)
+    )
+  } as unknown as ethereum.ChainAdapter,
   web3: {} as Web3
 }
 
@@ -116,23 +159,12 @@ describe('getCowTradeQuote', () => {
       receiveAddress: ''
     }
 
-    await expect(getCowSwapTradeQuote(defaultDeps, input)).rejects.toThrow(
-      '[getCowSwapTradeQuote] - Both assets need to be ERC-20 to use CowSwap'
+    await expect(getCowSwapTradeQuote(deps, input)).rejects.toThrow(
+      '[getCowSwapTradeQuote] - Sell asset needs to be ERC-20 to use CowSwap'
     )
   })
 
   it('should call cowService with correct parameters, handle the fees and return the correct trade quote when selling WETH', async () => {
-    const deps: CowSwapperDeps = {
-      apiUrl: 'https://api.cow.fi/mainnet/api',
-      adapter: {
-        getAddress: jest.fn(() => Promise.resolve('address11')),
-        getFeeData: jest.fn<Promise<FeeDataEstimate<KnownChainIds.EthereumMainnet>>, []>(() =>
-          Promise.resolve(feeData)
-        )
-      } as unknown as ethereum.ChainAdapter,
-      web3: {} as Web3
-    }
-
     const input: GetTradeQuoteInput = {
       chainId: KnownChainIds.EthereumMainnet,
       sellAsset: WETH,
@@ -166,6 +198,43 @@ describe('getCowTradeQuote', () => {
     expect(cowService.post).toHaveBeenCalledWith(
       'https://api.cow.fi/mainnet/api/v1/quote/',
       expectedApiInputWethToFox
+    )
+  })
+
+  it('should call cowService with correct parameters, handle the fees and return the correct trade quote when buying ETH', async () => {
+    const input: GetTradeQuoteInput = {
+      chainId: KnownChainIds.EthereumMainnet,
+      sellAsset: FOX,
+      buyAsset: ETH,
+      sellAmount: '1000000000000000000000',
+      sendMax: true,
+      sellAssetAccountNumber: 0,
+      wallet: <HDWallet>{},
+      receiveAddress: ''
+    }
+
+    ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
+      Promise.resolve({
+        data: {
+          quote: {
+            ...expectedApiInputFoxToEth,
+            sellAmountBeforeFee: undefined,
+            sellAmount: '938195228120306016256',
+            buyAmount: '46868859830863283',
+            feeAmount: '61804771879693983744',
+            sellTokenBalance: 'erc20',
+            buyTokenBalance: 'erc20'
+          }
+        }
+      })
+    )
+
+    const trade = await getCowSwapTradeQuote(deps, input)
+
+    expect(trade).toEqual(expectedTradeQuoteFoxToEth)
+    expect(cowService.post).toHaveBeenCalledWith(
+      'https://api.cow.fi/mainnet/api/v1/quote/',
+      expectedApiInputFoxToEth
     )
   })
 })

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -9,7 +9,7 @@ import { CowSwapperDeps } from '../CowSwapper'
 import { getCowSwapMinMax } from '../getCowSwapMinMax/getCowSwapMinMax'
 import { CowSwapQuoteResponse } from '../types'
 import {
-  COW_SWAP_ETH_BUY_ADDRESS,
+  COW_SWAP_ETH_MARKER_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   DEFAULT_ADDRESS,
   DEFAULT_APP_DATA,
@@ -55,7 +55,7 @@ export async function getCowSwapTradeQuote(
     }
 
     const buyToken =
-      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
+      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_MARKER_ADDRESS
     const { minimum, maximum } = await getCowSwapMinMax(deps, sellAsset, buyAsset)
 
     const minQuoteSellAmount = bnOrZero(minimum).times(bn(10).exponentiatedBy(sellAsset.precision))

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -1,4 +1,4 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 
@@ -9,6 +9,7 @@ import { CowSwapperDeps } from '../CowSwapper'
 import { getCowSwapMinMax } from '../getCowSwapMinMax/getCowSwapMinMax'
 import { CowSwapQuoteResponse } from '../types'
 import {
+  COW_SWAP_ETH_BUY_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   DEFAULT_ADDRESS,
   DEFAULT_APP_DATA,
@@ -32,17 +33,29 @@ export async function getCowSwapTradeQuote(
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
       fromAssetId(sellAsset.assetId)
-    const { assetReference: buyAssetErc20Address, assetNamespace: buyAssetNamespace } = fromAssetId(
+    const { assetReference: buyAssetErc20Address, chainId: buyAssetChainId } = fromAssetId(
       buyAsset.assetId
     )
 
-    if (buyAssetNamespace !== 'erc20' || sellAssetNamespace !== 'erc20') {
-      throw new SwapError('[getCowSwapTradeQuote] - Both assets need to be ERC-20 to use CowSwap', {
+    if (sellAssetNamespace !== 'erc20') {
+      throw new SwapError('[getCowSwapTradeQuote] - Sell asset needs to be ERC-20 to use CowSwap', {
         code: SwapErrorTypes.UNSUPPORTED_PAIR,
-        details: { buyAssetNamespace, sellAssetNamespace }
+        details: { sellAssetNamespace }
       })
     }
 
+    if (buyAssetChainId !== KnownChainIds.EthereumMainnet) {
+      throw new SwapError(
+        '[getCowSwapTradeQuote] - Buy asset needs to be on ETH mainnet to use CowSwap',
+        {
+          code: SwapErrorTypes.UNSUPPORTED_PAIR,
+          details: { buyAssetChainId }
+        }
+      )
+    }
+
+    const buyToken =
+      buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_BUY_ADDRESS
     const { minimum, maximum } = await getCowSwapMinMax(deps, sellAsset, buyAsset)
 
     const minQuoteSellAmount = bnOrZero(minimum).times(bn(10).exponentiatedBy(sellAsset.precision))
@@ -54,7 +67,7 @@ export async function getCowSwapTradeQuote(
 
     const apiInput: CowSwapSellQuoteApiInput = {
       sellToken: sellAssetErc20Address,
-      buyToken: buyAssetErc20Address,
+      buyToken,
       receiver: DEFAULT_ADDRESS,
       validTo: getNowPlusThirtyMinutesTimestamp(),
       appData: DEFAULT_APP_DATA,

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -18,4 +18,4 @@ export const ORDER_STATUS_FULFILLED = 'fulfilled'
 
 // Address used by CowSwap to buy ETH
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13
-export const COW_SWAP_ETH_BUY_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+export const COW_SWAP_ETH_MARKER_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -15,3 +15,7 @@ export const ORDER_KIND_BUY = 'buy'
 export const SIGNING_SCHEME = 'ethsign'
 export const ERC20_TOKEN_BALANCE = 'erc20'
 export const ORDER_STATUS_FULFILLED = 'fulfilled'
+
+// Address used by CowSwap to buy ETH
+// See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13
+export const COW_SWAP_ETH_BUY_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'


### PR DESCRIPTION
This enables `ETH` as a possible buy asset for swaps on CowSwap.
closes https://github.com/shapeshift/web/issues/2283

`0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` refers to the assetId used by `CowSwap` for `ETH` as buy asset.

Steps to test : 
- Launch web with local lib
- try to swap any ERC-20 to ETH

![trade1](https://user-images.githubusercontent.com/5720927/182028266-326cdb5a-3a96-46c9-b4c8-093d11282844.png)
![trade2](https://user-images.githubusercontent.com/5720927/182028269-f400de12-759b-4d0e-9009-1f1996b1fb61.png)
![trade3](https://user-images.githubusercontent.com/5720927/182028270-aa6f9065-9a54-4480-83dc-586a1c4cfcca.png)
