### PR TITLE
chore: add `array-type` lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,8 @@
     "simple-import-sort/imports": [
       "error"
     ],
-    "object-shorthand": "error"
+    "object-shorthand": "error",
+    "@typescript-eslint/array-type": "error"
   },
   "overrides": [
     {

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,4 @@
 
 # chore: add trailing comma lint rule (https://github.com/shapeshift/lib/pull/975)
 505516c23b582ff1cd2d684b6c84a117157e3423
+# TODO: Replace me with the hash of this commit

--- a/packages/asset-service/src/generateAssetData/coingecko.ts
+++ b/packages/asset-service/src/generateAssetData/coingecko.ts
@@ -20,12 +20,9 @@ type TokenList = {
   logoURI: string
   keywords: string[]
   timestamp: string
-  tokens: Array<Token>
+  tokens: Token[]
 }
-export async function getAssets(
-  chainId: ChainId,
-  overrideAssets: Array<Asset> = [],
-): Promise<Asset[]> {
+export async function getAssets(chainId: ChainId, overrideAssets: Asset[] = []): Promise<Asset[]> {
   const { category, explorer, explorerAddressLink, explorerTxLink } = (() => {
     switch (chainId) {
       case ethChainId:
@@ -49,7 +46,7 @@ export async function getAssets(
 
   const { data } = await axios.get<TokenList>(`https://tokens.coingecko.com/${category}/all.json`)
 
-  return data.tokens.reduce<Array<Asset>>((prev, token) => {
+  return data.tokens.reduce<Asset[]>((prev, token) => {
     try {
       // blacklist wormhole assets - users can't hold a balance and we don't support wormholes
       if (token.name.toLowerCase().includes('wormhole')) return prev

--- a/packages/asset-service/src/generateAssetData/ethereum/overrides.ts
+++ b/packages/asset-service/src/generateAssetData/ethereum/overrides.ts
@@ -1,7 +1,7 @@
 import { Asset } from '../../service/AssetService'
 import { ethereum } from '../baseAssets'
 
-export const overrideTokens: Array<Asset> = [
+export const overrideTokens: Asset[] = [
   // example overriding FOX token with custom values instead of goingecko
   {
     assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -40,7 +40,7 @@ export type ChainAdapter<T extends ChainId> = {
    * For UTXO coins, that's the list of UTXO account types
    * For other networks, this is unimplemented, and left as a responsibility of the consumer.
    */
-  getSupportedAccountTypes?(): Array<UtxoAccountType>
+  getSupportedAccountTypes?(): UtxoAccountType[]
   /**
    * Get the balance of an address
    */

--- a/packages/chain-adapters/src/coinselect.d.ts
+++ b/packages/chain-adapters/src/coinselect.d.ts
@@ -11,14 +11,14 @@ type Output = {
 
 type CoinSelectResult<T> = {
   fee: number
-  inputs?: Array<T>
-  outputs?: Array<Output>
+  inputs?: T[]
+  outputs?: Output[]
 }
 
 declare module 'coinselect' {
   declare function coinSelect<T = unknown>(
-    utxos: Array<Utxo>,
-    outputs: Array<Output>,
+    utxos: Utxo[],
+    outputs: Output[],
     feeRate: number,
   ): CoinSelectResult<Omit<T, 'value'> & { value: number }>
 
@@ -27,8 +27,8 @@ declare module 'coinselect' {
 
 declare module 'coinselect/split' {
   declare function split<T = unknown>(
-    utxos: Array<Utxo>,
-    outputs: Array<Output>,
+    utxos: Utxo[],
+    outputs: Output[],
     feeRate: number,
   ): CoinSelectResult<Omit<T, 'value'> & { value: number }>
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -57,7 +57,7 @@ export interface ChainAdapterArgs {
 
 export interface CosmosSdkBaseAdapterArgs extends ChainAdapterArgs {
   defaultBIP44Params: BIP44Params
-  supportedChainIds: Array<ChainId>
+  supportedChainIds: ChainId[]
   chainId: CosmosSdkChainId
 }
 
@@ -65,7 +65,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
   protected readonly chainId: CosmosSdkChainId
   protected readonly coinName: string
   protected readonly defaultBIP44Params: BIP44Params
-  protected readonly supportedChainIds: Array<ChainId>
+  protected readonly supportedChainIds: ChainId[]
   protected readonly providers: {
     http: unchained.cosmos.V1Api | unchained.osmosis.V1Api
     ws: unchained.ws.Client<unchained.cosmos.Tx> | unchained.ws.Client<unchained.osmosis.Tx>
@@ -297,7 +297,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     this.providers.ws.close('txs')
   }
 
-  async getValidators(): Promise<Array<cosmos.Validator>> {
+  async getValidators(): Promise<cosmos.Validator[]> {
     try {
       const { data } = await this.providers.http.getValidators()
       return data.validators.map<cosmos.Validator>((validator) => transformValidator(validator))

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -57,14 +57,14 @@ export interface ChainAdapterArgs {
 
 export interface EvmBaseAdapterArgs extends ChainAdapterArgs {
   defaultBIP44Params: BIP44Params
-  supportedChainIds: Array<ChainId>
+  supportedChainIds: ChainId[]
   chainId: EvmChainId
 }
 
 export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdapter<T> {
   protected readonly chainId: EvmChainId
   protected readonly defaultBIP44Params: BIP44Params
-  protected readonly supportedChainIds: Array<ChainId>
+  protected readonly supportedChainIds: ChainId[]
   protected readonly providers: {
     http: unchained.ethereum.V1Api | unchained.avalanche.V1Api
     ws: unchained.ws.Client<unchained.evm.types.Tx>

--- a/packages/chain-adapters/src/evm/types.ts
+++ b/packages/chain-adapters/src/evm/types.ts
@@ -4,7 +4,7 @@ import { AssetBalance } from '../types'
 
 export type Account = {
   nonce: number
-  tokens?: Array<AssetBalance>
+  tokens?: AssetBalance[]
 }
 
 export type FeeData = {

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -96,7 +96,7 @@ export type TradeType = unchained.TradeType
 export type TxMetadata = unchained.evm.TxMetadata | unchained.cosmos.TxMetadata
 
 export type Transaction = Omit<unchained.StandardTx, 'transfers'> & {
-  transfers: Array<TxTransfer>
+  transfers: TxTransfer[]
   data?: TxMetadata
 }
 
@@ -111,7 +111,7 @@ export type SubscribeError = {
 export type TxHistoryResponse = {
   cursor: string
   pubkey: string
-  transactions: Array<Transaction>
+  transactions: Transaction[]
 }
 
 type ChainTxTypeInner = {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -67,8 +67,8 @@ export interface ChainAdapterArgs {
 export interface UtxoBaseAdapterArgs extends ChainAdapterArgs {
   defaultBIP44Params: BIP44Params
   defaultUtxoAccountType: UtxoAccountType
-  supportedChainIds: Array<ChainId>
-  supportedAccountTypes: Array<UtxoAccountType>
+  supportedChainIds: ChainId[]
+  supportedAccountTypes: UtxoAccountType[]
   chainId: UtxoChainId
 }
 
@@ -77,8 +77,8 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   protected readonly coinName: string
   protected readonly defaultBIP44Params: BIP44Params
   protected readonly defaultUtxoAccountType: UtxoAccountType
-  protected readonly supportedChainIds: Array<ChainId>
-  protected readonly supportedAccountTypes: Array<UtxoAccountType>
+  protected readonly supportedChainIds: ChainId[]
+  protected readonly supportedAccountTypes: UtxoAccountType[]
   protected readonly providers: {
     http:
       | unchained.bitcoin.V1Api
@@ -89,7 +89,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   protected assetId: AssetId
-  protected accountAddresses: Record<string, Array<string>> = {}
+  protected accountAddresses: Record<string, string[]> = {}
   protected parser: unchained.utxo.BaseTransactionParser<unchained.utxo.types.Tx>
 
   protected constructor(args: UtxoBaseAdapterArgs) {
@@ -121,7 +121,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     return this.chainId
   }
 
-  getSupportedAccountTypes(): Array<UtxoAccountType> {
+  getSupportedAccountTypes(): UtxoAccountType[] {
     return this.supportedAccountTypes
   }
 
@@ -253,7 +253,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
       const { inputs, outputs } = coinSelectResult
 
-      const signTxInputs: Array<BTCSignTxInput> = []
+      const signTxInputs: BTCSignTxInput[] = []
       for (const input of inputs) {
         if (!input.path) continue
 
@@ -374,8 +374,8 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
       cursor: input.cursor,
     })
 
-    const getAddresses = (tx: unchained.utxo.types.Tx): Array<string> => {
-      const addresses: Array<string> = []
+    const getAddresses = (tx: unchained.utxo.types.Tx): string[] => {
+      const addresses: string[] = []
 
       tx.vin?.forEach((vin) => {
         if (!vin.addresses) return

--- a/packages/chain-adapters/src/utxo/types.ts
+++ b/packages/chain-adapters/src/utxo/types.ts
@@ -4,7 +4,7 @@ import { GetAddressInputBase } from '../types'
 
 export type Account = {
   /** Derived addresses and associated balances if account is xpub based (gap limit 20) */
-  addresses?: Array<Address>
+  addresses?: Address[]
   /** Next unused change address index for current account if account is xpub based */
   nextChangeAddressIndex?: number
   /** Next unused receive address index for current account if account is xpub based */
@@ -45,7 +45,7 @@ export type Vout = {
 }
 
 export type ScriptPubKey = {
-  addresses: Array<string>
+  addresses: string[]
   type: string
   reqSigs: number
   hex: string
@@ -60,8 +60,8 @@ export type NodeTransaction = {
   vsize: number
   weight: number
   locktime: number
-  vin: Array<Vin>
-  vout: Array<Vout>
+  vin: Vin[]
+  vout: Vout[]
   hex: string
   blockhash: string
   confirmations: number

--- a/packages/investor/src/Investor.ts
+++ b/packages/investor/src/Investor.ts
@@ -2,11 +2,9 @@ import { InvestorOpportunity } from './InvestorOpportunity'
 
 export interface Investor<TxType = unknown, MetaData = unknown> {
   initialize: () => Promise<void>
-  findAll: () => Promise<Array<InvestorOpportunity<TxType, MetaData>>>
+  findAll: () => Promise<InvestorOpportunity<TxType, MetaData>[]>
   findByOpportunityId: (
     opportunityId: string,
   ) => Promise<InvestorOpportunity<TxType, MetaData> | undefined>
-  findByUnderlyingAssetId: (
-    assetId: string,
-  ) => Promise<Array<InvestorOpportunity<TxType, MetaData>>>
+  findByUnderlyingAssetId: (assetId: string) => Promise<InvestorOpportunity<TxType, MetaData>[]>
 }

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -116,7 +116,7 @@ interface TradeBase<C extends ChainId> {
   sellAmount: string
   feeData: QuoteFeeData<C>
   rate: string
-  sources: Array<SwapSource>
+  sources: SwapSource[]
   buyAsset: Asset
   sellAsset: Asset
   sellAssetAccountNumber: number

--- a/packages/swapper/src/swappers/cow/types.ts
+++ b/packages/swapper/src/swappers/cow/types.ts
@@ -27,7 +27,7 @@ export type CowSwapGetTradesElement = {
   txHash: string
 }
 
-export type CowSwapGetTradesResponse = Array<CowSwapGetTradesElement>
+export type CowSwapGetTradesResponse = CowSwapGetTradesElement[]
 
 export interface CowTrade<C extends ChainId> extends Trade<C> {
   feeAmountInSellToken: string

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
@@ -32,7 +32,7 @@ export const ORDER_TYPE_FIELDS = [
 /**
  * EIP-712 typed data type definitions.
  */
-export declare type TypedDataTypes = Record<string, Array<TypedDataField>>
+export declare type TypedDataTypes = Record<string, TypedDataField[]>
 
 export type CowSwapOrder = {
   sellToken: string

--- a/packages/swapper/src/swappers/utils/abi/erc20-abi.ts
+++ b/packages/swapper/src/swappers/utils/abi/erc20-abi.ts
@@ -1,6 +1,6 @@
 import { AbiItem } from 'web3-utils'
 
-export const erc20Abi: Array<AbiItem> = [
+export const erc20Abi: AbiItem[] = [
   {
     constant: true,
     inputs: [],

--- a/packages/swapper/src/swappers/zrx/types.ts
+++ b/packages/swapper/src/swappers/zrx/types.ts
@@ -9,7 +9,7 @@ export type ZrxCommonResponse = {
   buyAmount: string
   sellAmount: string
   allowanceTarget: string
-  sources: Array<SwapSource>
+  sources: SwapSource[]
 }
 
 export type ZrxPriceResponse = ZrxCommonResponse & {

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/foxyStaking.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/foxyStaking.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const foxyStaking: Array<JsonFragment> = [
+const foxyStaking: JsonFragment[] = [
   {
     inputs: [
       {

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/shapeShiftRouter.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/shapeShiftRouter.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const shapeShiftRouter: Array<JsonFragment> = [
+const shapeShiftRouter: JsonFragment[] = [
   {
     inputs: [
       {

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/thor.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/thor.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const thor: Array<JsonFragment> = [
+const thor: JsonFragment[] = [
   { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
   {
     anonymous: false,

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/uniV2.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/uniV2.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const uniV2: Array<JsonFragment> = [
+const uniV2: JsonFragment[] = [
   {
     inputs: [
       { internalType: 'address', name: '_factory', type: 'address' },

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/uniV2StakingRewards.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/uniV2StakingRewards.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const uniV2StakingRewards: Array<JsonFragment> = [
+const uniV2StakingRewards: JsonFragment[] = [
   {
     inputs: [
       {

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/weth.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/weth.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const weth: Array<JsonFragment> = [
+const weth: JsonFragment[] = [
   {
     constant: true,
     inputs: [],

--- a/packages/unchained-client/src/evm/ethereum/parser/abi/yearnVault.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/abi/yearnVault.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const yearnVault: Array<JsonFragment> = [
+const yearnVault: JsonFragment[] = [
   {
     name: 'Transfer',
     inputs: [

--- a/packages/unchained-client/src/evm/parser/abi/erc20.ts
+++ b/packages/unchained-client/src/evm/parser/abi/erc20.ts
@@ -1,6 +1,6 @@
 import { JsonFragment } from '@ethersproject/abi/lib/fragments'
 
-const erc20: Array<JsonFragment> = [
+const erc20: JsonFragment[] = [
   {
     inputs: [
       {

--- a/packages/unchained-client/src/evm/parser/index.ts
+++ b/packages/unchained-client/src/evm/parser/index.ts
@@ -21,7 +21,7 @@ export class BaseTransactionParser<T extends Tx> {
 
   protected readonly provider: ethers.providers.JsonRpcProvider
 
-  private parsers: Array<SubParser<T>> = []
+  private parsers: SubParser<T>[] = []
 
   constructor(args: TransactionParserArgs) {
     this.chainId = args.chainId
@@ -39,7 +39,7 @@ export class BaseTransactionParser<T extends Tx> {
     this.parsers.unshift(parser)
   }
 
-  protected registerParsers(parsers: Array<SubParser<T>>): void {
+  protected registerParsers(parsers: SubParser<T>[]): void {
     parsers.forEach((parser) => this.registerParser(parser))
   }
 

--- a/packages/unchained-client/src/types.ts
+++ b/packages/unchained-client/src/types.ts
@@ -43,7 +43,7 @@ export interface Transfer {
   assetId: string
   type: TransferType
   totalValue: string
-  components: Array<{ value: string }>
+  components: { value: string }[]
   token?: Token
 }
 
@@ -69,7 +69,7 @@ export interface StandardTx {
   fee?: Fee
   status: TxStatus
   trade?: Trade
-  transfers: Array<Transfer>
+  transfers: Transfer[]
   txid: string
 }
 

--- a/packages/unchained-client/src/utils.ts
+++ b/packages/unchained-client/src/utils.ts
@@ -17,14 +17,14 @@ export async function findAsyncSequential<T, U>(
 
 // keep track of all individual tx components and add up the total value transferred
 export function aggregateTransfer(
-  transfers: Array<Transfer>,
+  transfers: Transfer[],
   type: TransferType,
   assetId: string,
   from: string,
   to: string,
   value: string,
   token?: Token,
-): Array<Transfer> {
+): Transfer[] {
   if (!new BigNumber(value).gt(0)) return transfers
 
   const index = transfers?.findIndex(


### PR DESCRIPTION
Adds `array-type` lint rule for codebase consistency.

https://typescript-eslint.io/rules/array-type/