### PR TITLE
chore(unchained-client): use evm tx type

### DIFF
--- a/packages/unchained-client/src/evm/parser/zrx.ts
+++ b/packages/unchained-client/src/evm/parser/zrx.ts
@@ -1,10 +1,7 @@
-import { Tx as AvalancheTx } from '../../generated/avalanche'
-import { Tx as EthTx } from '../../generated/ethereum'
 import { Dex, TradeType } from '../../types'
+import { type Tx } from '../parser/types'
 import { SubParser, txInteractsWithContract, TxSpecific } from '.'
 import { ZRX_PROXY_CONTRACT } from './constants'
-
-type Tx = EthTx | AvalancheTx
 
 export class Parser implements SubParser<Tx> {
   async parse(tx: Tx): Promise<TxSpecific | undefined> {

--- a/packages/unchained-client/src/evm/parser/zrx.ts
+++ b/packages/unchained-client/src/evm/parser/zrx.ts
@@ -1,6 +1,6 @@
 import { Dex, TradeType } from '../../types'
 import { type Tx } from '../parser/types'
-import { SubParser, txInteractsWithContract, TxSpecific } from '.'
+import { type SubParser, type TxSpecific, txInteractsWithContract } from '.'
 import { ZRX_PROXY_CONTRACT } from './constants'
 
 export class Parser implements SubParser<Tx> {


### PR DESCRIPTION
Use existing evm `Tx` type instead of custom union.