### PR TITLE
fix(swapper): thorchainSwapper quote inversion

### DIFF
--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -40,7 +40,7 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
     chainSpecific: { estimatedGas: '100000', approvalFee: '700000', gasPrice: '7' },
     tradeFee: '0.00024'
   },
-  rate: '12755.10204081632653061224',
+  rate: '0.0000784',
   sources: [{ name: 'thorchain', proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -58,17 +58,16 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
         details: { chainId }
       })
 
-    const tradeRate = await getTradeRate(sellAsset, buyAsset.assetId, sellAmount, deps)
-    const rate = bnOrZero(1).div(tradeRate).toString()
+    const rate = await getTradeRate(sellAsset, buyAsset.assetId, sellAmount, deps)
 
     const buyAmount = toBaseUnit(
-      bnOrZero(fromBaseUnit(sellAmount, sellAsset.precision)).times(tradeRate),
+      bnOrZero(fromBaseUnit(sellAmount, sellAsset.precision)).times(rate),
       buyAsset.precision
     )
 
     const tradeFee = await estimateTradeFee(deps, buyAsset)
 
-    const sellAssetTradeFee = bnOrZero(tradeFee).times(bnOrZero(rate))
+    const sellAssetTradeFee = bnOrZero(tradeFee).dividedBy(bnOrZero(rate))
 
     // minimum is tradeFee padded by an amount to be sure they get something back
     // usually it will be slightly more than the amount because sellAssetTradeFee is already a high estimate

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.test.ts
@@ -42,7 +42,7 @@ describe('estimateTradeFee', () => {
       .mockReturnValueOnce(Promise.resolve({ data: [foxMidgardPool, ethMidgardPool] }))
     const estimatedTradeFee = await estimateTradeFee(deps, FOX)
 
-    const expectedResult = '856.785841407056721352948224'
+    const expectedResult = '0.000005270675333037554496'
     expect(estimatedTradeFee).toEqual(expectedResult)
   })
   it('should throw if trying to get fee data for an unsupported buy asset', async () => {

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -54,8 +54,8 @@ export const estimateTradeFee = async (
   const buyFeeAssetRatio =
     buyAsset.assetId !== buyFeeAssetId
       ? await getPriceRatio(deps, {
-          sellAssetId: buyAsset.assetId,
-          buyAssetId: buyFeeAssetId
+          sellAssetId: buyFeeAssetId,
+          buyAssetId: buyAsset.assetId
         })
       : '1'
 

--- a/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/estimateTradeFee/estimateTradeFee.ts
@@ -54,8 +54,8 @@ export const estimateTradeFee = async (
   const buyFeeAssetRatio =
     buyAsset.assetId !== buyFeeAssetId
       ? await getPriceRatio(deps, {
-          sellAssetId: buyFeeAssetId,
-          buyAssetId: buyAsset.assetId
+          sellAssetId: buyAsset.assetId,
+          buyAssetId: buyFeeAssetId
         })
       : '1'
 

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
@@ -5,6 +5,7 @@ import { ThorchainSwapperDeps } from '../../types'
 import { ethMidgardPool, foxMidgardPool } from '../test-data/midgardResponse'
 import { thorService } from '../thorService'
 import { getPriceRatio } from './getPriceRatio'
+
 jest.mock('../thorService')
 
 describe('getPriceRatio', () => {
@@ -23,7 +24,7 @@ describe('getPriceRatio', () => {
 
     const ratio = await getPriceRatio(deps, { buyAssetId: foxId, sellAssetId: ethId })
 
-    const expectedRatio = '0.00007843266864639218'
+    const expectedRatio = '12749.78930665262978203792'
 
     expect(ratio).toEqual(expectedRatio)
   })

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
@@ -30,7 +30,7 @@ export const getPriceRatio = async (
         code: SwapErrorTypes.RESPONSE_ERROR,
         details: { buyPoolId, sellPoolId }
       })
-    return bnOrZero(buyUsdPrice).dividedBy(sellUsdPrice).toString()
+    return bnOrZero(sellUsdPrice).dividedBy(buyUsdPrice).toString()
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[getPriceRatio]: Thorchain getPriceRatio failed', {

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.test.ts
@@ -59,7 +59,7 @@ describe('getTradeRate', () => {
     expect(rate).toEqual(expectedRate)
   })
 
-  it('should throw if trying to caculate a rate for an unsupported asset', async () => {
+  it('should throw if trying to calculate a rate for an unsupported asset', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve({ data: [foxMidgardPool, ethMidgardPool] })
     )


### PR DESCRIPTION
`ThorSwapper`'s `getPriceRatio` is returning an inverted response, which is called when a `sellAmount` of `0` is quoted for.

We then invert it again here:

https://github.com/shapeshift/lib/blob/d3002a6ff2c5a220bf79aa8df08e03d581da2e32/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts#L62

This hides the `getPriceRatio` bug when the `sellAmount` is `0`, e.g. for the initial quote, but then causes an inverted rate when `sellAmount` is _not_ `0`.

**Before** 😕 

<img width="404" alt="Screen Shot 2022-08-12 at 3 35 10 pm" src="https://user-images.githubusercontent.com/97164662/184291132-8f15e555-191d-49de-8e86-04028a98988e.png">

**After** 😌 

<img width="404" alt="Screen Shot 2022-08-12 at 3 35 10 pm" src="https://user-images.githubusercontent.com/97164662/184291202-13708af9-17a0-4606-9d39-e6161e31a9f0.png">

Closes https://github.com/shapeshift/web/issues/2417