### PR TITLE
feat(swapper): add isCowTrade typeguard

### DIFF
--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -102,3 +102,5 @@ export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
     return cowGetTradeTxs(this.deps, args)
   }
 }
+
+export * from './utils'

--- a/packages/swapper/src/swappers/cow/utils.ts
+++ b/packages/swapper/src/swappers/cow/utils.ts
@@ -1,0 +1,8 @@
+import { ChainId } from '@shapeshiftoss/caip'
+
+import { Trade } from '../../api'
+import { CowTrade } from './types'
+
+export const isCowTrade = <C extends ChainId>(
+  trade: CowTrade<C> | Trade<C>
+): trade is CowTrade<C> => Boolean((trade as CowTrade<C>).feeAmountInSellToken)


### PR DESCRIPTION
Description

This adds an `isCowTrade` type guard, since we need to consume the feeAmountInSellToken property which is specific to CowTrade.

Issue

Contributes to https://github.com/shapeshift/web/issues/2271