### PR TITLE
feat(swapper): export CowSwapper types

### DIFF
--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -102,3 +102,5 @@ export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
     return cowGetTradeTxs(this.deps, args)
   }
 }
+
+export * from './types'


### PR DESCRIPTION
### Description

This exposes CowSwapper types for client-side consumption, since we need to consume the `feeAmountInSellToken` property which is specific to `CowTrade`.

### Issue

Contributes to https://github.com/shapeshift/web/issues/2271