### PR TITLE
fix: off-by-one allowance check

### DIFF
--- a/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
@@ -37,7 +37,7 @@ export async function cowApprovalNeeded(
     const allowanceOnChain = bnOrZero(allowanceResult)
 
     return {
-      approvalNeeded: allowanceOnChain.lte(bnOrZero(quote.sellAmount)),
+      approvalNeeded: allowanceOnChain.lt(bnOrZero(quote.sellAmount)),
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
@@ -67,7 +67,7 @@ export const thorTradeApprovalNeeded = async ({
         details: { feeData: quote.feeData },
       })
     return {
-      approvalNeeded: allowanceOnChain.lte(bnOrZero(quote.sellAmount)),
+      approvalNeeded: allowanceOnChain.lt(bnOrZero(quote.sellAmount)),
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
@@ -60,7 +60,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
         details: { feeData: quote.feeData },
       })
     return {
-      approvalNeeded: allowanceOnChain.lte(bnOrZero(quote.sellAmount)),
+      approvalNeeded: allowanceOnChain.lt(bnOrZero(quote.sellAmount)),
     }
   } catch (e) {
     if (e instanceof SwapError) throw e


### PR DESCRIPTION
### Description

This fixes the `approvalNeeded` methods that are currently checking for an allowance inclusive *lower than or equal* to the required allowance for a Tx, when they should check for exclusive *lower than* the required allowance for a Tx

### Issue

Relates to the (closed) https://github.com/shapeshift/web/issues/2263 issue