### PR TITLE
fix: fix bch swaps and fix detecting swaps into eth assets

### DIFF
--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -194,9 +194,13 @@ export class ThorchainSwapper implements Swapper<ChainId> {
           cause: responseData
         })
 
+      const standardBuyTxid = responseData?.actions[0]?.out[0]?.coins[0]?.asset.startsWith('ETH.')
+        ? `0x${buyTxid}`
+        : buyTxid
+
       return {
         sellTxid: tradeResult.tradeId,
-        buyTxid: buyTxid.toLowerCase()
+        buyTxid: standardBuyTxid.toLowerCase()
       }
     } catch (e) {
       if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/thorchain/types.ts
+++ b/packages/swapper/src/swappers/thorchain/types.ts
@@ -21,7 +21,11 @@ export type PoolResponse = {
   volume24h: string
 }
 
+type MidardCoins = {
+  asset: string
+}[]
 type MidgardActionOut = {
+  coins: MidardCoins
   txID: string
 }
 type MidgardAction = {

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
@@ -27,11 +27,14 @@ export const makeSwapMemo = ({
     })
 
   // bch hack
-  const parsedDestAddress = destinationAddress.includes('bitcoincash:')
+  // Our bitcoin cash addresses are prefixed with `bitcoincash:`
+  // But thorchain memos need to be short (under 80 bytes for utxo)
+  // For this reason thorchain doesnt allow / need bitcoincash: in the memo
+  const parsedDestinationAddress = destinationAddress.includes('bitcoincash:')
     ? destinationAddress.replace('bitcoincash:', '')
     : destinationAddress
 
-  const memo = `s:${thorId}:${parsedDestAddress}:${limit}:${THORCHAIN_AFFILIATE_NAME}:${THORCHAIN_AFFILIATE_BIPS}`
+  const memo = `s:${thorId}:${parsedDestinationAddress}:${limit}:${THORCHAIN_AFFILIATE_NAME}:${THORCHAIN_AFFILIATE_BIPS}`
   if (memo.length <= MAX_LENGTH) return memo
   const abbreviationAmount = memo.length - MAX_LENGTH
 

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
@@ -26,7 +26,12 @@ export const makeSwapMemo = ({
       details: { buyAssetId }
     })
 
-  const memo = `s:${thorId}:${destinationAddress}:${limit}:${THORCHAIN_AFFILIATE_NAME}:${THORCHAIN_AFFILIATE_BIPS}`
+  // bch hack
+  const parsedDestAddress = destinationAddress.includes('bitcoincash:')
+    ? destinationAddress.replace('bitcoincash:', '')
+    : destinationAddress
+
+  const memo = `s:${thorId}:${parsedDestAddress}:${limit}:${THORCHAIN_AFFILIATE_NAME}:${THORCHAIN_AFFILIATE_BIPS}`
   if (memo.length <= MAX_LENGTH) return memo
   const abbreviationAmount = memo.length - MAX_LENGTH
 


### PR DESCRIPTION
1) fix swaps into bch. Memos dont support `bitcoincash:` prefix.

2) fix detecting swaps into eth assets. Eth txids coming back from midgard dont have the 0x prefix and need it added
<img width="442" alt="Screen Shot 2022-08-03 at 6 09 33 PM" src="https://user-images.githubusercontent.com/6187559/182735984-0fdb68cf-0071-44d3-aae5-1359bce45774.png">

