### PR TITLE
feat: intersect unchained-client StandardTx type with chain-adapters Transaction

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,5 +1,6 @@
 import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
+import { StandardTx } from '@shapeshiftoss/unchained-client'
 
 import {
   Account,
@@ -11,7 +12,6 @@ import {
   SignTxInput,
   SubscribeError,
   SubscribeTxsInput,
-  Transaction,
   TxHistoryInput,
   TxHistoryResponse,
   ValidAddressResult
@@ -47,7 +47,7 @@ export type ChainAdapter<T extends ChainId> = {
 
   buildBIP44Params(params: Partial<BIP44Params>): BIP44Params
 
-  getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse<T>>
+  getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse>
 
   buildSendTransaction(input: BuildSendTxInput<T>): Promise<{
     txToSign: ChainTxType<T>
@@ -67,7 +67,7 @@ export type ChainAdapter<T extends ChainId> = {
 
   subscribeTxs(
     input: SubscribeTxsInput,
-    onMessage: (msg: Transaction<T>) => void,
+    onMessage: (msg: StandardTx) => void,
     onError?: (err: SubscribeError) => void
   ): Promise<void>
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -16,7 +16,6 @@ import {
   SignTxInput,
   SubscribeError,
   SubscribeTxsInput,
-  Transaction,
   TxHistoryInput,
   TxHistoryResponse,
   ValidAddressResult,
@@ -163,7 +162,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     }
   }
 
-  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse<T>> {
+  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
     try {
       const { data } = await this.providers.http.getTxHistory({
         pubkey: input.pubkey,
@@ -239,7 +238,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
 
   async subscribeTxs(
     input: SubscribeTxsInput,
-    onMessage: (msg: Transaction<T>) => void,
+    onMessage: (msg: unchained.StandardTx) => void,
     onError: (err: SubscribeError) => void
   ): Promise<void> {
     const { wallet, bip44Params = this.defaultBIP44Params } = input

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -23,6 +23,7 @@ import {
   ValidAddressResultType
 } from '../types'
 import { toRootDerivationPath } from '../utils'
+import { bnOrZero } from '../utils/bignumber'
 import { cosmos } from './'
 
 const CHAIN_TO_BECH32_PREFIX_MAPPING = {
@@ -191,7 +192,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
               from: transfer.from,
               to: transfer.to,
               type: transfer.type,
-              value: transfer.totalValue
+              value: bnOrZero(transfer.totalValue).toString()
             })),
             data: parsedTx.data
           }
@@ -268,7 +269,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
             from: transfer.from,
             to: transfer.to,
             type: transfer.type,
-            value: transfer.totalValue
+            value: transfer.totalValue ?? '0'
           })),
           txid: tx.txid
         })

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -24,7 +24,6 @@ import {
   SignTxInput,
   SubscribeError,
   SubscribeTxsInput,
-  Transaction,
   TxHistoryInput,
   TxHistoryResponse,
   ValidAddressResult,
@@ -203,7 +202,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     }
   }
 
-  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse<T>> {
+  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
     const { data } = await this.providers.http.getTxHistory({
       pubkey: input.pubkey,
       pageSize: input.pageSize,
@@ -309,7 +308,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
 
   async subscribeTxs(
     input: SubscribeTxsInput,
-    onMessage: (msg: Transaction<T>) => void,
+    onMessage: (msg: unchained.StandardTx) => void,
     onError: (err: SubscribeError) => void
   ): Promise<void> {
     const { wallet, bip44Params = this.defaultBIP44Params } = input

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -231,7 +231,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
             from: transfer.from,
             to: transfer.to,
             type: transfer.type,
-            value: transfer.totalValue
+            value: transfer.totalValue ?? '0'
           })),
           data: parsedTx.data
         }
@@ -339,7 +339,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
             from: transfer.from,
             to: transfer.to,
             type: transfer.type,
-            value: transfer.totalValue
+            value: transfer.totalValue ?? '0'
           })),
           txid: tx.txid,
           data: tx.data

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -7,7 +7,7 @@ import {
   OsmosisSignTx
 } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, ChainSpecific, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
-import { TradeType, TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
+import { StandardTx, TradeType, TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
 
 import * as cosmos from './cosmossdk/cosmos'
 import * as osmosis from './cosmossdk/osmosis'
@@ -127,10 +127,10 @@ export type SubscribeError = {
   message: string
 }
 
-export type TxHistoryResponse<T extends ChainId> = {
+export type TxHistoryResponse = {
   cursor: string
   pubkey: string
-  transactions: Array<Transaction<T>>
+  transactions: Array<StandardTx>
 }
 
 type ChainTxTypeInner = {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -23,7 +23,6 @@ import {
   SignTxInput,
   SubscribeError,
   SubscribeTxsInput,
-  Transaction,
   TxHistoryInput,
   TxHistoryResponse,
   ValidAddressResult,
@@ -334,7 +333,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     }
   }
 
-  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse<T>> {
+  async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
     if (!this.accountAddresses[input.pubkey]) {
       await this.getAccount(input.pubkey)
     }
@@ -410,7 +409,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
   async subscribeTxs(
     input: SubscribeTxsInput,
-    onMessage: (msg: Transaction<T>) => void,
+    onMessage: (msg: unchained.StandardTx) => void,
     onError: (err: SubscribeError) => void
   ): Promise<void> {
     const {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -388,7 +388,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
                 from: transfer.from,
                 to: transfer.to,
                 type: transfer.type,
-                value: transfer.totalValue
+                value: transfer.totalValue ?? '0'
               }))
             }
           })
@@ -446,7 +446,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
             from: transfer.from,
             to: transfer.to,
             type: transfer.type,
-            value: transfer.totalValue
+            value: transfer.totalValue ?? '0'
           })),
           txid: tx.txid
         })

--- a/packages/unchained-client/src/types.ts
+++ b/packages/unchained-client/src/types.ts
@@ -1,3 +1,5 @@
+import { AssetId, ChainId } from '@shapeshiftoss/caip'
+
 // these are user facing values, and should be rendered as such
 export enum Dex {
   Thor = 'THORChain',
@@ -42,9 +44,10 @@ export interface Transfer {
   to: string
   assetId: string
   type: TransferType
-  totalValue: string
-  components: Array<{ value: string }>
+  totalValue?: string
+  components?: Array<{ value: string }>
   token?: Token
+  value?: string
 }
 
 // these are user facing values, and should be rendered as such
@@ -68,6 +71,7 @@ export enum TxParser {
 export interface BaseTxMetadata {
   method?: string
   parser: string
+  assetId?: AssetId
 }
 
 export interface StandardTxMetadata extends BaseTxMetadata {
@@ -79,11 +83,14 @@ export interface StandardTx {
   blockHash?: string
   blockHeight: number
   blockTime: number
+  chain?: ChainId
+  data?: BaseTxMetadata
   chainId: string
   confirmations: number
   fee?: Fee
   status: TxStatus
   trade?: Trade
+  tradeDetails?: Trade
   transfers: Array<Transfer>
   txid: string
 }

--- a/packages/unchained-client/src/utils.ts
+++ b/packages/unchained-client/src/utils.ts
@@ -33,8 +33,10 @@ export function aggregateTransfer(
   const transfer = transfers?.[index]
 
   if (transfer) {
-    transfer.totalValue = new BigNumber(transfer.totalValue).plus(value).toString(10)
-    transfer.components.push({ value })
+    transfer.totalValue = new BigNumber(transfer.totalValue ?? 0).plus(value).toString(10)
+    if (transfer.components) {
+      transfer.components.push({ value })
+    }
     transfers[index] = transfer
   } else {
     transfers = [


### PR DESCRIPTION
### Description

WIP - This adds the fields from chain-adapters `Transaction` type to unchained-client`StandardTx`, to be able to eventually consolidate them and remove the chain-adapters ones.

Note that for now, there is some amount of duplication (e.g `chain` and `chainId`, `tradeDetails` and `trade` until this is consolidated) 

Needed to unrug https://github.com/shapeshift/web/pull/2257

### Issue

- contributes to https://github.com/shapeshift/web/issues/2279
- contributes to the already closed https://github.com/shapeshift/lib/issues/658