### PR TITLE
feat(investor-yearn): accept bip44Params in signAndBroadcast input

### DIFF
--- a/packages/investor-yearn/src/YearnOpportunity.ts
+++ b/packages/investor-yearn/src/YearnOpportunity.ts
@@ -9,6 +9,7 @@ import {
 } from '@shapeshiftoss/investor'
 import { Logger } from '@shapeshiftoss/logger'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { BIP44Params } from '@shapeshiftoss/types'
 import { type ChainId, type Vault, type VaultMetadata, Yearn } from '@yfi/sdk'
 import type { BigNumber } from 'bignumber.js'
 import isNil from 'lodash/isNil'
@@ -176,12 +177,16 @@ export class YearnOpportunity
     wallet: HDWallet
     tx: PreparedTransaction
     feePriority?: FeePriority
+    bip44Params?: BIP44Params
   }): Promise<string> {
-    const { wallet, tx, feePriority } = input
+    const { bip44Params, wallet, tx, feePriority } = input
+
+    if (!bip44Params) throw new Error('bip44Params required for signAndBroadcast')
+
     const feeSpeed: FeePriority = feePriority ? feePriority : 'fast'
     const chainAdapter = this.#internals.chainAdapter
 
-    const path = toPath(chainAdapter.buildBIP44Params({ accountNumber: 0 }))
+    const path = toPath(bip44Params)
     const addressNList = bip32ToAddressNList(path)
     const gasPrice = numberToHex(bnOrZero(tx.gasPrice).times(feeMultipier[feeSpeed]).toString())
     const txToSign: ETHSignTx = {

--- a/packages/investor-yearn/src/yearncli.ts
+++ b/packages/investor-yearn/src/yearncli.ts
@@ -63,6 +63,11 @@ const main = async (): Promise<void> => {
     wallet,
     tx: depositPreparedTx,
     feePriority: 'fast',
+    bip44Params: {
+      accountNumber: 0,
+      coinType: 60,
+      purpose: 44,
+    },
   })
   console.info(
     JSON.stringify(

--- a/packages/investor/package.json
+++ b/packages/investor/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "@shapeshiftoss/hdwallet-core": "^1.23.0",
+    "@shapeshiftoss/types": "8.1.0",
     "bignumber.js": "^9.0.2"
   }
 }

--- a/packages/investor/src/InvestorOpportunity.ts
+++ b/packages/investor/src/InvestorOpportunity.ts
@@ -1,4 +1,5 @@
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { BIP44Params } from '@shapeshiftoss/types'
 import type { BigNumber } from 'bignumber.js'
 
 import { FeePriority } from './Extensions'
@@ -103,5 +104,6 @@ export abstract class InvestorOpportunity<TxType = unknown, MetaData = unknown> 
     tx: TxType
     /** Specify the user's preferred fee priority (fast/average/slow) */
     feePriority?: FeePriority
+    bip44Params?: BIP44Params
   }) => Promise<string>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,6 +2994,11 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
+"@shapeshiftoss/types@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-8.1.0.tgz#a087f3b89fd68bb07749a75de4afbb5314850711"
+  integrity sha512-/sDoPB5tHWzcMjF/si66ZkZuzcp4JuTGi7AhQoUUeigYNHD5PHjOER4L60MnKSLIyDX8T+yF8335Zq6U5Q6Hag==
+
 "@shapeshiftoss/unchained-client@^9.5.0":
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-9.9.0.tgz#093ba1f9f9ce04b07a027eeba2ba9ad32c4f86ba"


### PR DESCRIPTION
BREAKING CHANGE: signAndBroadcast now accepts a bip44Params property in its input and will throw if not passed.

### Description

This PR:

- Accepts an optional (for backward-compatibility and not to break the abstracted `InvestorOpportunity` base type) `bip44Params` as input property
- Adds the optional property in the abstracted `InvestorOpportunity` 

### Issue

- Tackles https://github.com/shapeshift/web/issues/2605