### PR TITLE
chore: buildSendTx requires BIP44Params

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -166,6 +166,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
            for the reader. */
       } as Account<T>
     } catch (err) {
+      console.error('error retrieving cosmos account: ', err)
       return ErrorHandler(err)
     }
   }

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -163,7 +163,7 @@ export type BuildSendTxInput<T extends ChainId> = {
   to: string
   value: string
   wallet: HDWallet
-  bip44Params?: BIP44Params // TODO maybe these shouldnt be optional
+  bip44Params: BIP44Params
   sendMax?: boolean
   memo?: string
 } & ChainSpecificBuildTxData<T>

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -108,6 +108,7 @@ export type GetTradeQuoteInput =
 
 export type BuildTradeInput = GetTradeQuoteInput & {
   slippage?: string
+  bip44Params: BIP44Params
   wallet: HDWallet
 }
 

--- a/packages/swapper/src/swappercli.ts
+++ b/packages/swapper/src/swappercli.ts
@@ -1,5 +1,5 @@
 import { AssetService } from '@shapeshiftoss/asset-service'
-import { ethereum } from '@shapeshiftoss/chain-adapters'
+import { ethereum, EvmBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { NativeAdapterArgs, NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -133,8 +133,10 @@ const main = async (): Promise<void> => {
     } on ${swapper.getType()}? (y/n): `,
   )
   if (answer === 'y') {
+    const bip44Params = EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 })
     const trade = await swapper.buildTrade({
       chainId: KnownChainIds.EthereumMainnet,
+      bip44Params,
       wallet,
       buyAsset,
       sendMax: false,

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -1,5 +1,5 @@
 import { Asset } from '@shapeshiftoss/asset-service'
-import { ethereum, FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
+import { ethereum, EvmBaseAdapter, FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
@@ -196,6 +196,7 @@ describe('cowBuildTrade', () => {
       sellAmount: '11111',
       sendMax: true,
       sellAssetAccountNumber: 1,
+      bip44Params: EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 }),
       wallet: <HDWallet>{},
       receiveAddress: '',
     }
@@ -213,6 +214,7 @@ describe('cowBuildTrade', () => {
       sellAmount: '1000000000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
+      bip44Params: EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 }),
       wallet: <HDWallet>{},
       receiveAddress: '',
     }
@@ -250,6 +252,7 @@ describe('cowBuildTrade', () => {
       sellAmount: '100000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
+      bip44Params: EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 }),
       wallet: <HDWallet>{},
       receiveAddress: '',
     }
@@ -287,6 +290,7 @@ describe('cowBuildTrade', () => {
       sellAmount: '1000000000000000000000',
       sendMax: true,
       sellAssetAccountNumber: 0,
+      bip44Params: EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 }),
       wallet: <HDWallet>{},
       receiveAddress: '',
     }

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -30,6 +30,7 @@ export const buildTrade = async ({
       sellAsset,
       sellAssetAccountNumber,
       sellAmount,
+      bip44Params,
       wallet,
       slippage: slippageTolerance = DEFAULT_SLIPPAGE,
       receiveAddress: destinationAddress,
@@ -111,6 +112,7 @@ export const buildTrade = async ({
       }
     } else if (chainNamespace === CHAIN_NAMESPACE.Cosmos) {
       const txData = await cosmosTxData({
+        bip44Params,
         deps,
         sellAdapter: sellAdapter as unknown as cosmos.ChainAdapter,
         sellAmount,

--- a/packages/swapper/src/swappers/thorchain/utils/cosmos/cosmosTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/cosmos/cosmosTxData.ts
@@ -2,7 +2,7 @@ import { Asset } from '@shapeshiftoss/asset-service'
 import { ChainId } from '@shapeshiftoss/caip'
 import { ChainAdapter, cosmos } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 
 import { SwapError, SwapErrorTypes, TradeQuote } from '../../../../api'
 import { InboundResponse, ThorchainSwapperDeps } from '../../types'
@@ -11,6 +11,7 @@ import { makeSwapMemo } from '../makeSwapMemo/makeSwapMemo'
 import { thorService } from '../thorService'
 
 export const cosmosTxData = async (input: {
+  bip44Params: BIP44Params
   destinationAddress: string
   deps: ThorchainSwapperDeps
   sellAmount: string
@@ -23,6 +24,7 @@ export const cosmosTxData = async (input: {
   sellAdapter: ChainAdapter<KnownChainIds.CosmosMainnet>
 }) => {
   const {
+    bip44Params,
     deps,
     destinationAddress,
     sellAmount,
@@ -66,6 +68,7 @@ export const cosmosTxData = async (input: {
   const buildTxResponse = await (
     sellAdapter as unknown as cosmos.ChainAdapter
   ).buildSendTransaction({
+    bip44Params,
     value: sellAmount,
     wallet,
     to: vault,

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -1,4 +1,5 @@
 import { Asset } from '@shapeshiftoss/asset-service'
+import { EvmBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
@@ -37,6 +38,7 @@ export const setupQuote = () => {
 export const setupBuildTrade = () => {
   const sellAsset: Asset = { ...FOX }
   const buyAsset: Asset = { ...WETH }
+  const bip44Params = EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 })
   const buildTradeInput: BuildTradeInput = {
     chainId: KnownChainIds.EthereumMainnet,
     sellAmount: '1000000000000000000',
@@ -44,6 +46,7 @@ export const setupBuildTrade = () => {
     sendMax: false,
     sellAssetAccountNumber: 0,
     sellAsset,
+    bip44Params,
     wallet: <HDWallet>{},
     receiveAddress: '',
   }

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -1,4 +1,4 @@
-import { ethereum } from '@shapeshiftoss/chain-adapters'
+import { ethereum, EvmBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -73,6 +73,7 @@ describe('zrxBuildTrade', () => {
     buyAsset,
     sellAmount: '1000000000000000000',
     sellAssetAccountNumber: 0,
+    bip44Params: EvmBaseAdapter.prototype.getBIP44Params({ accountNumber: 0 }),
     wallet,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
   }


### PR DESCRIPTION
Building a Send Transaction for any supported chain now requires BIP44Params