### PR TITLE
feat: use CHAIN_NAMESPACE.Evm & CHAIN_NAMESPACE.CosmosSdk

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -37,12 +37,12 @@
     "node-polyglot": "^2.4.2"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
     "@ethersproject/providers": "^5.5.3",
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/investor-idle": "^1.0.0",
     "@types/node-polyglot": "^2.4.2",

--- a/packages/asset-service/src/service/TrustWalletService.ts
+++ b/packages/asset-service/src/service/TrustWalletService.ts
@@ -15,7 +15,7 @@ export const generateTrustWalletUrl = (assetId: AssetId) => {
   if (chainReference) {
     url += `/assets/`
     switch (chainNamespace) {
-      case CHAIN_NAMESPACE.Ethereum:
+      case CHAIN_NAMESPACE.Evm:
         url += Web3.utils.toChecksumAddress(assetReference)
         break
     }

--- a/packages/caip/README.md
+++ b/packages/caip/README.md
@@ -12,7 +12,7 @@ Usage
 ### `toChainId` | `toCAIP2`
 
 ```ts
-const chainNamespace = CHAIN_NAMESPACE.Ethereum
+const chainNamespace = CHAIN_NAMESPACE.Evm
 const chainReference = CHAIN_REFERENCE.EthereumMainnet
 const result = toChainId({ chainNamespace, chainReference })
 expect(result).toEqual('eip155:1')
@@ -23,7 +23,7 @@ expect(result).toEqual('eip155:1')
 ```ts
 const ethereumChainId = 'eip155:1'
 const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
-expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
 expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumMainnet)
 ```
 
@@ -36,7 +36,7 @@ Usage
 ### `toAccountId` | `toCAIP10`
 
 ```ts
-const chainNamespace = CHAIN_NAMESPACE.Ethereum
+const chainNamespace = CHAIN_NAMESPACE.Evm
 const chainReference = CHAIN_REFERENCE.EthereumMainnet
 const chainId = toChainId({ chainNamespace, chainReference })
 const account = '0xa44c286ba83bb771cd0107b2c1df678435bd1535'
@@ -67,7 +67,7 @@ Usage
 Ether
 
 ```ts
-const chainNamespace = CHAIN_NAMESPACE.Ethereum
+const chainNamespace = CHAIN_NAMESPACE.Evm
 const chainReference = CHAIN_REFERENCE.EthereumMainnet
 const chainId = toChainId({ chainNamespace, chainReference })
 const assetNamespace = 'slip44'
@@ -79,7 +79,7 @@ expect(toAssetId({ chainId, assetNamespace, assetReference })).toEqual('eip155:1
 ERC20 token
 
 ```ts
-const chainNamespace = CHAIN_NAMESPACE.Ethereum
+const chainNamespace = CHAIN_NAMESPACE.Evm
 const chainReference = CHAIN_REFERENCE.EthereumMainnet
 const chainId = toChainId({ chainNamespace, chainReference })
 const assetNamespace = 'erc20'

--- a/packages/caip/src/accountId/accountId.test.ts
+++ b/packages/caip/src/accountId/accountId.test.ts
@@ -17,7 +17,7 @@ describe('toAccountId', () => {
   })
 
   it('throws on empty account', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainNamespace = CHAIN_NAMESPACE.Evm
     const chainReference = CHAIN_REFERENCE.EthereumMainnet
     const chainId = toChainId({ chainNamespace, chainReference })
     const account = ''
@@ -26,7 +26,7 @@ describe('toAccountId', () => {
   })
 
   it('accepts valid eth chainId and account', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainNamespace = CHAIN_NAMESPACE.Evm
     const chainReference = CHAIN_REFERENCE.EthereumMainnet
     const chainId = toChainId({ chainNamespace, chainReference })
     const account = '0xa44c286ba83bb771cd0107b2c1df678435bd1535'
@@ -36,7 +36,7 @@ describe('toAccountId', () => {
   })
 
   it('lowercases eth address', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainNamespace = CHAIN_NAMESPACE.Evm
     const chainReference = CHAIN_REFERENCE.EthereumMainnet
     const chainId = toChainId({ chainNamespace, chainReference })
     const account = '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535'
@@ -90,7 +90,7 @@ describe('fromAccountId', () => {
     const accountId = 'eip155:1:0xa44c286ba83bb771cd0107b2c1df678435bd1535'
     const { account, chainId, chainNamespace, chainReference } = fromAccountId(accountId)
     const expectedAccount = '0xa44c286ba83bb771cd0107b2c1df678435bd1535'
-    const expectedChainNamespace = CHAIN_NAMESPACE.Ethereum
+    const expectedChainNamespace = CHAIN_NAMESPACE.Evm
     const expectedChainReference = CHAIN_REFERENCE.EthereumMainnet
     expect(account).toEqual(expectedAccount)
     expect(chainNamespace).toEqual(expectedChainNamespace)
@@ -102,7 +102,7 @@ describe('fromAccountId', () => {
     const accountId = 'eip155:1:0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535'
     const { account, chainId, chainNamespace, chainReference } = fromAccountId(accountId)
     const expectedAccount = '0xa44c286ba83bb771cd0107b2c1df678435bd1535'
-    const expectedChainNamespace = CHAIN_NAMESPACE.Ethereum
+    const expectedChainNamespace = CHAIN_NAMESPACE.Evm
     const expectedChainReference = CHAIN_REFERENCE.EthereumMainnet
     expect(account).toEqual(expectedAccount)
     expect(chainNamespace).toEqual(expectedChainNamespace)

--- a/packages/caip/src/accountId/accountId.ts
+++ b/packages/caip/src/accountId/accountId.ts
@@ -40,8 +40,7 @@ export const toAccountId: ToAccountId = ({
   // we lowercase eth accounts as per the draft spec
   // it's not explicit, but cHecKsUM can be recovered from lowercase eth accounts
   // we don't lowercase bitcoin addresses as they'll fail checksum
-  const outputAccount =
-    chainNamespace === CHAIN_NAMESPACE.Ethereum ? account.toLowerCase() : account
+  const outputAccount = chainNamespace === CHAIN_NAMESPACE.Evm ? account.toLowerCase() : account
 
   return `${chainId}:${outputAccount}`
 }
@@ -77,8 +76,7 @@ export const fromAccountId: FromAccountId = (accountId) => {
   // we lowercase eth accounts as per the draft spec
   // it's not explicit, but cHecKsUM can be recovered from lowercase eth accounts
   // we don't lowercase bitcoin addresses as they'll fail checksum
-  const outputAccount =
-    chainNamespace === CHAIN_NAMESPACE.Ethereum ? account.toLowerCase() : account
+  const outputAccount = chainNamespace === CHAIN_NAMESPACE.Evm ? account.toLowerCase() : account
 
   return { chainId, account: outputAccount, chainNamespace, chainReference }
 }

--- a/packages/caip/src/adapters/coincap/index.test.ts
+++ b/packages/caip/src/adapters/coincap/index.test.ts
@@ -39,7 +39,7 @@ describe('adapters:coincap', () => {
   })
 
   it('can get AssetId for cosmos', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
     const assetId = toAssetId({
       chainNamespace,
@@ -51,7 +51,7 @@ describe('adapters:coincap', () => {
   })
 
   it('can get AssetId for osmosis', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.OsmosisMainnet
     const assetId = toAssetId({
       chainNamespace,
@@ -97,7 +97,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for cosmos AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -109,7 +109,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for osmosis AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,

--- a/packages/caip/src/adapters/coincap/index.test.ts
+++ b/packages/caip/src/adapters/coincap/index.test.ts
@@ -17,7 +17,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get AssetId id for ethereum', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -29,7 +29,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get AssetId id for FOX', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const assetReference = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
@@ -76,7 +76,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for ethereum AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -88,7 +88,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for FOX', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const assetReference = '0xc770eefad204b5180df6a14ee197d99d808ee52d'

--- a/packages/caip/src/adapters/coincap/utils.ts
+++ b/packages/caip/src/adapters/coincap/utils.ts
@@ -57,7 +57,7 @@ export const parseEthData = (data: CoinCapCoin[]) => {
   )
 
   return ethCoins.reduce((acc, { id, explorer }) => {
-    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainNamespace = CHAIN_NAMESPACE.Evm
     const chainReference = CHAIN_REFERENCE.EthereumMainnet
     let assetReference: string = ASSET_REFERENCE.Ethereum
     const assetNamespace = id === 'ethereum' ? 'slip44' : 'erc20'

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -29,7 +29,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds id for ethereum', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -41,7 +41,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds id for FOX', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const assetReference = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
@@ -74,7 +74,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds for USD Coin on Ethereum and Avalanche', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const assetNamespace = 'erc20'
       const usdcEth = toAssetId({
         chainNamespace,
@@ -106,7 +106,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for ethereum AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -118,7 +118,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for FOX', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const assetReference = '0xc770eefad204b5180df6a14ee197d99d808ee52d'

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -50,7 +50,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds for cosmos', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -62,7 +62,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -127,7 +127,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for cosmos AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -139,7 +139,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for osmosis AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -52,7 +52,7 @@ export const chainIdToCoingeckoAssetPlatform = (chainId: ChainId): string => {
             `chainNamespace ${chainNamespace}, chainReference ${chainReference} not supported.`,
           )
       }
-    case CHAIN_NAMESPACE.Cosmos:
+    case CHAIN_NAMESPACE.CosmosSdk:
       switch (chainReference) {
         case CHAIN_REFERENCE.CosmosHubMainnet:
           return CoingeckoAssetPlatform.Cosmos

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -41,7 +41,7 @@ export const assetIdToCoingecko = (assetId: AssetId): CoinGeckoId | undefined =>
 export const chainIdToCoingeckoAssetPlatform = (chainId: ChainId): string => {
   const { chainNamespace, chainReference } = fromChainId(chainId)
   switch (chainNamespace) {
-    case CHAIN_NAMESPACE.Ethereum:
+    case CHAIN_NAMESPACE.Evm:
       switch (chainReference) {
         case CHAIN_REFERENCE.EthereumMainnet:
           return CoingeckoAssetPlatform.Ethereum

--- a/packages/caip/src/adapters/coingecko/utils.ts
+++ b/packages/caip/src/adapters/coingecko/utils.ts
@@ -43,7 +43,7 @@ export const parseData = (coins: CoingeckoCoin[]): AssetMap => {
       if (Object.keys(platforms).includes('ethereum')) {
         try {
           const assetId = toAssetId({
-            chainNamespace: CHAIN_NAMESPACE.Ethereum,
+            chainNamespace: CHAIN_NAMESPACE.Evm,
             chainReference: CHAIN_REFERENCE.EthereumMainnet,
             assetNamespace: 'erc20',
             assetReference: platforms.ethereum,
@@ -57,7 +57,7 @@ export const parseData = (coins: CoingeckoCoin[]): AssetMap => {
       if (Object.keys(platforms).includes('avalanche')) {
         try {
           const assetId = toAssetId({
-            chainNamespace: CHAIN_NAMESPACE.Ethereum,
+            chainNamespace: CHAIN_NAMESPACE.Evm,
             chainReference: CHAIN_REFERENCE.AvalancheCChain,
             assetNamespace: 'erc20',
             assetReference: platforms.avalanche,

--- a/packages/caip/src/adapters/osmosis/index.test.ts
+++ b/packages/caip/src/adapters/osmosis/index.test.ts
@@ -3,7 +3,7 @@ import { ASSET_REFERENCE, CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../../constan
 import { assetIdToOsmosis, osmosisToAssetId } from '.'
 
 describe('osmosis adapter', () => {
-  const chainNamespace = CHAIN_NAMESPACE.Cosmos
+  const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
   const chainReference = CHAIN_REFERENCE.OsmosisMainnet
 
   describe('osmosisToAssetId', () => {

--- a/packages/caip/src/adapters/osmosis/utils.ts
+++ b/packages/caip/src/adapters/osmosis/utils.ts
@@ -45,7 +45,7 @@ export const parseOsmosisData = (data: OsmosisCoin[]) => {
       assetNamespace = 'ibc'
     }
 
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.OsmosisMainnet
     const assetId = toAssetId({ chainNamespace, chainReference, assetNamespace, assetReference })
 
@@ -58,7 +58,7 @@ export const parseOsmosisData = (data: OsmosisCoin[]) => {
 
 export const parseData = (d: OsmosisCoin[]) => {
   const osmosisMainnet = toChainId({
-    chainNamespace: CHAIN_NAMESPACE.Cosmos,
+    chainNamespace: CHAIN_NAMESPACE.CosmosSdk,
     chainReference: CHAIN_REFERENCE.OsmosisMainnet,
   })
 

--- a/packages/caip/src/adapters/yearn/index.test.ts
+++ b/packages/caip/src/adapters/yearn/index.test.ts
@@ -7,7 +7,7 @@ import { assetIdToYearn, yearnToAssetId } from '.'
 describe('adapters:yearn', () => {
   describe('yearnToAssetId', () => {
     it('can get AssetId id for yvUSDC 0.3.0', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const checksumAddress = '0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9'
@@ -22,7 +22,7 @@ describe('adapters:yearn', () => {
   })
   describe('AssetIdToYearn', () => {
     it('can get coincap id for yvUSDC 0.3.0', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetNamespace = 'erc20'
       const checksumAddress = '0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9'

--- a/packages/caip/src/adapters/yearn/utils.ts
+++ b/packages/caip/src/adapters/yearn/utils.ts
@@ -34,7 +34,7 @@ export const fetchData = async () => {
 
 export const parseEthData = (data: (Token | Vault)[]) => {
   const assetNamespace = 'erc20'
-  const chainNamespace = CHAIN_NAMESPACE.Ethereum
+  const chainNamespace = CHAIN_NAMESPACE.Evm
   const chainReference = CHAIN_REFERENCE.EthereumMainnet
 
   return data.reduce((acc, datum) => {
@@ -54,7 +54,7 @@ export const parseEthData = (data: (Token | Vault)[]) => {
 
 export const parseData = (d: (Token | Vault)[]) => {
   const ethMainnet = toChainId({
-    chainNamespace: CHAIN_NAMESPACE.Ethereum,
+    chainNamespace: CHAIN_NAMESPACE.Evm,
     chainReference: CHAIN_REFERENCE.EthereumMainnet,
   })
   return { [ethMainnet]: parseEthData(d) }

--- a/packages/caip/src/assetId/assetId.test.ts
+++ b/packages/caip/src/assetId/assetId.test.ts
@@ -103,7 +103,7 @@ describe('assetId', () => {
     })
 
     it('can make Cosmos AssetId on CosmosHub mainnet', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -120,7 +120,7 @@ describe('assetId', () => {
     })
 
     it('can make Osmosis AssetId on Osmosis mainnet with slip44 reference', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -137,7 +137,7 @@ describe('assetId', () => {
     })
 
     it('can return ibc AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -155,7 +155,7 @@ describe('assetId', () => {
     })
 
     it('can return native AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -172,7 +172,7 @@ describe('assetId', () => {
     })
 
     it('can return cw20 AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -189,7 +189,7 @@ describe('assetId', () => {
     })
 
     it('can return cw721 AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -206,7 +206,7 @@ describe('assetId', () => {
     })
 
     it('can make Cosmos AssetId on CosmosHub vega', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubVega
       const assetIdArgSuperset = {
         chainNamespace,
@@ -223,7 +223,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid Cosmos network', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.BitcoinTestnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -239,7 +239,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid Cosmos slip44 reference', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -454,17 +454,32 @@ describe('assetId', () => {
           erc20,
           '0xc770eefad204b5180df6a14ee197d99d808ee52d',
         ],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.CosmosHubMainnet, slip44, ASSET_REFERENCE.Cosmos],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.CosmosHubVega, slip44, ASSET_REFERENCE.Cosmos],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisMainnet, slip44, ASSET_REFERENCE.Osmosis],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisTestnet, slip44, ASSET_REFERENCE.Osmosis],
         [
-          CHAIN_NAMESPACE.Cosmos,
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.CosmosHubMainnet,
+          slip44,
+          ASSET_REFERENCE.Cosmos,
+        ],
+        [CHAIN_NAMESPACE.CosmosSdk, CHAIN_REFERENCE.CosmosHubVega, slip44, ASSET_REFERENCE.Cosmos],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.OsmosisMainnet,
+          slip44,
+          ASSET_REFERENCE.Osmosis,
+        ],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.OsmosisTestnet,
+          slip44,
+          ASSET_REFERENCE.Osmosis,
+        ],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
           CHAIN_REFERENCE.OsmosisMainnet,
           ibc,
           '346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593',
         ],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisMainnet, native, 'uion'],
+        [CHAIN_NAMESPACE.CosmosSdk, CHAIN_REFERENCE.OsmosisMainnet, native, 'uion'],
       ])(
         'returns a AssetId from the result of fromAssetId for %s',
         (
@@ -580,7 +595,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:cosmoshub-4/slip44:118'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -591,7 +606,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/slip44:118'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -603,7 +618,7 @@ describe('assetId', () => {
         'cosmos:osmosis-1/ibc:346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('ibc')
@@ -616,7 +631,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/cw20:canlab'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('cw20')
@@ -627,7 +642,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/cw721:osmokitty'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('cw721')

--- a/packages/caip/src/assetId/assetId.test.ts
+++ b/packages/caip/src/assetId/assetId.test.ts
@@ -37,7 +37,7 @@ describe('assetId', () => {
     })
 
     it('can make eth AssetId on mainnet', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -54,7 +54,7 @@ describe('assetId', () => {
     })
 
     it('can make eth AssetId on ropsten', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumRopsten
       const assetIdArgSuperset = {
         chainNamespace,
@@ -71,7 +71,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid eth network', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.CosmosHubVega
       const assetIdArgSuperset = {
         chainNamespace,
@@ -87,7 +87,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid namespace', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -271,7 +271,7 @@ describe('assetId', () => {
     })
 
     it('can make FOX AssetId on mainnet', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -288,7 +288,7 @@ describe('assetId', () => {
     })
 
     it('should lower case ERC20 asset references', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -305,7 +305,7 @@ describe('assetId', () => {
     })
 
     it('should lower case ERC721 asset references', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -322,7 +322,7 @@ describe('assetId', () => {
     })
 
     it('can make FOX AssetId on ropsten', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumRopsten
       const assetIdArgSuperset = {
         chainNamespace,
@@ -339,7 +339,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid assetReference length', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -355,7 +355,7 @@ describe('assetId', () => {
     })
 
     it('throws with no assetReference string', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -371,7 +371,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid assetReference string', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -387,7 +387,7 @@ describe('assetId', () => {
     })
 
     it('throws if no asset namespace provided', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -446,20 +446,10 @@ describe('assetId', () => {
       it.each([
         [CHAIN_NAMESPACE.Utxo, CHAIN_REFERENCE.BitcoinMainnet, slip44, ASSET_REFERENCE.Bitcoin],
         [CHAIN_NAMESPACE.Utxo, CHAIN_REFERENCE.BitcoinTestnet, slip44, ASSET_REFERENCE.Bitcoin],
+        [CHAIN_NAMESPACE.Evm, CHAIN_REFERENCE.EthereumMainnet, slip44, ASSET_REFERENCE.Ethereum],
+        [CHAIN_NAMESPACE.Evm, CHAIN_REFERENCE.EthereumRopsten, slip44, ASSET_REFERENCE.Ethereum],
         [
-          CHAIN_NAMESPACE.Ethereum,
-          CHAIN_REFERENCE.EthereumMainnet,
-          slip44,
-          ASSET_REFERENCE.Ethereum,
-        ],
-        [
-          CHAIN_NAMESPACE.Ethereum,
-          CHAIN_REFERENCE.EthereumRopsten,
-          slip44,
-          ASSET_REFERENCE.Ethereum,
-        ],
-        [
-          CHAIN_NAMESPACE.Ethereum,
+          CHAIN_NAMESPACE.Evm,
           CHAIN_REFERENCE.EthereumMainnet,
           erc20,
           '0xc770eefad204b5180df6a14ee197d99d808ee52d',
@@ -502,7 +492,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:1/slip44:60'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -513,7 +503,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:3/slip44:60'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRopsten)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -546,7 +536,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('erc20')
@@ -557,7 +547,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:3/erc20:0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRopsten)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('erc20')
@@ -568,7 +558,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:3/erc721:0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRopsten)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('erc721')
@@ -579,7 +569,7 @@ describe('assetId', () => {
       const AssetId = 'eip155:3/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRopsten)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('erc20')

--- a/packages/caip/src/chainId/chainId.test.ts
+++ b/packages/caip/src/chainId/chainId.test.ts
@@ -9,28 +9,28 @@ describe('chainId', () => {
   })
   describe('toChainId', () => {
     it('can turn CosmosHub mainnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:cosmoshub-4')
     })
 
     it('can turn CosmosHub testnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubVega
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:vega-testnet')
     })
 
     it('can turn Osmosis mainnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:osmosis-1')
     })
 
     it('can turn Osmosis testnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisTestnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:osmo-testnet-1')
@@ -107,14 +107,14 @@ describe('chainId', () => {
     it('can turn CosmosHub mainnet to chain and network', () => {
       const cosmosHubChainId = 'cosmos:cosmoshub-4'
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubMainnet)
     })
 
     it('can turn CosmosHub testnet to chain and network', () => {
       const cosmosHubChainId = 'cosmos:vega-testnet'
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubVega)
     })
 
@@ -135,14 +135,14 @@ describe('chainId', () => {
     it('can turn Osmosis mainnet to chain and network', () => {
       const osmosisChainId = 'cosmos:osmosis-1'
       const { chainNamespace, chainReference } = fromChainId(osmosisChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
     })
 
     it('can turn Osmosis testnet to chain and network', () => {
       const osmosisChainId = 'cosmos:osmo-testnet-1'
       const { chainNamespace, chainReference } = fromChainId(osmosisChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisTestnet)
     })
 

--- a/packages/caip/src/chainId/chainId.test.ts
+++ b/packages/caip/src/chainId/chainId.test.ts
@@ -37,14 +37,14 @@ describe('chainId', () => {
     })
 
     it('can turn Ethereum mainnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumMainnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('eip155:1')
     })
 
     it('can turn Ethereum testnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Ethereum
+      const chainNamespace = CHAIN_NAMESPACE.Evm
       const chainReference = CHAIN_REFERENCE.EthereumRopsten
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('eip155:3')
@@ -149,7 +149,7 @@ describe('chainId', () => {
     it('can turn Ethereum mainnet to chain and network', () => {
       const ethereumChainId = 'eip155:1'
       const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumMainnet)
     })
 
@@ -170,14 +170,14 @@ describe('chainId', () => {
     it('can turn Ethereum ropsten to chain and network', () => {
       const ethereumChainId = 'eip155:3'
       const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRopsten)
     })
 
     it('can turn Ethereum rinkeby to chain and network', () => {
       const ethereumChainId = 'eip155:4'
       const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Ethereum)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRinkeby)
     })
 

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -24,7 +24,7 @@ export const cosmosChainId: ChainId = 'cosmos:cosmoshub-4'
 export const osmosisChainId: ChainId = 'cosmos:osmosis-1'
 
 export const CHAIN_NAMESPACE = {
-  Ethereum: 'eip155',
+  Evm: 'eip155',
   Utxo: 'bip122',
   Cosmos: 'cosmos',
 } as const
@@ -60,7 +60,7 @@ export const VALID_CHAIN_IDS: ValidChainMap = Object.freeze({
     CHAIN_REFERENCE.DogecoinMainnet,
     CHAIN_REFERENCE.LitecoinMainnet,
   ],
-  [CHAIN_NAMESPACE.Ethereum]: [
+  [CHAIN_NAMESPACE.Evm]: [
     CHAIN_REFERENCE.EthereumMainnet,
     CHAIN_REFERENCE.EthereumRopsten,
     CHAIN_REFERENCE.EthereumRinkeby,
@@ -80,7 +80,7 @@ type ValidAssetNamespace = {
 
 export const VALID_ASSET_NAMESPACE: ValidAssetNamespace = Object.freeze({
   [CHAIN_NAMESPACE.Utxo]: ['slip44'],
-  [CHAIN_NAMESPACE.Ethereum]: ['slip44', 'erc20', 'erc721'],
+  [CHAIN_NAMESPACE.Evm]: ['slip44', 'erc20', 'erc721'],
   [CHAIN_NAMESPACE.Cosmos]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
 })
 

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -26,7 +26,7 @@ export const osmosisChainId: ChainId = 'cosmos:osmosis-1'
 export const CHAIN_NAMESPACE = {
   Evm: 'eip155',
   Utxo: 'bip122',
-  Cosmos: 'cosmos',
+  CosmosSdk: 'cosmos',
 } as const
 
 type ValidChainMap = {
@@ -66,7 +66,7 @@ export const VALID_CHAIN_IDS: ValidChainMap = Object.freeze({
     CHAIN_REFERENCE.EthereumRinkeby,
     CHAIN_REFERENCE.AvalancheCChain,
   ],
-  [CHAIN_NAMESPACE.Cosmos]: [
+  [CHAIN_NAMESPACE.CosmosSdk]: [
     CHAIN_REFERENCE.CosmosHubMainnet,
     CHAIN_REFERENCE.CosmosHubVega,
     CHAIN_REFERENCE.OsmosisMainnet,
@@ -81,7 +81,7 @@ type ValidAssetNamespace = {
 export const VALID_ASSET_NAMESPACE: ValidAssetNamespace = Object.freeze({
   [CHAIN_NAMESPACE.Utxo]: ['slip44'],
   [CHAIN_NAMESPACE.Evm]: ['slip44', 'erc20', 'erc721'],
-  [CHAIN_NAMESPACE.Cosmos]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
+  [CHAIN_NAMESPACE.CosmosSdk]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
 })
 
 export const ASSET_NAMESPACE_STRINGS = [

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -64,15 +64,13 @@ describe('isValidChainPartsPair', () => {
     expect(isValidChainPartsPair(CHAIN_NAMESPACE.Utxo, CHAIN_REFERENCE.BitcoinTestnet)).toEqual(
       true,
     )
-    expect(isValidChainPartsPair(CHAIN_NAMESPACE.Ethereum, CHAIN_REFERENCE.BitcoinTestnet)).toEqual(
+    expect(isValidChainPartsPair(CHAIN_NAMESPACE.Evm, CHAIN_REFERENCE.BitcoinTestnet)).toEqual(
       false,
     )
     expect(
       isValidChainPartsPair('invalid' as ChainNamespace, CHAIN_REFERENCE.BitcoinTestnet),
     ).toEqual(false)
-    expect(isValidChainPartsPair(CHAIN_NAMESPACE.Ethereum, 'invalid' as ChainReference)).toEqual(
-      false,
-    )
+    expect(isValidChainPartsPair(CHAIN_NAMESPACE.Evm, 'invalid' as ChainReference)).toEqual(false)
   })
 })
 
@@ -80,7 +78,7 @@ describe('type guard', () => {
   describe('isChainNamespace', () => {
     it('correctly determines type', () => {
       expect(isChainNamespace(CHAIN_NAMESPACE.Utxo)).toEqual(true)
-      expect(isChainNamespace(CHAIN_NAMESPACE.Ethereum)).toEqual(true)
+      expect(isChainNamespace(CHAIN_NAMESPACE.Evm)).toEqual(true)
       expect(isChainNamespace('invalid')).toEqual(false)
       expect(isChainNamespace('')).toEqual(false)
     })
@@ -151,7 +149,7 @@ describe('type guard assertion', () => {
   describe('assertIsChainNamespace', () => {
     it('correctly asserts type', () => {
       expect(() => assertIsChainNamespace(CHAIN_NAMESPACE.Utxo)).not.toThrow()
-      expect(() => assertIsChainNamespace(CHAIN_NAMESPACE.Ethereum)).not.toThrow()
+      expect(() => assertIsChainNamespace(CHAIN_NAMESPACE.Evm)).not.toThrow()
       expect(() => assertIsChainNamespace('invalid')).toThrow()
       expect(() => assertIsChainNamespace('')).toThrow()
     })
@@ -196,7 +194,7 @@ describe('type guard assertion', () => {
         assertValidChainPartsPair('invalid' as ChainNamespace, CHAIN_REFERENCE.BitcoinTestnet),
       ).toThrow()
       expect(() =>
-        assertValidChainPartsPair(CHAIN_NAMESPACE.Ethereum, 'invalid' as ChainReference),
+        assertValidChainPartsPair(CHAIN_NAMESPACE.Evm, 'invalid' as ChainReference),
       ).toThrow()
     })
   })

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -37,7 +37,7 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.27.0",
     "@shapeshiftoss/hdwallet-native": "^1.27.0",
     "@shapeshiftoss/types": "^8.1.0",
@@ -45,7 +45,7 @@
     "bs58check": "^2.0.2"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.27.0",
     "@shapeshiftoss/hdwallet-native": "^1.27.0",
     "@shapeshiftoss/types": "^8.1.0",

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -34,7 +34,7 @@ export const chainIdToChainLabel = (chainId: ChainId): string => {
             `chainReference: ${chainReference}, not supported for chainNamespace: ${chainNamespace}`,
           )
       }
-    case CHAIN_NAMESPACE.Ethereum:
+    case CHAIN_NAMESPACE.Evm:
       switch (chainReference) {
         case CHAIN_REFERENCE.EthereumMainnet:
         case CHAIN_REFERENCE.EthereumRinkeby:

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -47,7 +47,7 @@ export const chainIdToChainLabel = (chainId: ChainId): string => {
             `chainReference: ${chainReference}, not supported for chainNamespace: ${chainNamespace}`,
           )
       }
-    case CHAIN_NAMESPACE.Cosmos:
+    case CHAIN_NAMESPACE.CosmosSdk:
       switch (chainReference) {
         case CHAIN_REFERENCE.CosmosHubMainnet:
         case CHAIN_REFERENCE.CosmosHubVega:

--- a/packages/investor-foxy/README.md
+++ b/packages/investor-foxy/README.md
@@ -16,7 +16,7 @@ import { toChainId, CHAIN_NAMESPACE, CHAIN_REFERENCE } from '@shapeshiftoss/caip
 
 const api = new FoxyApi({
   adapter: await adapterManager.byChainId(
-    toChainId({ chainNamespace: CHAIN_NAMESPACE.Ethereum, chainReference: CHAIN_REFERENCE.EthereumMainnet })
+    toChainId({ chainNamespace: CHAIN_NAMESPACE.Evm, chainReference: CHAIN_REFERENCE.EthereumMainnet })
   ), // adapter is an ETH @shapeshiftoss/chain-adapters
   providerUrl: '<your eth node privider url>'
 })
@@ -60,7 +60,7 @@ For more in-depth examples, check out ./src/foxycli.ts
 ```javascript
 const api = new FoxyApi({
   adapter: await adapterManager.byChainId(
-    toChainId({ chainNamespace: CHAIN_NAMESPACE.Ethereum, chainReference: CHAIN_REFERENCE.EthereumMainnet })
+    toChainId({ chainNamespace: CHAIN_NAMESPACE.Evm, chainReference: CHAIN_REFERENCE.EthereumMainnet })
   ),
   providerUrl: 'https://dev-api.ethereum.shapeshift.com'
 })

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -36,13 +36,13 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/types": "^8.1.0",

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -1083,7 +1083,7 @@ export class FoxyApi {
       }
     })
 
-    const chainNamespace = CHAIN_NAMESPACE.Ethereum
+    const chainNamespace = CHAIN_NAMESPACE.Evm
     const chainReference = CHAIN_REFERENCE.EthereumMainnet
     const assetNamespace = 'erc20'
     const assetReference = tokenContractAddress

--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -35,14 +35,14 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/investor": "^1.0.1",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/investor": "^1.0.1",

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -36,14 +36,14 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/investor": "^1.0.1",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
     "@shapeshiftoss/investor": "^1.0.1",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -36,14 +36,14 @@
     "p-ratelimit": "^1.0.1"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/investor-foxy": "^4.0.2",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^9.5.0"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/investor-foxy": "^4.0.2",
     "@shapeshiftoss/types": "^8.1.0",

--- a/packages/market-service/src/yearn/yearn-tokens.test.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.test.ts
@@ -68,13 +68,13 @@ describe('yearn token market service', () => {
     it('can map yearn to assetIds', async () => {
       const result = await yearnTokenMarketCapService.findAll()
       const yvBtcAssetId = toAssetId({
-        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainNamespace: CHAIN_NAMESPACE.Evm,
         chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnTokenRestData[0].address.toLowerCase(),
       })
       const yvDaiAssetId = toAssetId({
-        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainNamespace: CHAIN_NAMESPACE.Evm,
         chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnTokenRestData[1].address.toLowerCase(),

--- a/packages/market-service/src/yearn/yearn-tokens.ts
+++ b/packages/market-service/src/yearn/yearn-tokens.ts
@@ -55,7 +55,7 @@ export class YearnTokenMarketCapService implements MarketService {
 
       return tokens.reduce((acc, token) => {
         const _assetId: string = toAssetId({
-          chainNamespace: CHAIN_NAMESPACE.Ethereum,
+          chainNamespace: CHAIN_NAMESPACE.Evm,
           chainReference: CHAIN_REFERENCE.EthereumMainnet,
           assetNamespace: 'erc20',
           assetReference: token.address,

--- a/packages/market-service/src/yearn/yearn-vaults.test.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.test.ts
@@ -38,7 +38,7 @@ describe('yearn market service', () => {
       const result = await yearnVaultMarketCapService.findAll()
       expect(Object.keys(result)[0]).toEqual(
         toAssetId({
-          chainNamespace: CHAIN_NAMESPACE.Ethereum,
+          chainNamespace: CHAIN_NAMESPACE.Evm,
           chainReference: CHAIN_REFERENCE.EthereumMainnet,
           assetNamespace: 'erc20',
           assetReference: yvBTCAddress.toLowerCase(),
@@ -73,13 +73,13 @@ describe('yearn market service', () => {
     it('can map yearn to AssetIds', async () => {
       const result = await yearnVaultMarketCapService.findAll()
       const yvBtcAssetId = toAssetId({
-        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainNamespace: CHAIN_NAMESPACE.Evm,
         chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnVaultRestData[0].address.toLowerCase(),
       })
       const yvDaiAssetId = toAssetId({
-        chainNamespace: CHAIN_NAMESPACE.Ethereum,
+        chainNamespace: CHAIN_NAMESPACE.Evm,
         chainReference: CHAIN_REFERENCE.EthereumMainnet,
         assetNamespace: 'erc20',
         assetReference: mockYearnVaultRestData[1].address.toLowerCase(),

--- a/packages/market-service/src/yearn/yearn-vaults.ts
+++ b/packages/market-service/src/yearn/yearn-vaults.ts
@@ -53,7 +53,7 @@ export class YearnVaultMarketCapService implements MarketService {
         )
         .reduce((acc, yearnItem) => {
           const assetId = toAssetId({
-            chainNamespace: CHAIN_NAMESPACE.Ethereum,
+            chainNamespace: CHAIN_NAMESPACE.Evm,
             chainReference: CHAIN_REFERENCE.EthereumMainnet,
             assetNamespace: 'erc20',
             assetReference: yearnItem.address,

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/asset-service": "^7.1.0",
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.27.0",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@shapeshiftoss/asset-service": "^7.1.0",
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/chain-adapters": "^7.13.0",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.27.0",

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -166,7 +166,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
         })
         const txid = await adapter.broadcastTransaction(signedTx)
         return { tradeId: txid }
-      } else if (chainNamespace === CHAIN_NAMESPACE.Cosmos) {
+      } else if (chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
         const signedTx = await (adapter as unknown as cosmos.ChainAdapter).signTransaction({
           txToSign: (trade as ThorTrade<KnownChainIds.CosmosMainnet>).txData as CosmosSignTx,
           wallet,

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -148,7 +148,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
 
       const { chainNamespace } = fromAssetId(trade.sellAsset.assetId)
 
-      if (chainNamespace === CHAIN_NAMESPACE.Ethereum) {
+      if (chainNamespace === CHAIN_NAMESPACE.Evm) {
         const signedTx = await (
           adapter as unknown as EvmBaseAdapter<EvmSupportedChainIds>
         ).signTransaction({

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -47,7 +47,7 @@ export const buildTrade = async ({
 
     const { chainNamespace } = fromAssetId(sellAsset.assetId)
 
-    if (chainNamespace === CHAIN_NAMESPACE.Ethereum) {
+    if (chainNamespace === CHAIN_NAMESPACE.Evm) {
       const sellAssetBip44Params = sellAdapter.buildBIP44Params({
         accountNumber: sellAssetAccountNumber,
       })

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -109,7 +109,7 @@ export const buildTrade = async ({
         receiveAddress: destinationAddress,
         txData: buildTxResponse.txToSign,
       }
-    } else if (chainNamespace === CHAIN_NAMESPACE.Cosmos) {
+    } else if (chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
       const txData = await cosmosTxData({
         deps,
         sellAdapter: sellAdapter as unknown as cosmos.ChainAdapter,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -126,7 +126,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             feeData,
           }
         })()
-      case CHAIN_NAMESPACE.Cosmos:
+      case CHAIN_NAMESPACE.CosmosSdk:
         return (async (): Promise<TradeQuote<KnownChainIds.CosmosMainnet>> => {
           const feeData = await (
             sellAdapter as ChainAdapter<KnownChainIds.CosmosMainnet>

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -74,7 +74,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
 
     const { chainNamespace } = fromAssetId(sellAsset.assetId)
     switch (chainNamespace) {
-      case CHAIN_NAMESPACE.Ethereum:
+      case CHAIN_NAMESPACE.Evm:
         return (async (): Promise<TradeQuote<KnownChainIds.EthereumMainnet>> => {
           const { router } = await getEthThorTxInfo({
             deps,

--- a/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
@@ -22,7 +22,7 @@ export const thorTradeApprovalNeeded = async ({
     const { assetReference: sellAssetErc20Address } = fromAssetId(sellAsset.assetId)
     const { chainNamespace } = fromChainId(sellAsset.chainId)
 
-    if (chainNamespace !== CHAIN_NAMESPACE.Ethereum) return { approvalNeeded: false }
+    if (chainNamespace !== CHAIN_NAMESPACE.Evm) return { approvalNeeded: false }
 
     const accountNumber = quote.sellAssetAccountNumber
 

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -29,13 +29,13 @@
     "ws": "^8.3.0"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.5.1",
-    "@shapeshiftoss/caip": "^6.7.0",
+    "@shapeshiftoss/caip": "^7.0.0",
     "@shapeshiftoss/common-api": "^8.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/types": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,6 +2831,20 @@
     tsoa "^4.1.0"
     ws "^8.8.0"
 
+"@shapeshiftoss/chain-adapters@^7.13.0":
+  version "7.17.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.17.1.tgz#25860127a0f28cf5749bc1146b9ccb8c58edf43d"
+  integrity sha512-jlXQvb/7Hd3LOeQnvqP9/fBrFRWnGLZXzVzRKOp/U/sNPZvM+7EwRIlrC6P+6Iw/rRTPVXhjtU5yRXJI/hhDHw==
+  dependencies:
+    axios "^0.26.1"
+    bech32 "^2.0.0"
+    bignumber.js "^9.0.2"
+    bitcoinjs-lib "^5.2.0"
+    coinselect "^3.1.13"
+    ethers "^5.4.7"
+    multicoin-address-validator "^0.5.2"
+    web3-utils "1.7.4"
+
 "@shapeshiftoss/common-api@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-8.0.0.tgz#3e98d15c426278a9015e90d4d674ff4e91e5377a"


### PR DESCRIPTION
### Description

BREAKING CHANGE: CHAIN_NAMESPACE.Ethereum is now CHAIN_NAMESPACE.Evm and CHAIN_NAMESPACE.Cosmos is now CHAIN_NAMESPACE.CosmosSdk

This renames 
- CHAIN_NAMESPACE.Ethereum to CHAIN_NAMESPACE.Evm since it
now refers to any EVM chain
- CHAIN_NAMESPACE.Cosmos to CHAIN_NAMESPACE.CosmosSdk for consistency
