### PR TITLE
feat(eslint-pluggin-logger): add missing fields in package.json

### DIFF
--- a/packages/eslint-plugin-logger/package.json
+++ b/packages/eslint-plugin-logger/package.json
@@ -2,7 +2,18 @@
   "name": "@shapeshiftoss/eslint-plugin-logger",
   "description": "An eslint plugin disallowing console.* in favor of their moduleLogger equivalent",
   "version": "1.0.0",
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shapeshift/lib"
+  },
   "scripts": {
     "build": "yarn clean && yarn compile",
     "clean": "rm -rf dist && rm -rf tsconfig.build.tsbuildinfo",


### PR DESCRIPTION
### Description

This adds missing fields to the package.json of eslint-plugin-logger,
namely `{publishConfig: 'public'}` which will make sure the package gets
published as a public, scoped package.
