### PR TITLE
feat: additonal thorchain asset support

### DIFF
--- a/packages/caip/src/adapters/thortrading/index.ts
+++ b/packages/caip/src/adapters/thortrading/index.ts
@@ -1,3 +1,4 @@
+import { btcAssetId, cosmosAssetId, dogeAssetId, ethAssetId, ltcAssetId } from '../../constants'
 import { AssetId } from './../../assetId/assetId'
 
 // derived from https://midgard.thorchain.info/v2/pools
@@ -47,12 +48,12 @@ const thorPoolIdAssetIdSymbolMap: Record<string, AssetId> = {
     'eip155:1/erc20:0xdbdb4d16eda451d0503b854cf79d55697f90c8df',
   'ETH.AAVE-0X7FC66500C84A76AD7E9C93437BFC5AC33E2DDAE9':
     'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
-  'BTC.BTC': 'bip122:000000000019d6689c085ae165831e93/slip44:0',
-  'ETH.ETH': 'eip155:1/slip44:60',
-  'LTC.LTC': 'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
-  'DOGE.DOGE': 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3',
-  'GAIA.ATOM': 'cosmos:cosmoshub-4/slip44:118'
-  //  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145' // uncomment when we support bch
+  'BTC.BTC': btcAssetId,
+  'ETH.ETH': ethAssetId,
+  'LTC.LTC': ltcAssetId,
+  'DOGE.DOGE': dogeAssetId,
+  'GAIA.ATOM': cosmosAssetId
+  //  'BCH.BCH': bchAssetId // uncomment when we support bch
 }
 
 const invert = <T extends Record<string, string>>(data: T) =>

--- a/packages/caip/src/adapters/thortrading/index.ts
+++ b/packages/caip/src/adapters/thortrading/index.ts
@@ -51,8 +51,8 @@ const thorPoolIdAssetIdSymbolMap: Record<string, AssetId> = {
   'ETH.ETH': 'eip155:1/slip44:60',
   'LTC.LTC': 'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
   'DOGE.DOGE': 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3',
-  'GAIA.ATOM': 'cosmos:cosmoshub-4/slip44:118',
-  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145'
+  'GAIA.ATOM': 'cosmos:cosmoshub-4/slip44:118'
+//  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145' // uncomment when we support bch
 }
 
 const invert = <T extends Record<string, string>>(data: T) =>

--- a/packages/caip/src/adapters/thortrading/index.ts
+++ b/packages/caip/src/adapters/thortrading/index.ts
@@ -52,7 +52,7 @@ const thorPoolIdAssetIdSymbolMap: Record<string, AssetId> = {
   'LTC.LTC': 'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
   'DOGE.DOGE': 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3',
   'GAIA.ATOM': 'cosmos:cosmoshub-4/slip44:118'
-//  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145' // uncomment when we support bch
+  //  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145' // uncomment when we support bch
 }
 
 const invert = <T extends Record<string, string>>(data: T) =>

--- a/packages/caip/src/adapters/thortrading/index.ts
+++ b/packages/caip/src/adapters/thortrading/index.ts
@@ -48,7 +48,11 @@ const thorPoolIdAssetIdSymbolMap: Record<string, AssetId> = {
   'ETH.AAVE-0X7FC66500C84A76AD7E9C93437BFC5AC33E2DDAE9':
     'eip155:1/erc20:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
   'BTC.BTC': 'bip122:000000000019d6689c085ae165831e93/slip44:0',
-  'ETH.ETH': 'eip155:1/slip44:60'
+  'ETH.ETH': 'eip155:1/slip44:60',
+  'LTC.LTC': 'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+  'DOGE.DOGE': 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3',
+  'GAIA.ATOM': 'cosmos:cosmoshub-4/slip44:118',
+  'BCH.BCH': 'bip122:000000000000000000651ef99cb9fcbe/slip44:145'
 }
 
 const invert = <T extends Record<string, string>>(data: T) =>

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -31,11 +31,21 @@ import { thorService } from './utils/thorService'
 
 export class ThorchainSwapper implements Swapper<ChainId> {
   readonly name = 'Thorchain'
-  private swapSupportedChainIds: Record<ChainId, boolean> = {
+  private sellSupportedChainIds: Record<ChainId, boolean> = {
     [KnownChainIds.EthereumMainnet]: true,
     [KnownChainIds.BitcoinMainnet]: true
   }
-  private supportedAssetIds: AssetId[] = []
+
+  private buySupportedChainIds: Record<ChainId, boolean> = {
+    [KnownChainIds.EthereumMainnet]: true,
+    [KnownChainIds.BitcoinMainnet]: true,
+    [KnownChainIds.DogecoinMainnet]: true, // implement estimateTradeFee for doge
+    [KnownChainIds.LitecoinMainnet]: true, // implement estimateTradeFee for ltc
+    [KnownChainIds.CosmosMainnet]: true // implement estimateTradeFee for atom
+  }
+
+  private supportedSellAssetIds: AssetId[] = []
+  private supportedBuyAssetIds: AssetId[] = []
   deps: ThorchainSwapperDeps
 
   constructor(deps: ThorchainSwapperDeps) {
@@ -48,14 +58,19 @@ export class ThorchainSwapper implements Swapper<ChainId> {
         `${this.deps.midgardUrl}/pools`
       )
 
-      const supportedAssetIds = responseData.reduce<AssetId[]>((acc, midgardPool) => {
+      this.supportedSellAssetIds = responseData.reduce<AssetId[]>((acc, midgardPool) => {
         const assetId = adapters.poolAssetIdToAssetId(midgardPool.asset)
-        if (!assetId || !this.swapSupportedChainIds[fromAssetId(assetId).chainId]) return acc
+        if (!assetId || !this.sellSupportedChainIds[fromAssetId(assetId).chainId]) return acc
         acc.push(assetId)
         return acc
       }, [])
 
-      this.supportedAssetIds = supportedAssetIds
+      this.supportedBuyAssetIds = responseData.reduce<AssetId[]>((acc, midgardPool) => {
+        const assetId = adapters.poolAssetIdToAssetId(midgardPool.asset)
+        if (!assetId || !this.buySupportedChainIds[fromAssetId(assetId).chainId]) return acc
+        acc.push(assetId)
+        return acc
+      }, [])
     } catch (e) {
       throw new SwapError('[thorchainInitialize]: initialize failed to set supportedAssetIds', {
         code: SwapErrorTypes.INITIALIZE_FAILED,
@@ -86,14 +101,14 @@ export class ThorchainSwapper implements Swapper<ChainId> {
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
     const { assetIds = [], sellAssetId } = args
-    if (!this.supportedAssetIds.includes(sellAssetId)) return []
+    if (!this.supportedSellAssetIds.includes(sellAssetId)) return []
     return assetIds.filter(
-      (assetId) => this.supportedAssetIds.includes(assetId) && assetId !== sellAssetId
+      (assetId) => this.supportedBuyAssetIds.includes(assetId) && assetId !== sellAssetId
     )
   }
 
   filterAssetIdsBySellable(): AssetId[] {
-    return this.supportedAssetIds
+    return this.supportedSellAssetIds
   }
 
   async buildTrade(input: BuildTradeInput): Promise<Trade<ChainId>> {

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -39,9 +39,9 @@ export class ThorchainSwapper implements Swapper<ChainId> {
   private buySupportedChainIds: Record<ChainId, boolean> = {
     [KnownChainIds.EthereumMainnet]: true,
     [KnownChainIds.BitcoinMainnet]: true,
-    [KnownChainIds.DogecoinMainnet]: true, // implement estimateTradeFee for doge
-    [KnownChainIds.LitecoinMainnet]: true, // implement estimateTradeFee for ltc
-    [KnownChainIds.CosmosMainnet]: true // implement estimateTradeFee for atom
+    [KnownChainIds.DogecoinMainnet]: true,
+    [KnownChainIds.LitecoinMainnet]: true,
+    [KnownChainIds.CosmosMainnet]: true
   }
 
   private supportedSellAssetIds: AssetId[] = []

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -6,5 +6,8 @@ export const THORCHAIN_FIXED_PRECISION = 8 // limit values are precision 8 regar
 
 // These are different from THOR_ETH_GAS_LIMIT
 // Used to estimate the fee thorchain will take out of the buyAsset
-export const THOR_TRADE_FEE_BTC_SIZE = 1000 // used for estimating thorchain side fees
-export const THOR_TRADE_FEE_ETH_GAS = 120000 // used for estimating thorchain side fees
+export const THOR_TRADE_FEE_BTC_SIZE = 1000
+export const THOR_TRADE_FEE_DOGE_SIZE = 1000
+export const THOR_TRADE_FEE_LTC_SIZE = 250
+export const THOR_TRADE_FEE_GAIA_SIZE = 1
+export const THOR_TRADE_FEE_ETH_GAS = 120000

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -25,10 +25,3 @@ export const THOR_TRADE_FEE_MULTIPLIERS: Record<ChainId, BigNumber> = {
   [KnownChainIds.CosmosMainnet]: bn(0.00000002), // 1 gas * 2 (as recommended on discord)
   [KnownChainIds.EthereumMainnet]: bn(0.00024) // A value that "works". Discord recommended value (80,000 gas * 2 or 160k) is often too low
 }
-
-export type SUPPORTED_BUY_CHAINS =
-  | KnownChainIds.BitcoinMainnet
-  | KnownChainIds.DogecoinMainnet
-  | KnownChainIds.LitecoinMainnet
-  | KnownChainIds.CosmosMainnet
-  | KnownChainIds.EthereumMainnet

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -16,11 +16,11 @@ export const THORCHAIN_FIXED_PRECISION = 8 // limit values are precision 8 regar
 // TODO figure out if its possible to accurately estimate the outbound fee.
 // Neither the discord nor official docs are correct
 export const THOR_TRADE_FEE_MULTIPLIERS: Record<SUPPORTED_BUY_CHAINS, BigNumber> = {
-  [KnownChainIds.BitcoinMainnet]: bn(0.00002),
-  [KnownChainIds.DogecoinMainnet]: bn(0.00002),
-  [KnownChainIds.LitecoinMainnet]: bn(0.000005),
-  [KnownChainIds.CosmosMainnet]: bn(0.00000002),
-  [KnownChainIds.EthereumMainnet]: bn(0.00024)
+  [KnownChainIds.BitcoinMainnet]: bn(0.00002), // 1000 estimated bytes * 2 (as recommended on discord)
+  [KnownChainIds.DogecoinMainnet]: bn(0.00002), // 1000 estimated bytes * 2 (as recommended on discord)
+  [KnownChainIds.LitecoinMainnet]: bn(0.000005), // 250 estimated bytes * 2 (as recommended on discord)
+  [KnownChainIds.CosmosMainnet]: bn(0.00000002), // 1 gas * 2 (as recommended on discord)
+  [KnownChainIds.EthereumMainnet]: bn(0.00024) // A value that "works". Discord recommended value (80,000 gas * 2 or 160k) is often too low
 }
 
 export type SUPPORTED_BUY_CHAINS =

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -12,15 +12,15 @@ export const THORCHAIN_FIXED_PRECISION = 8 // limit values are precision 8 regar
 // Used to estimate the fee thorchain will take out of the buyAsset
 // Official docs on fees are incorrect
 // https://discord.com/channels/838986635756044328/997675038675316776/998552541170253834
-// This is still not "perfect" and tends to overestimate by a randomish amount
+// This is still not "perfect" and tends to overestimate by a small randomish amount
 // TODO figure out if its possible to accurately estimate the outbound fee.
 // Neither the discord nor official docs are correct
 export const THOR_TRADE_FEE_MULTIPLIERS: Record<SUPPORTED_BUY_CHAINS, BigNumber> = {
-  [KnownChainIds.BitcoinMainnet]: bn(2000),
-  [KnownChainIds.DogecoinMainnet]: bn(2000),
-  [KnownChainIds.LitecoinMainnet]: bn(500),
-  [KnownChainIds.CosmosMainnet]: bn(0.02),
-  [KnownChainIds.EthereumMainnet]: bn(240000).times(bn(10).exponentiatedBy(9))
+  [KnownChainIds.BitcoinMainnet]: bn(0.00002),
+  [KnownChainIds.DogecoinMainnet]: bn(0.00002),
+  [KnownChainIds.LitecoinMainnet]: bn(0.000005),
+  [KnownChainIds.CosmosMainnet]: bn(0.00000002),
+  [KnownChainIds.EthereumMainnet]: bn(0.00024)
 }
 
 export type SUPPORTED_BUY_CHAINS =

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -1,13 +1,31 @@
+import { KnownChainIds } from '@shapeshiftoss/types'
+import BigNumber from 'bignumber.js'
+
+import { bn } from '../../utils/bignumber'
+
 export const MAX_THORCHAIN_TRADE = '100000000000000000000000000'
 export const MAX_ALLOWANCE = '100000000000000000000000000'
 export const THOR_MINIMUM_PADDING = 1.2
 export const THOR_ETH_GAS_LIMIT = '100000' // for sends of eth / erc20 into thorchain router
 export const THORCHAIN_FIXED_PRECISION = 8 // limit values are precision 8 regardless of the chain
 
-// These are different from THOR_ETH_GAS_LIMIT
 // Used to estimate the fee thorchain will take out of the buyAsset
-export const THOR_TRADE_FEE_BTC_SIZE = 1000
-export const THOR_TRADE_FEE_DOGE_SIZE = 1000
-export const THOR_TRADE_FEE_LTC_SIZE = 250
-export const THOR_TRADE_FEE_GAIA_SIZE = 1
-export const THOR_TRADE_FEE_ETH_GAS = 120000
+// Official docs on fees are incorrect
+// https://discord.com/channels/838986635756044328/997675038675316776/998552541170253834
+// This is still not "perfect" and tends to overestimate by a randomish amount
+// TODO figure out if its possible to accurately estimate the outbound fee.
+// Neither the discord nor official docs are correct
+export const THOR_TRADE_FEE_MULTIPLIERS: Record<SUPPORTED_BUY_CHAINS, BigNumber> = {
+  [KnownChainIds.BitcoinMainnet]: bn(2000),
+  [KnownChainIds.DogecoinMainnet]: bn(2000),
+  [KnownChainIds.LitecoinMainnet]: bn(500),
+  [KnownChainIds.CosmosMainnet]: bn(0.02),
+  [KnownChainIds.EthereumMainnet]: bn(240000).times(bn(10).exponentiatedBy(9))
+}
+
+export type SUPPORTED_BUY_CHAINS =
+  | KnownChainIds.BitcoinMainnet
+  | KnownChainIds.DogecoinMainnet
+  | KnownChainIds.LitecoinMainnet
+  | KnownChainIds.CosmosMainnet
+  | KnownChainIds.EthereumMainnet

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import BigNumber from 'bignumber.js'
 
@@ -17,7 +18,7 @@ export const THORCHAIN_AFFILIATE_BIPS = '0' // affiliate fee in basis points (10
 // This is still not "perfect" and tends to overestimate by a small randomish amount
 // TODO figure out if its possible to accurately estimate the outbound fee.
 // Neither the discord nor official docs are correct
-export const THOR_TRADE_FEE_MULTIPLIERS: Record<SUPPORTED_BUY_CHAINS, BigNumber> = {
+export const THOR_TRADE_FEE_MULTIPLIERS: Record<ChainId, BigNumber> = {
   [KnownChainIds.BitcoinMainnet]: bn(0.00002), // 1000 estimated bytes * 2 (as recommended on discord)
   [KnownChainIds.DogecoinMainnet]: bn(0.00002), // 1000 estimated bytes * 2 (as recommended on discord)
   [KnownChainIds.LitecoinMainnet]: bn(0.000005), // 250 estimated bytes * 2 (as recommended on discord)

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.test.ts
@@ -42,7 +42,7 @@ describe('estimateTradeFee', () => {
       .mockReturnValueOnce(Promise.resolve({ data: [foxMidgardPool, ethMidgardPool] }))
     const estimatedTradeFee = await estimateTradeFee(deps, FOX)
 
-    const expectedResult = '856.785841'
+    const expectedResult = '856.785841407056721352948224'
     expect(estimatedTradeFee).toEqual(expectedResult)
   })
   it('should throw if trying to get fee data for an unsupported buy asset', async () => {

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -6,6 +6,7 @@ import { SwapError, SwapErrorTypes } from '../../../../api'
 import { bn, bnOrZero, fromBaseUnit } from '../../../utils/bignumber'
 import { InboundResponse, ThorchainSwapperDeps } from '../../types'
 import {
+  THORCHAIN_FIXED_PRECISION,
   THOR_TRADE_FEE_BTC_SIZE,
   THOR_TRADE_FEE_DOGE_SIZE,
   THOR_TRADE_FEE_ETH_GAS,
@@ -122,7 +123,7 @@ export const estimateTradeFee = async (
     case KnownChainIds.CosmosMainnet:
       return fromBaseUnit(
         bnOrZero(gaiaEstimate(gasRate)).times(buyFeeAssetRatio).dp(0),
-        8 // because thorchain likes to be inconsistent for no good reason
+        THORCHAIN_FIXED_PRECISION // because thorchain likes to be inconsistent for no good reason
       )
     case KnownChainIds.EthereumMainnet:
       switch (assetNamespace) {

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -1,8 +1,7 @@
-import { Asset, AssetService } from '@shapeshiftoss/asset-service'
+import { Asset } from '@shapeshiftoss/asset-service'
 import { adapters, fromAssetId } from '@shapeshiftoss/caip'
 
 import { SwapError, SwapErrorTypes } from '../../../../api'
-import { fromBaseUnit } from '../../../utils/bignumber'
 import { InboundResponse, ThorchainSwapperDeps } from '../../types'
 import { SUPPORTED_BUY_CHAINS, THOR_TRADE_FEE_MULTIPLIERS } from '../constants'
 import { getPriceRatio } from '../getPriceRatio/getPriceRatio'
@@ -60,13 +59,8 @@ export const estimateTradeFee = async (
         })
       : '1'
 
-  const buyFeeAsset = new AssetService().getAll()[buyFeeAssetId]
-
-  return fromBaseUnit(
-    THOR_TRADE_FEE_MULTIPLIERS[buyChainId as SUPPORTED_BUY_CHAINS]
-      .times(buyFeeAssetRatio)
-      .times(gasRate)
-      .dp(0),
-    buyFeeAsset.precision
-  )
+  return THOR_TRADE_FEE_MULTIPLIERS[buyChainId as SUPPORTED_BUY_CHAINS]
+    .times(buyFeeAssetRatio)
+    .times(gasRate)
+    .toString()
 }

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -6,12 +6,12 @@ import { SwapError, SwapErrorTypes } from '../../../../api'
 import { bn, bnOrZero, fromBaseUnit } from '../../../utils/bignumber'
 import { InboundResponse, ThorchainSwapperDeps } from '../../types'
 import {
-  THORCHAIN_FIXED_PRECISION,
   THOR_TRADE_FEE_BTC_SIZE,
   THOR_TRADE_FEE_DOGE_SIZE,
   THOR_TRADE_FEE_ETH_GAS,
   THOR_TRADE_FEE_GAIA_SIZE,
-  THOR_TRADE_FEE_LTC_SIZE
+  THOR_TRADE_FEE_LTC_SIZE,
+  THORCHAIN_FIXED_PRECISION
 } from '../constants'
 import { getPriceRatio } from '../getPriceRatio/getPriceRatio'
 import { thorService } from '../thorService'

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -3,7 +3,7 @@ import { adapters, fromAssetId } from '@shapeshiftoss/caip'
 
 import { SwapError, SwapErrorTypes } from '../../../../api'
 import { InboundResponse, ThorchainSwapperDeps } from '../../types'
-import { SUPPORTED_BUY_CHAINS, THOR_TRADE_FEE_MULTIPLIERS } from '../constants'
+import { THOR_TRADE_FEE_MULTIPLIERS } from '../constants'
 import { getPriceRatio } from '../getPriceRatio/getPriceRatio'
 import { thorService } from '../thorService'
 
@@ -59,8 +59,10 @@ export const estimateTradeFee = async (
         })
       : '1'
 
-  return THOR_TRADE_FEE_MULTIPLIERS[buyChainId as SUPPORTED_BUY_CHAINS]
-    .times(buyFeeAssetRatio)
-    .times(gasRate)
-    .toString()
+  if (!THOR_TRADE_FEE_MULTIPLIERS[buyChainId])
+    throw new SwapError('[estimateTradeFee] - no trade fee multiplier', {
+      code: SwapErrorTypes.VALIDATION_FAILED,
+      details: { buyChainId }
+    })
+  return THOR_TRADE_FEE_MULTIPLIERS[buyChainId].times(buyFeeAssetRatio).times(gasRate).toString()
 }


### PR DESCRIPTION
- separate `buySupportedChainIds` from `sellSupportedChainIds` so we can easily add new buyAssets without having to implementing the sell logic at the same time.

- Add buy support for `doge` `ltc` `atom`
<img width="405" alt="Screen Shot 2022-08-01 at 5 21 51 PM" src="https://user-images.githubusercontent.com/6187559/182261298-9c1bade2-20ac-41e2-b66e-22831ce2f616.png">


To test:

link locally. enable thorchain ff. enable litecoin ff. see that you can trade into ltc, doge & atom