### PR TITLE
feat(swapper): serialize `GetTradeQuoteInput` type args

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -69,7 +69,6 @@ type CommonTradeInput = {
   sellAmount: string
   sendMax: boolean
   sellAssetAccountNumber: number
-  wallet: HDWallet
   receiveAddress: string
 }
 
@@ -99,7 +98,7 @@ export type GetUtxoTradeQuoteInput = CommonTradeInput & {
   chainId: UtxoSupportedChainIds
   accountType: UtxoAccountType
   bip44Params: BIP44Params
-  wallet: HDWallet
+  xpub: string
 }
 
 export type GetTradeQuoteInput =

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -114,7 +114,6 @@ const main = async (): Promise<void> => {
       sellAssetAccountNumber: 0,
       sendMax: false,
       receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-      wallet,
     })
   } catch (e) {
     console.error(e)

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -1,6 +1,5 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { ethereum, FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
-import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
@@ -202,7 +201,6 @@ describe('getCowTradeQuote', () => {
       sellAmount: '11111',
       sendMax: true,
       sellAssetAccountNumber: 1,
-      wallet: <HDWallet>{},
       receiveAddress: '',
     }
 
@@ -219,7 +217,6 @@ describe('getCowTradeQuote', () => {
       sellAmount: '1000000000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
-      wallet: <HDWallet>{},
       receiveAddress: '',
     }
 
@@ -256,7 +253,6 @@ describe('getCowTradeQuote', () => {
       sellAmount: '1000000000000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
-      wallet: <HDWallet>{},
       receiveAddress: '',
     }
 
@@ -293,7 +289,6 @@ describe('getCowTradeQuote', () => {
       sellAmount: '1000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
-      wallet: <HDWallet>{},
       receiveAddress: '',
     }
 

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -28,7 +28,7 @@ export async function getCowSwapTradeQuote(
   input: GetTradeQuoteInput,
 ): Promise<TradeQuote<KnownChainIds.EthereumMainnet>> {
   try {
-    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, wallet } = input
+    const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, receiveAddress } = input
     const { adapter, web3 } = deps
 
     const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } =
@@ -101,8 +101,6 @@ export async function getCowSwapTradeQuote(
     const buyCryptoAmount = bn(quote.buyAmount).div(bn(10).exponentiatedBy(buyAsset.precision))
     const sellCryptoAmount = bn(quote.sellAmount).div(bn(10).exponentiatedBy(sellAsset.precision))
     const rate = buyCryptoAmount.div(sellCryptoAmount).toString()
-
-    const receiveAddress = wallet ? await adapter.getAddress({ wallet }) : DEFAULT_ADDRESS
 
     const data = getApproveContractData({
       web3,

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -84,9 +84,7 @@ export const buildTrade = async ({
         sellAmount,
         slippageTolerance,
         destinationAddress,
-        wallet,
-        bip44Params: (input as GetUtxoTradeQuoteInput).bip44Params,
-        accountType: (input as GetUtxoTradeQuoteInput).accountType,
+        xpub: (input as GetUtxoTradeQuoteInput).xpub,
         tradeFee: quote.feeData.tradeFee,
       })
 

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -33,20 +33,7 @@ type GetThorTradeQuoteReturn = Promise<TradeQuote<ChainId>>
 type GetThorTradeQuote = (args: GetThorTradeQuoteInput) => GetThorTradeQuoteReturn
 
 export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
-  const {
-    sellAsset,
-    buyAsset,
-    sellAmount,
-    sellAssetAccountNumber,
-    wallet,
-    chainId,
-    receiveAddress,
-  } = input
-
-  if (!wallet)
-    throw new SwapError('[getThorTradeQuote] - wallet is required', {
-      code: SwapErrorTypes.VALIDATION_FAILED,
-    })
+  const { sellAsset, buyAsset, sellAmount, sellAssetAccountNumber, chainId, receiveAddress } = input
 
   try {
     const { assetReference: sellAssetErc20Address } = fromAssetId(sellAsset.assetId)
@@ -120,9 +107,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             sellAmount,
             slippageTolerance: DEFAULT_SLIPPAGE,
             destinationAddress: receiveAddress,
-            wallet,
-            bip44Params: (input as GetUtxoTradeQuoteInput).bip44Params,
-            accountType: (input as GetUtxoTradeQuoteInput).accountType,
+            xpub: (input as GetUtxoTradeQuoteInput).xpub,
             tradeFee,
           })
 

--- a/packages/swapper/src/swappers/thorchain/utils/bitcoin/utils/getThorTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/bitcoin/utils/getThorTxData.ts
@@ -1,9 +1,6 @@
 import { Asset } from '@shapeshiftoss/asset-service'
-import { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
-import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
 
-import { SwapError, SwapErrorTypes, UtxoSupportedChainIds } from '../../../../../api'
+import { SwapError, SwapErrorTypes } from '../../../../../api'
 import { InboundResponse, ThorchainSwapperDeps } from '../../../types'
 import { getLimit } from '../../getLimit/getLimit'
 import { makeSwapMemo } from '../../makeSwapMemo/makeSwapMemo'
@@ -16,9 +13,7 @@ type GetBtcThorTxInfoArgs = {
   sellAmount: string
   slippageTolerance: string
   destinationAddress: string
-  wallet: HDWallet
-  bip44Params: BIP44Params
-  accountType: UtxoAccountType
+  xpub: string
   tradeFee: string
 }
 type GetBtcThorTxInfoReturn = Promise<{
@@ -35,9 +30,7 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
   sellAmount,
   slippageTolerance,
   destinationAddress,
-  wallet,
-  bip44Params,
-  accountType,
+  xpub,
   tradeFee,
 }) => {
   try {
@@ -74,16 +67,10 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
       limit,
     })
 
-    const adapter = deps.adapterManager.get(
-      sellAsset.chainId,
-    ) as unknown as UtxoBaseAdapter<UtxoSupportedChainIds>
-
-    const pubkey = await adapter.getPublicKey(wallet, bip44Params, accountType)
-
     return {
       opReturnData: memo,
       vault,
-      pubkey: pubkey.xpub,
+      pubkey: xpub,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -30,7 +30,6 @@ export const setupQuote = () => {
     sellAssetAccountNumber: 0,
     sendMax: false,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-    wallet: {} as HDWallet,
   }
   return { quoteInput, tradeQuote, buyAsset, sellAsset }
 }


### PR DESCRIPTION
Serialize `GetTradeQuoteInput` type args so we can use `getTradeQuote` with RTK query, which only supports serializable arguments.

A `HDWallet` object isn't actually needed.

This is a breaking change for `@shapeshiftoss/swapper`.

Follow-up `web` PR to support the breaking change: https://github.com/shapeshift/web/pull/2555

Contributes to https://github.com/shapeshift/web/issues/2556