### PR TITLE
feat(investor-foxy): accept bip44Params

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -385,7 +385,7 @@ export class FoxyApi {
   async approve(input: ApproveInput): Promise<string> {
     const {
       amount,
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       tokenContractAddress,
       userAddress,
@@ -409,7 +409,6 @@ export class FoxyApi {
       })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const estimatedGas = estimatedGasBN.toString()
     const payload = {
@@ -446,7 +445,7 @@ export class FoxyApi {
   async deposit(input: TxInput): Promise<string> {
     const {
       amountDesired,
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       contractAddress,
       userAddress,
@@ -475,7 +474,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -493,7 +491,7 @@ export class FoxyApi {
   async withdraw(input: WithdrawInput): Promise<string> {
     const {
       amountDesired,
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       contractAddress,
       userAddress,
@@ -525,7 +523,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -612,7 +609,7 @@ export class FoxyApi {
 
   async claimWithdraw(input: ClaimWithdrawal): Promise<string> {
     const {
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       contractAddress,
       userAddress,
@@ -641,7 +638,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -729,7 +725,7 @@ export class FoxyApi {
   }
 
   async sendWithdrawalRequests(input: TxInputWithoutAmount): Promise<string> {
-    const { accountNumber = 0, dryRun = false, contractAddress, userAddress, wallet } = input
+    const { bip44Params, dryRun = false, contractAddress, userAddress, wallet } = input
     this.verifyAddresses([userAddress, contractAddress])
     if (!wallet || !contractAddress) throw new Error('Missing inputs')
 
@@ -751,7 +747,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -771,7 +766,7 @@ export class FoxyApi {
   async addLiquidity(input: TxInput): Promise<string> {
     const {
       amountDesired,
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       contractAddress,
       userAddress,
@@ -799,7 +794,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -819,7 +813,7 @@ export class FoxyApi {
   async removeLiquidity(input: TxInput): Promise<string> {
     const {
       amountDesired,
-      accountNumber = 0,
+      bip44Params,
       dryRun = false,
       contractAddress,
       userAddress,
@@ -846,7 +840,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const estimatedGas = estimatedGasBN.toString()
-    const bip44Params = this.adapter.buildBIP44Params({ accountNumber })
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -22,7 +22,7 @@ export type AllowanceInput = {
 
 export type ApproveInput = {
   amount?: string
-  accountNumber?: number
+  bip44Params: BIP44Params
   dryRun?: boolean
   tokenContractAddress: string
   contractAddress: string
@@ -36,7 +36,7 @@ export type EstimateGasApproveInput = Pick<
 >
 
 export type TxInput = {
-  accountNumber?: number
+  bip44Params: BIP44Params
   dryRun?: boolean
   tokenContractAddress?: string
   userAddress: string

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -106,6 +106,11 @@ const main = async (): Promise<void> => {
         contractAddress,
         userAddress,
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('approve', response)
     } catch (e) {
@@ -121,6 +126,11 @@ const main = async (): Promise<void> => {
         amountDesired: bnOrZero(amount),
         userAddress,
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('stake', response)
     } catch (e) {
@@ -137,6 +147,11 @@ const main = async (): Promise<void> => {
         type: WithdrawType.DELAYED,
         userAddress,
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('unstake', response)
     } catch (e) {
@@ -152,6 +167,11 @@ const main = async (): Promise<void> => {
         type: WithdrawType.INSTANT,
         userAddress,
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('instantUnstake', response)
     } catch (e) {
@@ -167,6 +187,11 @@ const main = async (): Promise<void> => {
         claimAddress,
         userAddress,
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('claimWithdraw', response)
     } catch (e) {
@@ -182,6 +207,11 @@ const main = async (): Promise<void> => {
         userAddress,
         amountDesired: bnOrZero(amount),
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('addLiquidity', response)
     } catch (e) {
@@ -197,6 +227,11 @@ const main = async (): Promise<void> => {
         userAddress,
         amountDesired: bnOrZero(amount),
         wallet,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('removeLiquidity', response)
     } catch (e) {
@@ -222,6 +257,11 @@ const main = async (): Promise<void> => {
       const response = await api.getTimeUntilClaimable({
         contractAddress: foxyStakingContractAddress,
         userAddress,
+        bip44Params: {
+          accountNumber: 0,
+          coinType: 60,
+          purpose: 44,
+        },
       })
       console.info('getTimeUntilClaim', response)
     } catch (e) {


### PR DESCRIPTION
BREAKING CHANGE: investor-foxy now expects full `bip44Params` params in tx input methods instead of `accountNumber`

### Description

This PR:

- Replaces the previous`accountNumber` input field in investor-foxy methods with `bip44Params`
- Removes the making of `bip44Params` from `accountNumber`, since it's now passed in

### Issue

- tackles https://github.com/shapeshift/web/issues/2611
- closes https://github.com/shapeshift/lib/issues/1000