### PR TITLE
chore(caip): add include & exclude patterns to caip's `tsconfig`

### DIFF
--- a/packages/caip/tsconfig.json
+++ b/packages/caip/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "composite": true
   },
-  "include": ["src/**/*", "src/**/*.json"]
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"],
 }

--- a/packages/caip/tsconfig.json
+++ b/packages/caip/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
+    "composite": true
   },
+  "include": ["src/**/*", "src/**/*.json"]
 }


### PR DESCRIPTION
Stops the IDE complaining about importing files not listed as part of the project, particularly in `packages/caip/src/adapters/coingecko/generated/index.ts`.

<img width="569" alt="Screen Shot 2022-08-02 at 7 27 08 am" src="https://user-images.githubusercontent.com/97164662/182249676-b4475d41-3701-4d75-90b8-5b193835019c.png">
