### PR TITLE
feat: rename CHAIN_NAMESPACE.Cosmos -> CHAIN_NAMESPACE.CosmosSdk

### DIFF
--- a/packages/caip/src/adapters/coincap/index.test.ts
+++ b/packages/caip/src/adapters/coincap/index.test.ts
@@ -39,7 +39,7 @@ describe('adapters:coincap', () => {
   })
 
   it('can get AssetId for cosmos', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
     const assetId = toAssetId({
       chainNamespace,
@@ -51,7 +51,7 @@ describe('adapters:coincap', () => {
   })
 
   it('can get AssetId for osmosis', () => {
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.OsmosisMainnet
     const assetId = toAssetId({
       chainNamespace,
@@ -97,7 +97,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for cosmos AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -109,7 +109,7 @@ describe('adapters:coincap', () => {
     })
 
     it('can get coincap id for osmosis AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,

--- a/packages/caip/src/adapters/coingecko/index.test.ts
+++ b/packages/caip/src/adapters/coingecko/index.test.ts
@@ -50,7 +50,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds for cosmos', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -62,7 +62,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get AssetIds for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -127,7 +127,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for cosmos AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetId = toAssetId({
         chainNamespace,
@@ -139,7 +139,7 @@ describe('adapters:coingecko', () => {
     })
 
     it('can get CoinGecko id for osmosis AssetId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetId = toAssetId({
         chainNamespace,

--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -52,7 +52,7 @@ export const chainIdToCoingeckoAssetPlatform = (chainId: ChainId): string => {
             `chainNamespace ${chainNamespace}, chainReference ${chainReference} not supported.`,
           )
       }
-    case CHAIN_NAMESPACE.Cosmos:
+    case CHAIN_NAMESPACE.CosmosSdk:
       switch (chainReference) {
         case CHAIN_REFERENCE.CosmosHubMainnet:
           return CoingeckoAssetPlatform.Cosmos

--- a/packages/caip/src/adapters/osmosis/index.test.ts
+++ b/packages/caip/src/adapters/osmosis/index.test.ts
@@ -3,7 +3,7 @@ import { ASSET_REFERENCE, CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../../constan
 import { assetIdToOsmosis, osmosisToAssetId } from '.'
 
 describe('osmosis adapter', () => {
-  const chainNamespace = CHAIN_NAMESPACE.Cosmos
+  const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
   const chainReference = CHAIN_REFERENCE.OsmosisMainnet
 
   describe('osmosisToAssetId', () => {

--- a/packages/caip/src/adapters/osmosis/utils.ts
+++ b/packages/caip/src/adapters/osmosis/utils.ts
@@ -45,7 +45,7 @@ export const parseOsmosisData = (data: OsmosisCoin[]) => {
       assetNamespace = 'ibc'
     }
 
-    const chainNamespace = CHAIN_NAMESPACE.Cosmos
+    const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
     const chainReference = CHAIN_REFERENCE.OsmosisMainnet
     const assetId = toAssetId({ chainNamespace, chainReference, assetNamespace, assetReference })
 
@@ -58,7 +58,7 @@ export const parseOsmosisData = (data: OsmosisCoin[]) => {
 
 export const parseData = (d: OsmosisCoin[]) => {
   const osmosisMainnet = toChainId({
-    chainNamespace: CHAIN_NAMESPACE.Cosmos,
+    chainNamespace: CHAIN_NAMESPACE.CosmosSdk,
     chainReference: CHAIN_REFERENCE.OsmosisMainnet,
   })
 

--- a/packages/caip/src/assetId/assetId.test.ts
+++ b/packages/caip/src/assetId/assetId.test.ts
@@ -103,7 +103,7 @@ describe('assetId', () => {
     })
 
     it('can make Cosmos AssetId on CosmosHub mainnet', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -120,7 +120,7 @@ describe('assetId', () => {
     })
 
     it('can make Osmosis AssetId on Osmosis mainnet with slip44 reference', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -137,7 +137,7 @@ describe('assetId', () => {
     })
 
     it('can return ibc AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -155,7 +155,7 @@ describe('assetId', () => {
     })
 
     it('can return native AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -172,7 +172,7 @@ describe('assetId', () => {
     })
 
     it('can return cw20 AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -189,7 +189,7 @@ describe('assetId', () => {
     })
 
     it('can return cw721 AssetId for osmosis', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -206,7 +206,7 @@ describe('assetId', () => {
     })
 
     it('can make Cosmos AssetId on CosmosHub vega', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubVega
       const assetIdArgSuperset = {
         chainNamespace,
@@ -223,7 +223,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid Cosmos network', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.BitcoinTestnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -239,7 +239,7 @@ describe('assetId', () => {
     })
 
     it('throws with invalid Cosmos slip44 reference', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const assetIdArgSuperset = {
         chainNamespace,
@@ -454,17 +454,32 @@ describe('assetId', () => {
           erc20,
           '0xc770eefad204b5180df6a14ee197d99d808ee52d',
         ],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.CosmosHubMainnet, slip44, ASSET_REFERENCE.Cosmos],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.CosmosHubVega, slip44, ASSET_REFERENCE.Cosmos],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisMainnet, slip44, ASSET_REFERENCE.Osmosis],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisTestnet, slip44, ASSET_REFERENCE.Osmosis],
         [
-          CHAIN_NAMESPACE.Cosmos,
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.CosmosHubMainnet,
+          slip44,
+          ASSET_REFERENCE.Cosmos,
+        ],
+        [CHAIN_NAMESPACE.CosmosSdk, CHAIN_REFERENCE.CosmosHubVega, slip44, ASSET_REFERENCE.Cosmos],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.OsmosisMainnet,
+          slip44,
+          ASSET_REFERENCE.Osmosis,
+        ],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
+          CHAIN_REFERENCE.OsmosisTestnet,
+          slip44,
+          ASSET_REFERENCE.Osmosis,
+        ],
+        [
+          CHAIN_NAMESPACE.CosmosSdk,
           CHAIN_REFERENCE.OsmosisMainnet,
           ibc,
           '346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593',
         ],
-        [CHAIN_NAMESPACE.Cosmos, CHAIN_REFERENCE.OsmosisMainnet, native, 'uion'],
+        [CHAIN_NAMESPACE.CosmosSdk, CHAIN_REFERENCE.OsmosisMainnet, native, 'uion'],
       ])(
         'returns a AssetId from the result of fromAssetId for %s',
         (
@@ -580,7 +595,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:cosmoshub-4/slip44:118'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -591,7 +606,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/slip44:118'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('slip44')
@@ -603,7 +618,7 @@ describe('assetId', () => {
         'cosmos:osmosis-1/ibc:346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('ibc')
@@ -616,7 +631,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/cw20:canlab'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('cw20')
@@ -627,7 +642,7 @@ describe('assetId', () => {
       const AssetId = 'cosmos:osmosis-1/cw721:osmokitty'
       const { chainId, chainReference, chainNamespace, assetNamespace, assetReference } =
         fromAssetId(AssetId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
       expect(chainId).toEqual(toChainId({ chainNamespace, chainReference }))
       expect(assetNamespace).toEqual('cw721')

--- a/packages/caip/src/chainId/chainId.test.ts
+++ b/packages/caip/src/chainId/chainId.test.ts
@@ -9,28 +9,28 @@ describe('chainId', () => {
   })
   describe('toChainId', () => {
     it('can turn CosmosHub mainnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubMainnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:cosmoshub-4')
     })
 
     it('can turn CosmosHub testnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.CosmosHubVega
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:vega-testnet')
     })
 
     it('can turn Osmosis mainnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisMainnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:osmosis-1')
     })
 
     it('can turn Osmosis testnet to ChainId', () => {
-      const chainNamespace = CHAIN_NAMESPACE.Cosmos
+      const chainNamespace = CHAIN_NAMESPACE.CosmosSdk
       const chainReference = CHAIN_REFERENCE.OsmosisTestnet
       const result = toChainId({ chainNamespace, chainReference })
       expect(result).toEqual('cosmos:osmo-testnet-1')
@@ -107,14 +107,14 @@ describe('chainId', () => {
     it('can turn CosmosHub mainnet to chain and network', () => {
       const cosmosHubChainId = 'cosmos:cosmoshub-4'
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubMainnet)
     })
 
     it('can turn CosmosHub testnet to chain and network', () => {
       const cosmosHubChainId = 'cosmos:vega-testnet'
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubVega)
     })
 
@@ -135,14 +135,14 @@ describe('chainId', () => {
     it('can turn Osmosis mainnet to chain and network', () => {
       const osmosisChainId = 'cosmos:osmosis-1'
       const { chainNamespace, chainReference } = fromChainId(osmosisChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisMainnet)
     })
 
     it('can turn Osmosis testnet to chain and network', () => {
       const osmosisChainId = 'cosmos:osmo-testnet-1'
       const { chainNamespace, chainReference } = fromChainId(osmosisChainId)
-      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Cosmos)
+      expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.OsmosisTestnet)
     })
 

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -26,7 +26,7 @@ export const osmosisChainId: ChainId = 'cosmos:osmosis-1'
 export const CHAIN_NAMESPACE = {
   Evm: 'eip155',
   Utxo: 'bip122',
-  Cosmos: 'cosmos',
+  CosmosSdk: 'cosmos',
 } as const
 
 type ValidChainMap = {
@@ -66,7 +66,7 @@ export const VALID_CHAIN_IDS: ValidChainMap = Object.freeze({
     CHAIN_REFERENCE.EthereumRinkeby,
     CHAIN_REFERENCE.AvalancheCChain,
   ],
-  [CHAIN_NAMESPACE.Cosmos]: [
+  [CHAIN_NAMESPACE.CosmosSdk]: [
     CHAIN_REFERENCE.CosmosHubMainnet,
     CHAIN_REFERENCE.CosmosHubVega,
     CHAIN_REFERENCE.OsmosisMainnet,
@@ -81,7 +81,7 @@ type ValidAssetNamespace = {
 export const VALID_ASSET_NAMESPACE: ValidAssetNamespace = Object.freeze({
   [CHAIN_NAMESPACE.Utxo]: ['slip44'],
   [CHAIN_NAMESPACE.Evm]: ['slip44', 'erc20', 'erc721'],
-  [CHAIN_NAMESPACE.Cosmos]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
+  [CHAIN_NAMESPACE.CosmosSdk]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
 })
 
 export const ASSET_NAMESPACE_STRINGS = [

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -47,7 +47,7 @@ export const chainIdToChainLabel = (chainId: ChainId): string => {
             `chainReference: ${chainReference}, not supported for chainNamespace: ${chainNamespace}`,
           )
       }
-    case CHAIN_NAMESPACE.Cosmos:
+    case CHAIN_NAMESPACE.CosmosSdk:
       switch (chainReference) {
         case CHAIN_REFERENCE.CosmosHubMainnet:
         case CHAIN_REFERENCE.CosmosHubVega:

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -166,7 +166,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
         })
         const txid = await adapter.broadcastTransaction(signedTx)
         return { tradeId: txid }
-      } else if (chainNamespace === CHAIN_NAMESPACE.Cosmos) {
+      } else if (chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
         const signedTx = await (adapter as unknown as cosmos.ChainAdapter).signTransaction({
           txToSign: (trade as ThorTrade<KnownChainIds.CosmosMainnet>).txData as CosmosSignTx,
           wallet,

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -109,7 +109,7 @@ export const buildTrade = async ({
         receiveAddress: destinationAddress,
         txData: buildTxResponse.txToSign,
       }
-    } else if (chainNamespace === CHAIN_NAMESPACE.Cosmos) {
+    } else if (chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
       const txData = await cosmosTxData({
         deps,
         sellAdapter: sellAdapter as unknown as cosmos.ChainAdapter,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -126,7 +126,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             feeData,
           }
         })()
-      case CHAIN_NAMESPACE.Cosmos:
+      case CHAIN_NAMESPACE.CosmosSdk:
         return (async (): Promise<TradeQuote<KnownChainIds.CosmosMainnet>> => {
           const feeData = await (
             sellAdapter as ChainAdapter<KnownChainIds.CosmosMainnet>


### PR DESCRIPTION
### Description

BREAKING CHANGE: CHAIN_NAMESPACE.Cosmos is now CHAIN_NAMESPACE.CosmosSdk

This renames CHAIN_NAMESPACE.Cosmos to CHAIN_NAMESPACE.CosmosSdk since it refers to any Cosmos SDK chain.
This brings consistency to the renamed 
 - CHAIN_NAMESPACE.Bitcoin -> CHAIN_NAMESPACE.Utxo 
 - CHAIN_NAMESPACE.Ethereum -> CHAIN_NAMESPACE.Evm
