### PR TITLE
refactor(caip): remove named capture groups in parseAssetId regular expression

### DIFF
--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -10,6 +10,7 @@ import {
 } from '../constants'
 import {
   assertIsAssetNamespace,
+  assertIsAssetReference,
   assertIsChainNamespace,
   assertIsChainReference,
   assertValidChainPartsPair,
@@ -132,23 +133,21 @@ export const fromAssetId: FromAssetId = (assetId) => {
   const matches = parseAssetIdRegExp.exec(assetId)
   if (!matches) throw new Error(`fromAssetId: could not parse AssetId: ${assetId}`)
 
-  // These should never throw because isAssetId() would have already caught it, but they help with type inference
-  assertIsChainNamespace(matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_NAMESPACE_CAPTURE_GROUP])
-  assertIsChainReference(matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_REFERENCE_CAPTURE_GROUP])
-  assertIsAssetNamespace(matches[ASSET_ID_CAPTURE_GROUPS.ASSET_NAMESPACE_CAPTURE_GROUP])
-
   const chainNamespace = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_NAMESPACE_CAPTURE_GROUP]
   const chainReference = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_REFERENCE_CAPTURE_GROUP]
   const assetNamespace = matches[ASSET_ID_CAPTURE_GROUPS.ASSET_NAMESPACE_CAPTURE_GROUP]
-
   const shouldLowercaseAssetReference =
     assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
-
   const assetReference = shouldLowercaseAssetReference
     ? toLower(matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP])
     : matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP]
-  assertIsChainReference(chainReference)
+
+  // These should never throw because isAssetId() would have already caught it, but they help with type inference
   assertIsChainNamespace(chainNamespace)
+  assertIsChainReference(chainReference)
+  assertIsAssetNamespace(assetNamespace)
+  assertIsAssetReference(assetReference)
+
   const chainId = toChainId({ chainNamespace, chainReference })
 
   if (assetNamespace && assetReference && chainId) {

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -126,23 +126,26 @@ export const fromAssetId: FromAssetId = (assetId) => {
   const matches = parseAssetIdRegExp.exec(assetId)
   if (!matches) throw new Error(`fromAssetId: could not parse AssetId: ${assetId}`)
 
-  const [, chainNamespace, chainReference, assetNamespace] = matches
-  let [, , , , assetReference] = matches
+  const { 1: chainNamespace, 2: chainReference, 3: assetNamespace, 4: assetReference } = matches
 
   // These should never throw because isAssetId() would have already caught it, but they help with type inference
   assertIsChainNamespace(chainNamespace)
   assertIsChainReference(chainReference)
   assertIsAssetNamespace(assetNamespace)
 
-  const shouldLowercaseAssetReference =
-    assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
-
-  assetReference = shouldLowercaseAssetReference ? assetReference.toLowerCase() : assetReference
-
   const chainId = toChainId({ chainNamespace, chainReference })
 
   if (assetNamespace && assetReference && chainId) {
-    return { chainId, chainReference, chainNamespace, assetNamespace, assetReference }
+    return {
+      chainId,
+      chainReference,
+      chainNamespace,
+      assetNamespace,
+      assetReference:
+        assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
+          ? assetReference.toLowerCase()
+          : assetReference,
+    }
   } else {
     throw new Error(`fromAssetId: invalid AssetId: ${assetId}`)
   }

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -1,16 +1,9 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
-import toLower from 'lodash/toLower'
 
 import { ChainId, ChainNamespace, ChainReference, fromChainId, toChainId } from '../chainId/chainId'
-import {
-  ASSET_ID_CAPTURE_GROUPS,
-  ASSET_NAMESPACE,
-  ASSET_REFERENCE,
-  VALID_ASSET_NAMESPACE,
-} from '../constants'
+import { ASSET_NAMESPACE, ASSET_REFERENCE, VALID_ASSET_NAMESPACE } from '../constants'
 import {
   assertIsAssetNamespace,
-  assertIsAssetReference,
   assertIsChainNamespace,
   assertIsChainReference,
   assertValidChainPartsPair,
@@ -133,20 +126,18 @@ export const fromAssetId: FromAssetId = (assetId) => {
   const matches = parseAssetIdRegExp.exec(assetId)
   if (!matches) throw new Error(`fromAssetId: could not parse AssetId: ${assetId}`)
 
-  const chainNamespace = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_NAMESPACE_CAPTURE_GROUP]
-  const chainReference = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_REFERENCE_CAPTURE_GROUP]
-  const assetNamespace = matches[ASSET_ID_CAPTURE_GROUPS.ASSET_NAMESPACE_CAPTURE_GROUP]
-  const shouldLowercaseAssetReference =
-    assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
-  const assetReference = shouldLowercaseAssetReference
-    ? toLower(matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP])
-    : matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP]
+  const [, chainNamespace, chainReference, assetNamespace] = matches
+  let [, , , , assetReference] = matches
 
   // These should never throw because isAssetId() would have already caught it, but they help with type inference
   assertIsChainNamespace(chainNamespace)
   assertIsChainReference(chainReference)
   assertIsAssetNamespace(assetNamespace)
-  assertIsAssetReference(assetReference)
+
+  const shouldLowercaseAssetReference =
+    assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
+
+  assetReference = shouldLowercaseAssetReference ? assetReference.toLowerCase() : assetReference
 
   const chainId = toChainId({ chainNamespace, chainReference })
 

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -141,10 +141,9 @@ export const fromAssetId: FromAssetId = (assetId) => {
       chainReference,
       chainNamespace,
       assetNamespace,
-      assetReference:
-        assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
-          ? assetReference.toLowerCase()
-          : assetReference,
+      assetReference: ['erc20', 'erc721'].includes(assetNamespace)
+        ? assetReference.toLowerCase()
+        : assetReference,
     }
   } else {
     throw new Error(`fromAssetId: invalid AssetId: ${assetId}`)

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -2,7 +2,12 @@
 import toLower from 'lodash/toLower'
 
 import { ChainId, ChainNamespace, ChainReference, fromChainId, toChainId } from '../chainId/chainId'
-import { ASSET_NAMESPACE_STRINGS, ASSET_REFERENCE, VALID_ASSET_NAMESPACE } from '../constants'
+import {
+  ASSET_ID_CAPTURE_GROUPS,
+  ASSET_NAMESPACE,
+  ASSET_REFERENCE,
+  VALID_ASSET_NAMESPACE,
+} from '../constants'
 import {
   assertIsAssetNamespace,
   assertIsChainNamespace,
@@ -15,7 +20,7 @@ import { Nominal, parseAssetIdRegExp } from '../utils'
 
 export type AssetId = Nominal<string, 'AssetId'>
 
-export type AssetNamespace = typeof ASSET_NAMESPACE_STRINGS[number]
+export type AssetNamespace = typeof ASSET_NAMESPACE[keyof typeof ASSET_NAMESPACE]
 
 export type AssetReference = typeof ASSET_REFERENCE[keyof typeof ASSET_REFERENCE]
 
@@ -124,24 +129,24 @@ export type FromAssetId = (assetId: AssetId) => FromAssetIdReturn
 
 export const fromAssetId: FromAssetId = (assetId) => {
   if (!isAssetId(assetId)) throw new Error(`fromAssetId: invalid AssetId: ${assetId}`)
-  const matches = parseAssetIdRegExp.exec(assetId)?.groups
+  const matches = parseAssetIdRegExp.exec(assetId)
   if (!matches) throw new Error(`fromAssetId: could not parse AssetId: ${assetId}`)
 
   // These should never throw because isAssetId() would have already caught it, but they help with type inference
-  assertIsChainNamespace(matches.chainNamespace)
-  assertIsChainReference(matches.chainReference)
-  assertIsAssetNamespace(matches.assetNamespace)
+  assertIsChainNamespace(matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_NAMESPACE_CAPTURE_GROUP])
+  assertIsChainReference(matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_REFERENCE_CAPTURE_GROUP])
+  assertIsAssetNamespace(matches[ASSET_ID_CAPTURE_GROUPS.ASSET_NAMESPACE_CAPTURE_GROUP])
 
-  const chainNamespace = matches.chainNamespace
-  const chainReference = matches.chainReference
-  const assetNamespace = matches.assetNamespace
+  const chainNamespace = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_NAMESPACE_CAPTURE_GROUP]
+  const chainReference = matches[ASSET_ID_CAPTURE_GROUPS.CHAIN_REFERENCE_CAPTURE_GROUP]
+  const assetNamespace = matches[ASSET_ID_CAPTURE_GROUPS.ASSET_NAMESPACE_CAPTURE_GROUP]
 
   const shouldLowercaseAssetReference =
     assetNamespace && ['erc20', 'erc721'].includes(assetNamespace)
 
   const assetReference = shouldLowercaseAssetReference
-    ? toLower(matches.assetReference)
-    : matches.assetReference
+    ? toLower(matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP])
+    : matches[ASSET_ID_CAPTURE_GROUPS.ASSET_REFERENCE_CAPTURE_GROUP]
   assertIsChainReference(chainReference)
   assertIsChainNamespace(chainNamespace)
   const chainId = toChainId({ chainNamespace, chainReference })

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -52,6 +52,27 @@ export const CHAIN_REFERENCE = {
   AvalancheCChain: '43114', // https://docs.avax.network/apis/avalanchego/apis/c-chain
 } as const
 
+export const ASSET_NAMESPACE = {
+  cw20: 'cw20',
+  cw721: 'cw721',
+  erc20: 'erc20',
+  erc721: 'erc721',
+  slip44: 'slip44',
+  native: 'native',
+  ibc: 'ibc',
+} as const
+
+export const ASSET_REFERENCE = {
+  Bitcoin: '0',
+  Litecoin: '2',
+  Dogecoin: '3',
+  Ethereum: '60',
+  Cosmos: '118',
+  Osmosis: '118',
+  BitcoinCash: '145',
+  AvalancheC: '9000',
+} as const
+
 export const VALID_CHAIN_IDS: ValidChainMap = Object.freeze({
   [CHAIN_NAMESPACE.Utxo]: [
     CHAIN_REFERENCE.BitcoinMainnet,
@@ -79,35 +100,13 @@ type ValidAssetNamespace = {
 }
 
 export const VALID_ASSET_NAMESPACE: ValidAssetNamespace = Object.freeze({
-  [CHAIN_NAMESPACE.Utxo]: ['slip44'],
-  [CHAIN_NAMESPACE.Evm]: ['slip44', 'erc20', 'erc721'],
-  [CHAIN_NAMESPACE.CosmosSdk]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
+  [CHAIN_NAMESPACE.Utxo]: [ASSET_NAMESPACE.slip44],
+  [CHAIN_NAMESPACE.Evm]: [ASSET_NAMESPACE.slip44, ASSET_NAMESPACE.erc20, ASSET_NAMESPACE.erc721],
+  [CHAIN_NAMESPACE.CosmosSdk]: [
+    ASSET_NAMESPACE.cw20,
+    ASSET_NAMESPACE.cw721,
+    ASSET_NAMESPACE.ibc,
+    ASSET_NAMESPACE.native,
+    ASSET_NAMESPACE.slip44,
+  ],
 })
-
-export const ASSET_NAMESPACE = {
-  cw20: 'cw20',
-  cw721: 'cw721',
-  erc20: 'erc20',
-  erc721: 'erc721',
-  slip44: 'slip44',
-  native: 'native',
-  ibc: 'ibc',
-} as const
-
-export const ASSET_REFERENCE = {
-  Bitcoin: '0',
-  Litecoin: '2',
-  Dogecoin: '3',
-  Ethereum: '60',
-  Cosmos: '118',
-  Osmosis: '118',
-  BitcoinCash: '145',
-  AvalancheC: '9000',
-} as const
-
-export const enum ASSET_ID_CAPTURE_GROUPS {
-  CHAIN_NAMESPACE_CAPTURE_GROUP = 1,
-  CHAIN_REFERENCE_CAPTURE_GROUP,
-  ASSET_NAMESPACE_CAPTURE_GROUP,
-  ASSET_REFERENCE_CAPTURE_GROUP,
-}

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -84,15 +84,15 @@ export const VALID_ASSET_NAMESPACE: ValidAssetNamespace = Object.freeze({
   [CHAIN_NAMESPACE.Cosmos]: ['cw20', 'cw721', 'ibc', 'native', 'slip44'],
 })
 
-export const ASSET_NAMESPACE_STRINGS = [
-  'cw20',
-  'cw721',
-  'erc20',
-  'erc721',
-  'slip44',
-  'native',
-  'ibc',
-] as const
+export const ASSET_NAMESPACE = {
+  cw20: 'cw20',
+  cw721: 'cw721',
+  erc20: 'erc20',
+  erc721: 'erc721',
+  slip44: 'slip44',
+  native: 'native',
+  ibc: 'ibc',
+} as const
 
 export const ASSET_REFERENCE = {
   Bitcoin: '0',
@@ -104,3 +104,10 @@ export const ASSET_REFERENCE = {
   BitcoinCash: '145',
   AvalancheC: '9000',
 } as const
+
+export const enum ASSET_ID_CAPTURE_GROUPS {
+  CHAIN_NAMESPACE_CAPTURE_GROUP = 1,
+  CHAIN_REFERENCE_CAPTURE_GROUP,
+  ASSET_NAMESPACE_CAPTURE_GROUP,
+  ASSET_REFERENCE_CAPTURE_GROUP,
+}

--- a/packages/caip/src/typeGuards.ts
+++ b/packages/caip/src/typeGuards.ts
@@ -25,9 +25,11 @@ export const isAssetReference = (
 
 export const isAssetId = (maybeAssetId: AssetId | string): maybeAssetId is AssetReference => {
   const matches = parseAssetIdRegExp.exec(maybeAssetId)
-  const [, chainNamespace, chainReference, assetNamespace] = matches || []
+  if (!matches) {
+    return false
+  }
+  const { 1: chainNamespace, 2: chainReference, 3: assetNamespace } = matches
   return (
-    !!matches &&
     isChainNamespace(chainNamespace) &&
     isChainReference(chainReference) &&
     isAssetNamespace(assetNamespace)

--- a/packages/caip/src/typeGuards.ts
+++ b/packages/caip/src/typeGuards.ts
@@ -1,11 +1,6 @@
 import { AssetId, AssetNamespace, AssetReference } from './assetId/assetId'
 import { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
-import {
-  ASSET_NAMESPACE_STRINGS,
-  ASSET_REFERENCE,
-  CHAIN_NAMESPACE,
-  CHAIN_REFERENCE,
-} from './constants'
+import { ASSET_NAMESPACE, ASSET_REFERENCE, CHAIN_NAMESPACE, CHAIN_REFERENCE } from './constants'
 import { isValidChainPartsPair, parseAssetIdRegExp } from './utils'
 
 export const isChainNamespace = (
@@ -21,7 +16,7 @@ export const isChainReference = (
 export const isAssetNamespace = (
   maybeAssetNamespace: AssetNamespace | string,
 ): maybeAssetNamespace is AssetNamespace =>
-  ASSET_NAMESPACE_STRINGS.some((s) => s === maybeAssetNamespace)
+  Object.values(ASSET_NAMESPACE).some((s) => s === maybeAssetNamespace)
 
 export const isAssetReference = (
   maybeAssetReference: AssetReference | string,

--- a/packages/caip/src/typeGuards.ts
+++ b/packages/caip/src/typeGuards.ts
@@ -24,12 +24,13 @@ export const isAssetReference = (
   Object.values(ASSET_REFERENCE).some((s) => s === maybeAssetReference)
 
 export const isAssetId = (maybeAssetId: AssetId | string): maybeAssetId is AssetReference => {
-  const matches = parseAssetIdRegExp.exec(maybeAssetId)?.groups
+  const matches = parseAssetIdRegExp.exec(maybeAssetId)
+  const [, chainNamespace, chainReference, assetNamespace] = matches || []
   return (
     !!matches &&
-    isChainNamespace(matches.chainNamespace) &&
-    isChainReference(matches.chainReference) &&
-    isAssetNamespace(matches.assetNamespace)
+    isChainNamespace(chainNamespace) &&
+    isChainReference(chainReference) &&
+    isAssetNamespace(assetNamespace)
   )
 }
 

--- a/packages/caip/src/utils.test.ts
+++ b/packages/caip/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { ChainNamespace, ChainReference } from './chainId/chainId'
 import {
-  ASSET_NAMESPACE_STRINGS,
+  ASSET_NAMESPACE,
   ASSET_REFERENCE,
   btcAssetId,
   btcChainId,
@@ -106,8 +106,8 @@ describe('type guard', () => {
 
   describe('isAssetNamespace', () => {
     it('correctly determines type', () => {
-      expect(isAssetNamespace(ASSET_NAMESPACE_STRINGS[0])).toEqual(true)
-      expect(isAssetNamespace(ASSET_NAMESPACE_STRINGS[1])).toEqual(true)
+      expect(isAssetNamespace(ASSET_NAMESPACE.cw20)).toEqual(true)
+      expect(isAssetNamespace(ASSET_NAMESPACE.cw721)).toEqual(true)
       expect(isAssetNamespace('invalid')).toEqual(false)
       expect(isAssetNamespace('')).toEqual(false)
     })
@@ -166,8 +166,8 @@ describe('type guard assertion', () => {
 
   describe('assertIsAssetNamespace', () => {
     it('correctly asserts type', () => {
-      expect(() => assertIsAssetNamespace(ASSET_NAMESPACE_STRINGS[0])).not.toThrow()
-      expect(() => assertIsAssetNamespace(ASSET_NAMESPACE_STRINGS[1])).not.toThrow()
+      expect(() => assertIsAssetNamespace(ASSET_NAMESPACE.cw20)).not.toThrow()
+      expect(() => assertIsAssetNamespace(ASSET_NAMESPACE.cw721)).not.toThrow()
       expect(() => assertIsAssetNamespace('invalid')).toThrow()
       expect(() => assertIsAssetNamespace('')).toThrow()
     })

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -2,7 +2,7 @@ import { AccountId, fromAccountId } from './accountId/accountId'
 import { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 import * as constants from './constants'
 
-// https://regex101.com/r/f0xGqP/2
+// https://regex101.com/r/URAeoi/1
 export const parseAssetIdRegExp =
   /([-a-z\d]{3,8}):([-a-zA-Z\d]{1,32})\/([-a-z\d]{3,8}):([-a-zA-Z\d]+)/
 

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -4,7 +4,7 @@ import * as constants from './constants'
 
 // https://regex101.com/r/f0xGqP/2
 export const parseAssetIdRegExp =
-  /(?<chainNamespace>[-a-z\d]{3,8}):(?<chainReference>[-a-zA-Z\d]{1,32})\/(?<assetNamespace>[-a-z\d]{3,8}):(?<assetReference>[-a-zA-Z\d]+)/
+  /([-a-z\d]{3,8}):([-a-zA-Z\d]{1,32})\/([-a-z\d]{3,8}):([-a-zA-Z\d]+)/
 
 export const accountIdToChainId = (accountId: AccountId): ChainId =>
   fromAccountId(accountId).chainId


### PR DESCRIPTION
### Description
Non-breaking changes.
This removes the use of named capture groups in parseAssetIdRegExp to maintain compatibility with the Secure ECMAScript runtime.