### PR TITLE
chore: add zrx and coswap approveAmount tests

### DIFF
--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.test.ts
@@ -11,7 +11,7 @@ import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
 import { getUsdRate } from './utils/helpers/helpers'
 import { setupExecuteTrade } from './utils/test-data/setupZrxSwapQuote'
 import { zrxApprovalNeeded } from './zrxApprovalNeeded/zrxApprovalNeeded'
-import { zrxApproveInfinite } from './zrxApprove/zrxApprove'
+import { zrxApproveAmount, zrxApproveInfinite } from './zrxApprove/zrxApprove'
 import { zrxBuildTrade } from './zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
@@ -38,6 +38,7 @@ jest.mock('./zrxApprovalNeeded/zrxApprovalNeeded', () => ({
 
 jest.mock('./zrxApprove/zrxApprove', () => ({
   zrxApproveInfinite: jest.fn(),
+  zrxApproveAmount: jest.fn(),
 }))
 
 describe('ZrxSwapper', () => {
@@ -96,5 +97,13 @@ describe('ZrxSwapper', () => {
     const args = { quote: tradeQuote, wallet }
     await swapper.approveInfinite(args)
     expect(zrxApproveInfinite).toHaveBeenCalled()
+  })
+
+  it('calls zrxApproveAmount on swapper.approveAmount', async () => {
+    const swapper = new ZrxSwapper(zrxEthereumSwapperDeps)
+    const { tradeQuote } = setupQuote()
+    const args = { quote: tradeQuote, wallet }
+    await swapper.approveAmount(args)
+    expect(zrxApproveAmount).toHaveBeenCalled()
   })
 })

--- a/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.test.ts
@@ -4,7 +4,7 @@ import Web3 from 'web3'
 import { setupDeps } from '../../utils/test-data/setupDeps'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
 import { zrxServiceFactory } from '../utils/zrxService'
-import { zrxApproveInfinite } from './zrxApprove'
+import { zrxApproveAmount, zrxApproveInfinite } from './zrxApprove'
 
 const zrxService = zrxServiceFactory('https://api.0x.org/')
 
@@ -47,5 +47,22 @@ describe('zrxApproveInfinite', () => {
     ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
 
     expect(await zrxApproveInfinite(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
+  })
+})
+
+describe('zrxApproveAmount', () => {
+  const deps = setupDeps()
+  const { tradeQuote } = setupQuote()
+  const wallet = {
+    ethGetAddress: jest.fn(() => Promise.resolve('0xc770eefad204b5180df6a14ee197d99d808ee52d')),
+    ethSignTx: jest.fn(() => Promise.resolve({})),
+  } as unknown as HDWallet
+
+  it('should return a txid', async () => {
+    const data = { allowanceTarget: '10000' }
+    const quote = { ...tradeQuote }
+    ;(zrxService.get as jest.Mock<unknown>).mockReturnValue(Promise.resolve({ data }))
+
+    expect(await zrxApproveAmount(deps, { quote, wallet })).toEqual('grantAllowanceTxId')
   })
 })


### PR DESCRIPTION
We need to wait for https://github.com/shapeshift/lib/pull/976 to be merged in order to add cowswap tests