### PR TITLE
feat: implement CowSwap approveAmount method

### DIFF
--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -7,13 +7,12 @@ import Web3 from 'web3'
 import {
   ApprovalNeededInput,
   ApprovalNeededOutput,
+  ApproveAmountInput,
   ApproveInfiniteInput,
   BuildTradeInput,
   BuyAssetBySellIdInput,
   ExecuteTradeInput,
   GetTradeQuoteInput,
-  SwapError,
-  SwapErrorTypes,
   Swapper,
   SwapperType,
   TradeQuote,
@@ -21,7 +20,7 @@ import {
   TradeTxs,
 } from '../../api'
 import { cowApprovalNeeded } from './cowApprovalNeeded/cowApprovalNeeded'
-import { cowApproveInfinite } from './cowApproveInfinite/cowApproveInfinite'
+import { cowApproveAmount, cowApproveInfinite } from './cowApprove/cowApprove'
 import { cowBuildTrade } from './cowBuildTrade/cowBuildTrade'
 import { cowExecuteTrade } from './cowExecuteTrade/cowExecuteTrade'
 import { cowGetTradeTxs } from './cowGetTradeTxs/cowGetTradeTxs'
@@ -78,10 +77,8 @@ export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
     return cowApproveInfinite(this.deps, args)
   }
 
-  async approveAmount(): Promise<string> {
-    throw new SwapError('CowSwapper: approveAmount unimplemented', {
-      code: SwapErrorTypes.RESPONSE_ERROR,
-    })
+  async approveAmount(args: ApproveAmountInput<KnownChainIds.EthereumMainnet>): Promise<string> {
+    return cowApproveAmount(this.deps, args)
   }
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {

--- a/packages/swapper/src/swappers/cow/cowApprove/cowApprove.test.ts
+++ b/packages/swapper/src/swappers/cow/cowApprove/cowApprove.test.ts
@@ -3,7 +3,7 @@ import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
-import { cowApproveInfinite } from './/cowApproveInfinite'
+import { cowApproveInfinite } from './cowApprove'
 
 jest.mock('web3')
 jest.mock('../../utils/helpers/helpers', () => ({

--- a/packages/swapper/src/swappers/cow/cowApprove/cowApprove.ts
+++ b/packages/swapper/src/swappers/cow/cowApprove/cowApprove.ts
@@ -1,6 +1,6 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { ApproveInfiniteInput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApproveAmountInput, ApproveInfiniteInput, SwapError, SwapErrorTypes } from '../../../api'
 import { erc20Abi } from '../../utils/abi/erc20-abi'
 import { grantAllowance } from '../../utils/helpers/helpers'
 import { CowSwapperDeps } from '../CowSwapper'
@@ -28,6 +28,33 @@ export async function cowApproveInfinite(
     throw new SwapError('[cowApproveInfinite]', {
       cause: e,
       code: SwapErrorTypes.APPROVE_INFINITE_FAILED,
+    })
+  }
+}
+
+export async function cowApproveAmount(
+  { adapter, web3 }: CowSwapperDeps,
+  { quote, wallet, amount }: ApproveAmountInput<KnownChainIds.EthereumMainnet>,
+) {
+  try {
+    const approvalAmount = amount ?? quote.sellAmount
+    const allowanceGrantRequired = await grantAllowance<KnownChainIds.EthereumMainnet>({
+      quote: {
+        ...quote,
+        sellAmount: approvalAmount,
+      },
+      wallet,
+      adapter,
+      erc20Abi,
+      web3,
+    })
+
+    return allowanceGrantRequired
+  } catch (e) {
+    if (e instanceof SwapError) throw e
+    throw new SwapError('[cowApproveAmount]', {
+      cause: e,
+      code: SwapErrorTypes.APPROVE_AMOUNT_FAILED,
     })
   }
 }


### PR DESCRIPTION
We implemented some approveAmount methods to the API here: https://github.com/shapeshift/lib/pull/962/files#diff-da9b9171daba90b60db4c8919dd419411d0b7b094a101403e8310c743202c7e4

We need to implement the same for CowSwap as it causes an error 

closes #972