### PR TITLE
fix: always return 0 tradeFee for cow swaps

### DIFF
--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -122,7 +122,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
       estimatedGas: '100000',
       gasPrice: '79036500000'
     },
-    tradeFee: '17.95954294012756741283729339486489192096'
+    tradeFee: '0'
   },
   sellAmount: '1000000000000000000',
   buyAmount: '14501811818247595090576', // 14501 FOX
@@ -144,7 +144,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
       gasPrice: '79036500000',
       approvalFee: '7903650000000000'
     },
-    tradeFee: '3.6162531444'
+    tradeFee: '0'
   },
   sellAmount: '100000000',
   buyAmount: '19136098853078932263', // 19.13 WETH
@@ -165,7 +165,7 @@ const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
       estimatedGas: '100000',
       gasPrice: '79036500000'
     },
-    tradeFee: '5.3955565850972847808512'
+    tradeFee: '0'
   },
   sellAmount: '1000000000000000000000',
   buyAmount: '46868859830863283',


### PR DESCRIPTION
### Description

This sets the CowSwap `tradeFee` to 0, and removes the related logic in that component which fetches the sell asset USD rate and calculating the USD fiat value.

According to our web consumption, the logic is wrong, and is not what `tradeFee` should refer to. In lib main currently, `tradeFee` in `cowBuildTrade` refers to `tradeFeeFiat` i.e the amount subtracted from the *sell* asset when swapping, *converted to fiat*

However, this is consumed by web as the amount subtracted from the *buy* asset (e.g native ETH fees) in *crypto*, see:

https://github.com/shapeshift/web/blob/7b9c730c5207659d35842b18dd0d26896a2df446/src/components/Trade/TradeConfirm/TradeConfirm.tsx#L248

Effectively, this means `tradeFee` should always be 0 for cow swaps, and the logic related to the making of this value should be removed.

### Issue

- tackles https://github.com/shapeshift/web/issues/2362 - needs a web PR to close it

### Screenshots

<img width="420" alt="image" src="https://user-images.githubusercontent.com/17035424/183898005-95154b96-53a4-45ad-b6f7-ea3e5654729c.png">