### PR TITLE
feat(caip & market-service): handle multiple assets with the same CoinGecko `id`

### DIFF
--- a/packages/caip/README.md
+++ b/packages/caip/README.md
@@ -134,7 +134,7 @@ and commit the generated `adapter.json` files.
 ### Usage
 
 ```ts
-console.log(coingeckoToAssetId('shapeshift-fox-token'))
+console.log(coingeckoToAssetIds('shapeshift-fox-token'))
 
 [eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d]
 

--- a/packages/caip/README.md
+++ b/packages/caip/README.md
@@ -136,7 +136,7 @@ and commit the generated `adapter.json` files.
 ```ts
 console.log(coingeckoToAssetId('shapeshift-fox-token'))
 
-eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d
+[eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d]
 
 console.log(assetIdToCoingecko('bip122:000000000019d6689c085ae165831e93/slip44:0'))
 

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -10,11 +10,11 @@ import {
   assetIdToCoingecko,
   chainIdToCoingeckoAssetPlatform,
   CoingeckoAssetPlatform,
-  coingeckoToAssetId
+  coingeckoToAssetIds
 } from '.'
 
 describe('adapters:coingecko', () => {
-  describe('coingeckoToAssetId', () => {
+  describe('coingeckoToAssetIds', () => {
     it('can get AssetId for bitcoin', () => {
       const chainNamespace = CHAIN_NAMESPACE.Bitcoin
       const chainReference = CHAIN_REFERENCE.BitcoinMainnet
@@ -25,7 +25,7 @@ describe('adapters:coingecko', () => {
         assetNamespace: 'slip44',
         assetReference: ASSET_REFERENCE.Bitcoin
       })
-      expect(coingeckoToAssetId('bitcoin')).toEqual(assetId)
+      expect(coingeckoToAssetIds('bitcoin')).toEqual([assetId])
     })
 
     it('can get AssetId id for ethereum', () => {
@@ -37,7 +37,7 @@ describe('adapters:coingecko', () => {
         assetNamespace: 'slip44',
         assetReference: ASSET_REFERENCE.Ethereum
       })
-      expect(coingeckoToAssetId('ethereum')).toEqual(assetId)
+      expect(coingeckoToAssetIds('ethereum')).toEqual([assetId])
     })
 
     it('can get AssetId id for FOX', () => {
@@ -46,7 +46,7 @@ describe('adapters:coingecko', () => {
       const assetNamespace = 'erc20'
       const assetReference = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
       const assetId = toAssetId({ chainNamespace, chainReference, assetNamespace, assetReference })
-      expect(coingeckoToAssetId('shapeshift-fox-token')).toEqual(assetId)
+      expect(coingeckoToAssetIds('shapeshift-fox-token')).toEqual([assetId])
     })
   })
 
@@ -59,7 +59,7 @@ describe('adapters:coingecko', () => {
       assetNamespace: 'slip44',
       assetReference: ASSET_REFERENCE.Cosmos
     })
-    expect(coingeckoToAssetId('cosmos')).toEqual(assetId)
+    expect(coingeckoToAssetIds('cosmos')).toEqual([assetId])
   })
 
   it('can get AssetId for osmosis', () => {
@@ -71,7 +71,7 @@ describe('adapters:coingecko', () => {
       assetNamespace: 'slip44',
       assetReference: ASSET_REFERENCE.Osmosis
     })
-    expect(coingeckoToAssetId('osmosis')).toEqual(assetId)
+    expect(coingeckoToAssetIds('osmosis')).toEqual([assetId])
   })
 
   describe('AssetIdtoCoingecko', () => {

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -15,7 +15,7 @@ import {
 
 describe('adapters:coingecko', () => {
   describe('coingeckoToAssetIds', () => {
-    it('can get AssetId for bitcoin', () => {
+    it('can get AssetIds for bitcoin', () => {
       const chainNamespace = CHAIN_NAMESPACE.Bitcoin
       const chainReference = CHAIN_REFERENCE.BitcoinMainnet
 
@@ -28,7 +28,7 @@ describe('adapters:coingecko', () => {
       expect(coingeckoToAssetIds('bitcoin')).toEqual([assetId])
     })
 
-    it('can get AssetId id for ethereum', () => {
+    it('can get AssetIds id for ethereum', () => {
       const chainNamespace = CHAIN_NAMESPACE.Ethereum
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
@@ -40,7 +40,7 @@ describe('adapters:coingecko', () => {
       expect(coingeckoToAssetIds('ethereum')).toEqual([assetId])
     })
 
-    it('can get AssetId id for FOX', () => {
+    it('can get AssetIds id for FOX', () => {
       const chainNamespace = CHAIN_NAMESPACE.Ethereum
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
@@ -49,7 +49,7 @@ describe('adapters:coingecko', () => {
       expect(coingeckoToAssetIds('shapeshift-fox-token')).toEqual([assetId])
     })
 
-    it('can get AssetId for cosmos', () => {
+    it('can get AssetIds for cosmos', () => {
       const chainNamespace = CHAIN_NAMESPACE.Cosmos
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
@@ -61,7 +61,7 @@ describe('adapters:coingecko', () => {
       expect(coingeckoToAssetIds('cosmos')).toEqual([assetId])
     })
 
-    it('can get AssetId for osmosis', () => {
+    it('can get AssetIds for osmosis', () => {
       const chainNamespace = CHAIN_NAMESPACE.Cosmos
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -48,34 +48,52 @@ describe('adapters:coingecko', () => {
       const assetId = toAssetId({ chainNamespace, chainReference, assetNamespace, assetReference })
       expect(coingeckoToAssetIds('shapeshift-fox-token')).toEqual([assetId])
     })
-  })
 
-  it('can get AssetId for cosmos', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
-    const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
-    const assetId = toAssetId({
-      chainNamespace,
-      chainReference,
-      assetNamespace: 'slip44',
-      assetReference: ASSET_REFERENCE.Cosmos
+    it('can get AssetId for cosmos', () => {
+      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
+      const assetId = toAssetId({
+        chainNamespace,
+        chainReference,
+        assetNamespace: 'slip44',
+        assetReference: ASSET_REFERENCE.Cosmos
+      })
+      expect(coingeckoToAssetIds('cosmos')).toEqual([assetId])
     })
-    expect(coingeckoToAssetIds('cosmos')).toEqual([assetId])
-  })
 
-  it('can get AssetId for osmosis', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
-    const chainReference = CHAIN_REFERENCE.OsmosisMainnet
-    const assetId = toAssetId({
-      chainNamespace,
-      chainReference,
-      assetNamespace: 'slip44',
-      assetReference: ASSET_REFERENCE.Osmosis
+    it('can get AssetId for osmosis', () => {
+      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainReference = CHAIN_REFERENCE.OsmosisMainnet
+      const assetId = toAssetId({
+        chainNamespace,
+        chainReference,
+        assetNamespace: 'slip44',
+        assetReference: ASSET_REFERENCE.Osmosis
+      })
+      expect(coingeckoToAssetIds('osmosis')).toEqual([assetId])
     })
-    expect(coingeckoToAssetIds('osmosis')).toEqual([assetId])
+
+    it('can get AssetIds for USD Coin on Ethereum and Avalanche', () => {
+      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const assetNamespace = 'erc20'
+      const usdcEth = toAssetId({
+        chainNamespace,
+        chainReference: CHAIN_REFERENCE.EthereumMainnet,
+        assetNamespace,
+        assetReference: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      })
+      const usdcAvalanche = toAssetId({
+        chainNamespace,
+        chainReference: CHAIN_REFERENCE.AvalancheCChain,
+        assetNamespace,
+        assetReference: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e'
+      })
+      expect(coingeckoToAssetIds('usd-coin')).toEqual([usdcEth, usdcAvalanche])
+    })
   })
 
-  describe('AssetIdtoCoingecko', () => {
-    it('can get coingecko id for bitcoin AssetId', () => {
+  describe('assetIdToCoingecko', () => {
+    it('can get CoinGecko id for bitcoin AssetId', () => {
       const chainNamespace = CHAIN_NAMESPACE.Bitcoin
       const chainReference = CHAIN_REFERENCE.BitcoinMainnet
       const assetId = toAssetId({
@@ -87,7 +105,7 @@ describe('adapters:coingecko', () => {
       expect(assetIdToCoingecko(assetId)).toEqual('bitcoin')
     })
 
-    it('can get coingecko id for ethereum AssetId', () => {
+    it('can get CoinGecko id for ethereum AssetId', () => {
       const chainNamespace = CHAIN_NAMESPACE.Ethereum
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
@@ -99,7 +117,7 @@ describe('adapters:coingecko', () => {
       expect(assetIdToCoingecko(assetId)).toEqual('ethereum')
     })
 
-    it('can get coingecko id for FOX', () => {
+    it('can get CoinGecko id for FOX', () => {
       const chainNamespace = CHAIN_NAMESPACE.Ethereum
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
@@ -108,7 +126,7 @@ describe('adapters:coingecko', () => {
       expect(assetIdToCoingecko(assetId)).toEqual('shapeshift-fox-token')
     })
 
-    it('can get coingecko id for cosmos AssetId', () => {
+    it('can get CoinGecko id for cosmos AssetId', () => {
       const chainNamespace = CHAIN_NAMESPACE.Cosmos
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
@@ -120,7 +138,7 @@ describe('adapters:coingecko', () => {
       expect(assetIdToCoingecko(assetId)).toEqual('cosmos')
     })
 
-    it('can get coingecko id for osmosis AssetId', () => {
+    it('can get CoinGecko id for osmosis AssetId', () => {
       const chainNamespace = CHAIN_NAMESPACE.Cosmos
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
@@ -134,7 +152,7 @@ describe('adapters:coingecko', () => {
   })
 
   describe('chainIdToCoingeckoAssetPlatform', () => {
-    it('can get Coingecko asset platform from ChainId', () => {
+    it('can get CoinGecko asset platform from ChainId', () => {
       const chainId = ethChainId
       expect(chainIdToCoingeckoAssetPlatform(chainId)).toEqual(CoingeckoAssetPlatform.Ethereum)
     })

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -1,6 +1,7 @@
+import invertBy from 'lodash/invertBy'
 import toLower from 'lodash/toLower'
 
-import { fromAssetId } from '../../assetId/assetId'
+import { AssetId, fromAssetId } from '../../assetId/assetId'
 import { ChainId, fromChainId, toChainId } from '../../chainId/chainId'
 import { CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../../constants'
 import * as adapters from './generated'
@@ -17,20 +18,19 @@ export const coingeckoBaseUrl = 'https://api.coingecko.com/api/v3'
 export const coingeckoProBaseUrl = 'https://pro-api.coingecko.com/api/v3'
 export const coingeckoUrl = 'https://api.coingecko.com/api/v3/coins/list?include_platform=true'
 
-const generatedAssetIdToCoingeckoMap = Object.values(adapters).reduce((acc, cur) => ({
+const assetIdToCoinGeckoIdMapByChain: Record<AssetId, string>[] = Object.values(adapters)
+
+const generatedAssetIdToCoingeckoMap = assetIdToCoinGeckoIdMapByChain.reduce((acc, cur) => ({
   ...acc,
   ...cur
 })) as Record<string, string>
 
-const invert = <T extends Record<string, string>>(data: T) =>
-  Object.entries(data).reduce((acc, [k, v]) => ((acc[v] = k), acc), {} as Record<string, string>)
-
-const generatedCoingeckoToAssetIdMap: Record<string, string> = invert(
+const generatedCoingeckoToAssetIdsMap: Record<string, string[]> = invertBy(
   generatedAssetIdToCoingeckoMap
 )
 
-export const coingeckoToAssetId = (id: string): string | undefined =>
-  generatedCoingeckoToAssetIdMap[id]
+export const coingeckoToAssetIds = (id: string): string[] | undefined =>
+  generatedCoingeckoToAssetIdsMap[id]
 
 export const assetIdToCoingecko = (assetId: string): string | undefined =>
   generatedAssetIdToCoingeckoMap[toLower(assetId)]

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -31,7 +31,7 @@ const generatedCoingeckoToAssetIdsMap: Record<CoinGeckoId, AssetId[]> = invertBy
   generatedAssetIdToCoingeckoMap
 )
 
-export const coingeckoToAssetIds = (id: CoinGeckoId): AssetId[] | undefined =>
+export const coingeckoToAssetIds = (id: CoinGeckoId): AssetId[] =>
   generatedCoingeckoToAssetIdsMap[id]
 
 export const assetIdToCoingecko = (assetId: AssetId): CoinGeckoId | undefined =>

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -14,25 +14,27 @@ export enum CoingeckoAssetPlatform {
   Avalanche = 'avalanche'
 }
 
+type CoinGeckoId = string
+
 export const coingeckoBaseUrl = 'https://api.coingecko.com/api/v3'
 export const coingeckoProBaseUrl = 'https://pro-api.coingecko.com/api/v3'
 export const coingeckoUrl = 'https://api.coingecko.com/api/v3/coins/list?include_platform=true'
 
-const assetIdToCoinGeckoIdMapByChain: Record<AssetId, string>[] = Object.values(adapters)
+const assetIdToCoinGeckoIdMapByChain: Record<AssetId, CoinGeckoId>[] = Object.values(adapters)
 
 const generatedAssetIdToCoingeckoMap = assetIdToCoinGeckoIdMapByChain.reduce((acc, cur) => ({
   ...acc,
   ...cur
 })) as Record<string, string>
 
-const generatedCoingeckoToAssetIdsMap: Record<string, string[]> = invertBy(
+const generatedCoingeckoToAssetIdsMap: Record<CoinGeckoId, AssetId[]> = invertBy(
   generatedAssetIdToCoingeckoMap
 )
 
-export const coingeckoToAssetIds = (id: string): string[] | undefined =>
+export const coingeckoToAssetIds = (id: CoinGeckoId): AssetId[] | undefined =>
   generatedCoingeckoToAssetIdsMap[id]
 
-export const assetIdToCoingecko = (assetId: string): string | undefined =>
+export const assetIdToCoingecko = (assetId: AssetId): CoinGeckoId | undefined =>
   generatedAssetIdToCoingeckoMap[toLower(assetId)]
 
 // https://www.coingecko.com/en/api/documentation - See asset_platforms
@@ -79,7 +81,7 @@ export const makeCoingeckoUrlParts = (
   return { baseUrl, maybeApiKeyQueryParam }
 }
 
-export const makeCoingeckoAssetUrl = (assetId: string, apiKey?: string): string | undefined => {
+export const makeCoingeckoAssetUrl = (assetId: AssetId, apiKey?: string): string | undefined => {
   const id = assetIdToCoingecko(assetId)
   if (!id) return
 

--- a/packages/caip/src/adapters/coingecko/utils.ts
+++ b/packages/caip/src/adapters/coingecko/utils.ts
@@ -33,16 +33,6 @@ export type CoingeckoCoin = {
 
 type AssetMap = Record<ChainId, Record<AssetId, string>>
 
-export const writeFiles = async (data: AssetMap) => {
-  await Promise.all(
-    Object.entries(data).map(async ([chainId, assets]) => {
-      const path = `./src/adapters/coingecko/generated/${chainId}/adapter.json`.replace(':', '_')
-      await fs.promises.writeFile(path, JSON.stringify(assets))
-    })
-  )
-  console.info('Generated CoinGecko AssetId adapter data.')
-}
-
 export const fetchData = async (URL: string) => (await axios.get<CoingeckoCoin[]>(URL)).data
 
 export const parseData = (coins: CoingeckoCoin[]): AssetMap => {
@@ -92,4 +82,14 @@ export const parseData = (coins: CoingeckoCoin[]): AssetMap => {
     [cosmosChainId]: cosmosAssetMap,
     [osmosisChainId]: osmosisAssetMap
   }
+}
+
+export const writeFiles = async (data: AssetMap) => {
+  await Promise.all(
+    Object.entries(data).map(async ([chainId, assets]) => {
+      const path = `./src/adapters/coingecko/generated/${chainId}/adapter.json`.replace(':', '_')
+      await fs.promises.writeFile(path, JSON.stringify(assets))
+    })
+  )
+  console.info('Generated CoinGecko AssetId adapter data.')
 }

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -136,7 +136,7 @@ describe('coingecko market service', () => {
     it('can sort by market cap', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
-      expect(Object.keys(result)[0]).toEqual(adapters.coingeckoToAssetId(btc.id))
+      expect(adapters.coingeckoToAssetIds(btc.id)).toEqual([Object.keys(result)[0]])
     })
 
     it('can handle api errors', async () => {
@@ -181,8 +181,8 @@ describe('coingecko market service', () => {
     it('can map coingecko to assetIds', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
-      const btcAssetId = adapters.coingeckoToAssetId('bitcoin')
-      const ethAssetId = adapters.coingeckoToAssetId('ethereum')
+      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
+      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')?.[0]
       const [btcKey, ethKey] = Object.keys(result)
       expect(btcKey).toEqual(btcAssetId)
       expect(ethKey).toEqual(ethAssetId)
@@ -208,8 +208,8 @@ describe('coingecko market service', () => {
 
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
-      const btcAssetId = adapters.coingeckoToAssetId('bitcoin')
-      const ethAssetId = adapters.coingeckoToAssetId('ethereum')
+      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
+      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')?.[0]
       expect(result[btcAssetId!]).toEqual(btcResult)
       expect(result[ethAssetId!]).toEqual(ethResult)
     })
@@ -226,7 +226,7 @@ describe('coingecko market service', () => {
 
       mockedAxios.get.mockResolvedValue({ data: [fox] })
       const result = await coinGeckoMarketService.findAll()
-      const foxAssetId = adapters.coingeckoToAssetId('shapeshift-fox-token')
+      const foxAssetId = adapters.coingeckoToAssetIds('shapeshift-fox-token')?.[0]
       expect(result[foxAssetId!]).toEqual(foxResult)
     })
   })

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -12,7 +12,10 @@ const mockedAxios = axios as jest.Mocked<typeof axios>
 const coinGeckoMarketServiceArgs = { coinGeckoAPIKey: '' }
 const coinGeckoMarketService = new CoinGeckoMarketService(coinGeckoMarketServiceArgs)
 
-describe('coingecko market service', () => {
+const coinGeckoMarketApiUrl = 'https://api.coingecko.com/api/v3/coins/markets'
+const coinGeckoMarketProApiUrl = 'https://pro-api.coingecko.com/api/v3/coins/markets'
+
+describe('CoinGecko market service', () => {
   describe('findAll', () => {
     const btc: CoinGeckoMarketCap = {
       id: 'bitcoin',
@@ -141,18 +144,14 @@ describe('coingecko market service', () => {
     it('can use free tier with no api key', async () => {
       const freeCoinGeckoMarketService = new CoinGeckoMarketService({ coinGeckoAPIKey: '' })
       await freeCoinGeckoMarketService.findAll({ count: 10 })
-      // note - url starts with api, not pro-api
-      const url =
-        'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false'
+      const url = `${coinGeckoMarketApiUrl}?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false`
       expect(mockedAxios.get).toBeCalledWith(url)
     })
 
     it('can use pro tier with api key', async () => {
       const proCoinGeckoMarketService = new CoinGeckoMarketService({ coinGeckoAPIKey: 'dummyKey' })
       await proCoinGeckoMarketService.findAll({ count: 10 })
-      // note - url starts with pro-api, not api
-      const url =
-        'https://pro-api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false&x_cg_pro_api_key=dummyKey'
+      const url = `${coinGeckoMarketProApiUrl}?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false&x_cg_pro_api_key=dummyKey`
       expect(mockedAxios.get).toBeCalledWith(url)
     })
 
@@ -196,8 +195,7 @@ describe('coingecko market service', () => {
       mockedAxios.get.mockResolvedValue({ data: [btc] })
       await coinGeckoMarketService.findAll({ count: 10 })
       expect(mockedAxios.get).toHaveBeenCalledTimes(1)
-      const url =
-        'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false'
+      const url = `${coinGeckoMarketApiUrl}?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&sparkline=false`
       expect(mockedAxios.get).toBeCalledWith(url)
     })
 
@@ -207,7 +205,7 @@ describe('coingecko market service', () => {
       expect(mockedAxios.get).toHaveBeenCalledTimes(2)
     })
 
-    it('can map coingecko id to assetIds', async () => {
+    it('can map CoinGecko id to assetIds', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
       const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
@@ -217,7 +215,7 @@ describe('coingecko market service', () => {
       expect(ethKey).toEqual(ethAssetId)
     })
 
-    it('can map coingecko id to multiple assetIds', async () => {
+    it('can map CoinGecko id to multiple assetIds', async () => {
       mockedAxios.get.mockResolvedValue({ data: [usdc] })
       const result = await coinGeckoMarketService.findAll()
       const usdcAssetIds = adapters.coingeckoToAssetIds('usd-coin')

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -208,11 +208,11 @@ describe('CoinGecko market service', () => {
     it('can map CoinGecko id to assetIds', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
-      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
-      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')?.[0]
+      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')
+      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')
       const [btcKey, ethKey] = Object.keys(result)
-      expect(btcKey).toEqual(btcAssetId)
-      expect(ethKey).toEqual(ethAssetId)
+      expect(btcKey).toEqual([btcAssetId])
+      expect(ethKey).toEqual([ethAssetId])
     })
 
     it('can map CoinGecko id to multiple assetIds', async () => {

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -242,8 +242,8 @@ describe('CoinGecko market service', () => {
 
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
-      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
-      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')?.[0]
+      const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')[0]
+      const ethAssetId = adapters.coingeckoToAssetIds('ethereum')[0]
       expect(result[btcAssetId!]).toEqual(btcResult)
       expect(result[ethAssetId!]).toEqual(ethResult)
     })
@@ -260,7 +260,7 @@ describe('CoinGecko market service', () => {
 
       mockedAxios.get.mockResolvedValue({ data: [fox] })
       const result = await coinGeckoMarketService.findAll()
-      const foxAssetId = adapters.coingeckoToAssetIds('shapeshift-fox-token')?.[0]
+      const foxAssetId = adapters.coingeckoToAssetIds('shapeshift-fox-token')[0]
       expect(result[foxAssetId!]).toEqual(foxResult)
     })
   })

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -211,8 +211,8 @@ describe('CoinGecko market service', () => {
       const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')
       const ethAssetId = adapters.coingeckoToAssetIds('ethereum')
       const [btcKey, ethKey] = Object.keys(result)
-      expect(btcKey).toEqual([btcAssetId])
-      expect(ethKey).toEqual([ethAssetId])
+      expect(btcAssetId).toEqual([btcKey])
+      expect(ethAssetId).toEqual([ethKey])
     })
 
     it('can map CoinGecko id to multiple assetIds', async () => {

--- a/packages/market-service/src/coingecko/coingecko.test.ts
+++ b/packages/market-service/src/coingecko/coingecko.test.ts
@@ -109,6 +109,35 @@ describe('coingecko market service', () => {
       last_updated: '2021-10-10T22:16:22.950Z'
     }
 
+    const usdc: CoinGeckoMarketCap = {
+      ath: 1.17,
+      ath_change_percentage: -14.79969,
+      ath_date: '2019-05-08T00:40:28.300Z',
+      atl: 0.891848,
+      atl_change_percentage: 12.03135,
+      atl_date: '2021-05-19T13:14:05.611Z',
+      circulating_supply: 54492069074.1417,
+      current_price: 1,
+      fully_diluted_valuation: null,
+      high_24h: 1.015,
+      id: 'usd-coin',
+      image: 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389',
+      last_updated: '2022-08-01T05:50:36.806Z',
+      low_24h: 0.99002,
+      market_cap: 54500234986,
+      market_cap_change_24h: 33737555,
+      market_cap_change_percentage_24h: 0.06194,
+      market_cap_rank: 4,
+      max_supply: null,
+      name: 'USD Coin',
+      price_change_24h: -0.000088001691941342,
+      price_change_percentage_24h: -0.0088,
+      roi: null,
+      symbol: 'usdc',
+      total_supply: 54494627696.0103,
+      total_volume: 5745233196
+    }
+
     it('can use free tier with no api key', async () => {
       const freeCoinGeckoMarketService = new CoinGeckoMarketService({ coinGeckoAPIKey: '' })
       await freeCoinGeckoMarketService.findAll({ count: 10 })
@@ -178,7 +207,7 @@ describe('coingecko market service', () => {
       expect(mockedAxios.get).toHaveBeenCalledTimes(2)
     })
 
-    it('can map coingecko to assetIds', async () => {
+    it('can map coingecko id to assetIds', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: [btc] }).mockResolvedValue({ data: [eth] })
       const result = await coinGeckoMarketService.findAll()
       const btcAssetId = adapters.coingeckoToAssetIds('bitcoin')?.[0]
@@ -186,6 +215,13 @@ describe('coingecko market service', () => {
       const [btcKey, ethKey] = Object.keys(result)
       expect(btcKey).toEqual(btcAssetId)
       expect(ethKey).toEqual(ethAssetId)
+    })
+
+    it('can map coingecko id to multiple assetIds', async () => {
+      mockedAxios.get.mockResolvedValue({ data: [usdc] })
+      const result = await coinGeckoMarketService.findAll()
+      const usdcAssetIds = adapters.coingeckoToAssetIds('usd-coin')
+      expect(usdcAssetIds).toEqual(Object.keys(result))
     })
 
     it('extract correct values for each asset', async () => {

--- a/packages/market-service/src/coingecko/coingecko.ts
+++ b/packages/market-service/src/coingecko/coingecko.ts
@@ -74,17 +74,19 @@ export class CoinGeckoMarketService implements MarketService {
       )
 
       return marketData.flat().reduce<MarketCapResult>((prev, asset) => {
-        const assetId = adapters.coingeckoToAssetId(asset.id)
-        if (!assetId) return prev
+        const assetIds = adapters.coingeckoToAssetIds(asset.id)
+        if (!assetIds) return prev
 
-        prev[assetId] = {
-          price: asset.current_price.toString(),
-          marketCap: asset.market_cap.toString(),
-          volume: asset.total_volume.toString(),
-          changePercent24Hr: asset.price_change_percentage_24h,
-          supply: asset.circulating_supply.toString(),
-          maxSupply: asset.max_supply?.toString() ?? asset.total_supply?.toString()
-        }
+        assetIds.forEach((assetId) => {
+          prev[assetId] = {
+            price: asset.current_price.toString(),
+            marketCap: asset.market_cap.toString(),
+            volume: asset.total_volume.toString(),
+            changePercent24Hr: asset.price_change_percentage_24h,
+            supply: asset.circulating_supply.toString(),
+            maxSupply: asset.max_supply?.toString() ?? asset.total_supply?.toString()
+          }
+        })
 
         return prev
       }, {})


### PR DESCRIPTION
Stores an array of `AssetId`s, preventing the overwriting any existing `AssetId`s when there are multiple `AssetId`s mapping to a `CoinGeckoId`.

Before: `Record<CoinGeckoId, AssetId>`
After: `Record<CoinGeckoId, AssetId[]>`

With the `findAll` method fixed, when consumed by `web`  the assets page now shows all assets when Avalanche is enabled:

<img width="1279" alt="Screen Shot 2022-08-01 at 3 34 27 pm" src="https://user-images.githubusercontent.com/97164662/182078967-e2cc6708-eb3a-4054-b833-2389a28cd8df.png">

Contributes to https://github.com/shapeshift/web/issues/2101