### PR TITLE
WIP chore: fix avax adapter tests

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -1,5 +1,6 @@
 import { AssetId, ChainId, fromAssetId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
 import {
+  BIP32Path,
   bip32ToAddressNList,
   ETHSignMessage,
   ETHSignTx,
@@ -108,6 +109,11 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
       throw new Error('accountNumber must be >= 0')
     }
     return { ...this.defaultBIP44Params, accountNumber }
+  }
+
+  getAddressNList(accountNumber: number): BIP32Path {
+    const p = this.getBIP44Params({ accountNumber })
+    return bip32ToAddressNList(`m/${p.purpose}'/${p.coinType}'/${accountNumber}'/0/0`)
   }
 
   async buildSendTransaction(tx: BuildSendTxInput<T>): Promise<{

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -268,12 +268,12 @@ describe('AvalancheChainAdapter', () => {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
         },
       }
 
       await expect(adapter.signMessage(message)).resolves.toEqual(
-        '0x05a0edb4b98fe6b6ed270bf55aef84ddcb641512e19e340bf9eed3427854a7a4734fe45551dc24f1843cf2c823a73aa2454e3785eb15120573c522cc114e472d1c',
+        '0x4e577cdf5b142018700e3944191516da8037071600c7396c8bbab55cdc852e08375f01a35ebfc72699389a3bfbbe33afd95525207963c29048824c5d5e6cf1841b',
       )
     })
 
@@ -287,7 +287,7 @@ describe('AvalancheChainAdapter', () => {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
         },
       }
 
@@ -367,7 +367,7 @@ describe('AvalancheChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 43114,
           data: '',
           gasLimit: numberToHex(gasLimit),
@@ -434,7 +434,7 @@ describe('AvalancheChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 43114,
           data: '',
           gasLimit: numberToHex(gasLimit),
@@ -472,7 +472,7 @@ describe('AvalancheChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 43114,
           data: '0xa9059cbb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000190',
           gasLimit: numberToHex(gasLimit),
@@ -511,7 +511,7 @@ describe('AvalancheChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147492648, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 43114,
           data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
           gasLimit: numberToHex(gasLimit),

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -258,7 +258,7 @@ describe('EthereumChainAdapter', () => {
       await adapter.getAddress({ bip44Params, wallet })
 
       expect(wallet.ethGetAddress).toHaveBeenCalledWith({
-        addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+        addressNList: adapter.getAddressNList(0),
         showDisplay: false,
       })
     })
@@ -354,7 +354,7 @@ describe('EthereumChainAdapter', () => {
       const tx = {
         wallet: await getWallet(),
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           value: '0x0',
           to: EOA_ADDRESS,
           chainId: 1,
@@ -382,7 +382,7 @@ describe('EthereumChainAdapter', () => {
       const tx = {
         wallet: await getWallet(),
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           value: '0x0',
           to: EOA_ADDRESS,
           chainId: 1,
@@ -438,12 +438,11 @@ describe('EthereumChainAdapter', () => {
       const args = makeChainAdapterArgs()
       const adapter = new ethereum.ChainAdapter(args)
       const wallet = await getWallet()
-
       const message: SignMessageInput<ETHSignMessage> = {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
         },
       }
 
@@ -461,7 +460,7 @@ describe('EthereumChainAdapter', () => {
         wallet,
         messageToSign: {
           message: 'Hello world 111',
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
         },
       }
 
@@ -561,7 +560,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 1,
           data: '',
           gasLimit: numberToHex(gasLimit),
@@ -617,7 +616,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 1,
           data: '',
           gasLimit: numberToHex(gasLimit),
@@ -649,7 +648,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 1,
           data: '0xa9059cbb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000190',
           gasLimit: numberToHex(gasLimit),
@@ -683,7 +682,7 @@ describe('EthereumChainAdapter', () => {
 
       await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           chainId: 1,
           data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
           gasLimit: numberToHex(gasLimit),
@@ -749,7 +748,7 @@ describe('EthereumChainAdapter', () => {
 
       const expectedOutput = {
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           value: '123',
           to: '0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F',
           chainId: 1,
@@ -790,7 +789,7 @@ describe('EthereumChainAdapter', () => {
 
       const expectedOutput = {
         txToSign: {
-          addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
+          addressNList: adapter.getAddressNList(0),
           value: '123',
           to: '0x47CB53752e5dc0A972440dA127DCA9FBA6C2Ab6F',
           chainId: 1,


### PR DESCRIPTION
The `signMessage` test in the avax chain adapter was errantly passing 2147492648 (hardened 0) for the `coinType`. With HDWallet PR https://github.com/shapeshift/hdwallet/pull/571 we actually use the coinType passed in causing the signMessage test assertion on the signed response to fail.

I also cleaned up the other places we pass an addressNList in the evm tests to make this clear.

The signMessage test will fail in CI until we publish HDWallet/version bump.