### PR TITLE
feat(swapper): populate CowSwap `sellTxid`

### DIFF
--- a/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.test.ts
+++ b/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.test.ts
@@ -64,7 +64,7 @@ describe('cowGetTradeTxs', () => {
 
     const result = await cowGetTradeTxs(deps, input)
 
-    expect(result).toEqual({ sellTxid: '', buyTxid: '123txHash456' })
+    expect(result).toEqual({ sellTxid: 'tradeId1112345', buyTxid: '123txHash456' })
     expect(cowService.get).toHaveBeenNthCalledWith(
       1,
       'https://api.cow.fi/mainnet/api/v1/orders/tradeId1112345'

--- a/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.ts
+++ b/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.ts
@@ -25,7 +25,7 @@ export async function cowGetTradeTxs(deps: CowSwapperDeps, input: TradeResult): 
     )
 
     return {
-      sellTxid: '',
+      sellTxid: input.tradeId,
       buyTxid: getTradesResponse.data[0].txHash
     }
   } catch (e) {


### PR DESCRIPTION
Fixes an issue where we are not passing a `sellTxid` to `web` for CowSwap trades when `cowGetTradeTxs()` is called, which is causing an exception and preventing the trade confirm screen from being shown once the transaction is complete.

![image](https://user-images.githubusercontent.com/97164662/184071783-302047ce-30a2-4776-8b9e-3e77f7570896.png)

Closes https://github.com/shapeshift/web/issues/2399