### PR TITLE
feat(investor-foxy): switch from web3 to ethers and JsonRpcBatchProvider

### DIFF
--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -27,9 +27,10 @@
     "cli": "yarn build && node ./dist/foxycli.js"
   },
   "dependencies": {
-    "@ethersproject/providers": "^5.5.3",
+    "@ethersproject/providers": "^5.7.1",
     "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",
+    "ethers": "^5.7.1",
     "lodash": "^4.17.21",
     "web3": "1.7.4",
     "web3-core": "1.7.4",

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -38,13 +38,13 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^10.5.0",
     "@shapeshiftoss/hdwallet-core": "^1.36.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^10.5.0",
     "@shapeshiftoss/hdwallet-core": "^1.36.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1"

--- a/packages/investor-foxy/src/abi/erc20-abi.ts
+++ b/packages/investor-foxy/src/abi/erc20-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const erc20Abi: AbiItem[] = [
+export const erc20Abi: ContractInterface = [
   {
     constant: true,
     inputs: [],

--- a/packages/investor-foxy/src/abi/foxy-abi.ts
+++ b/packages/investor-foxy/src/abi/foxy-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const foxyAbi: AbiItem[] = [
+export const foxyAbi: ContractInterface = [
   {
     inputs: [],
     stateMutability: 'nonpayable',

--- a/packages/investor-foxy/src/abi/foxy-staking-abi.ts
+++ b/packages/investor-foxy/src/abi/foxy-staking-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const foxyStakingAbi: AbiItem[] = [
+export const foxyStakingAbi: ContractInterface = [
   {
     inputs: [
       {

--- a/packages/investor-foxy/src/abi/liquidity-reserve-abi.ts
+++ b/packages/investor-foxy/src/abi/liquidity-reserve-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const liquidityReserveAbi: AbiItem[] = [
+export const liquidityReserveAbi: ContractInterface = [
   {
     inputs: [
       {

--- a/packages/investor-foxy/src/abi/toke-manager-abi.ts
+++ b/packages/investor-foxy/src/abi/toke-manager-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const tokeManagerAbi: AbiItem[] = [
+export const tokeManagerAbi: ContractInterface = [
   { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
   {
     anonymous: false,

--- a/packages/investor-foxy/src/abi/toke-pool-abi.ts
+++ b/packages/investor-foxy/src/abi/toke-pool-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const tokePoolAbi: AbiItem[] = [
+export const tokePoolAbi: ContractInterface = [
   {
     anonymous: false,
     inputs: [

--- a/packages/investor-foxy/src/abi/toke-reward-hash-abi.ts
+++ b/packages/investor-foxy/src/abi/toke-reward-hash-abi.ts
@@ -1,6 +1,6 @@
-import { AbiItem } from 'web3-utils'
+import { ContractInterface } from 'ethers/lib/ethers'
 
-export const tokeRewardHashAbi: AbiItem[] = [
+export const tokeRewardHashAbi: ContractInterface = [
   { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
   {
     anonymous: false,

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -951,9 +951,11 @@ export class FoxyApi {
     this.verifyAddresses([userAddress, contractAddress])
     const stakingContract = this.getStakingContract(contractAddress)
 
-    let coolDownInfo
+    let coolDownInfo: [amount: string, gons: string, expiry: string]
     try {
-      coolDownInfo = await stakingContract.coolDownInfo(userAddress)
+      coolDownInfo = (await stakingContract.coolDownInfo(userAddress)).map(
+        (info: ethers.BigNumber) => info.toString(),
+      )
     } catch (e) {
       throw new Error(`Failed to get coolDowninfo: ${e}`)
     }
@@ -963,8 +965,12 @@ export class FoxyApi {
     } catch (e) {
       throw new Error(`Failed to getTimeUntilClaimable: ${e}`)
     }
+
+    const [amount, gons, expiry] = coolDownInfo
     return {
-      ...coolDownInfo,
+      amount,
+      gons,
+      expiry,
       releaseTime,
     }
   }

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -455,21 +455,12 @@ export class FoxyApi {
     }
 
     const stakingContract = this.getStakingContract(contractAddress)
-    const userChecksum = ethers.utils.getAddress(userAddress)
+    // const userChecksum = ethers.utils.getAddress(userAddress)
 
-    const data: string =
-      (
-        await stakingContract.populateTransaction['stake(uint256,address)'](
-          this.normalizeAmount(amountDesired),
-          userAddress,
-          { from: userChecksum, value: 0 },
-        )
-      ).data ?? ''
-
-    // {
-    // value: 0,
-    // from: userChecksum,
-    // })
+    const data = stakingContract.interface.encodeFunctionData('stake(uint256,address)', [
+      this.normalizeAmount(amountDesired),
+      userAddress,
+    ])
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const chainReferenceAsNumber = Number(this.ethereumChainReference)

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -964,7 +964,7 @@ export class FoxyApi {
     const contract = new ethers.Contract(tokenContractAddress, foxyAbi, this.provider)
 
     try {
-      const balance = await contract.methods.circulatingSupply().call()
+      const balance = await contract.circulatingSupply()
       return bnOrZero(balance)
     } catch (e) {
       throw new Error(`Failed to get tvl: ${e}`)

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -418,7 +418,7 @@ export class FoxyApi {
 
     let allowance
     try {
-      allowance = await depositTokenContract.allowance(userAddress, contractAddress).call()
+      allowance = await depositTokenContract.allowance(userAddress, contractAddress)
     } catch (e) {
       throw new Error(`Failed to get allowance ${e}`)
     }
@@ -532,7 +532,7 @@ export class FoxyApi {
 
     const coolDownInfo = await (async () => {
       try {
-        const coolDown = await stakingContract.coolDownInfo(userAddress).call()
+        const coolDown = await stakingContract.coolDownInfo(userAddress)
         return {
           ...coolDown,
           endEpoch: coolDown.expiry,
@@ -544,7 +544,7 @@ export class FoxyApi {
 
     const epoch = await (async () => {
       try {
-        return stakingContract.epoch().call()
+        return stakingContract.epoch()
       } catch (e) {
         console.error(`Failed to get epoch: ${e}`)
         return {}
@@ -553,7 +553,7 @@ export class FoxyApi {
 
     const requestedWithdrawals = await (async () => {
       try {
-        return tokePoolContract.requestedWithdrawals(stakingContract.address).call()
+        return tokePoolContract.requestedWithdrawals(stakingContract.address)
       } catch (e) {
         console.error(`Failed to get requestedWithdrawals: ${e}`)
         return {}
@@ -562,7 +562,7 @@ export class FoxyApi {
 
     const currentCycleIndex = await (async () => {
       try {
-        return tokeManagerContract.getCurrentCycleIndex().call()
+        return tokeManagerContract.getCurrentCycleIndex()
       } catch (e) {
         console.error(`Failed to get currentCycleIndex: ${e}`)
         return 0
@@ -571,7 +571,7 @@ export class FoxyApi {
 
     const withdrawalAmount = await (async () => {
       try {
-        return stakingContract.withdrawalAmount().call()
+        return stakingContract.withdrawalAmount()
       } catch (e) {
         console.error(`Failed to get currentCycleIndex: ${e}`)
         return 0
@@ -649,7 +649,7 @@ export class FoxyApi {
 
     const requestWithdrawalAmount = await (async () => {
       try {
-        return stakingContract.requestWithdrawalAmount().call()
+        return stakingContract.requestWithdrawalAmount()
       } catch (e) {
         console.error(`Failed to get requestWithdrawalAmount: ${e}`)
         return 0
@@ -658,7 +658,7 @@ export class FoxyApi {
 
     const timeLeftToRequestWithdrawal = await (async () => {
       try {
-        return stakingContract.timeLeftToRequestWithdrawal().call()
+        return stakingContract.timeLeftToRequestWithdrawal()
       } catch (e) {
         console.error(`Failed to get timeLeftToRequestWithdrawal: ${e}`)
         return 0
@@ -667,7 +667,7 @@ export class FoxyApi {
 
     const lastTokeCycleIndex = await (async () => {
       try {
-        return stakingContract.lastTokeCycleIndex().call()
+        return stakingContract.lastTokeCycleIndex()
       } catch (e) {
         console.error(`Failed to get lastTokeCycleIndex: ${e}`)
         return 0
@@ -676,7 +676,7 @@ export class FoxyApi {
 
     const duration = await (async () => {
       try {
-        return tokeManagerContract.getCycleDuration().call()
+        return tokeManagerContract.getCycleDuration()
       } catch (e) {
         console.error(`Failed to get cycleDuration: ${e}`)
         return 0
@@ -685,7 +685,7 @@ export class FoxyApi {
 
     const currentCycleIndex = await (async () => {
       try {
-        return tokeManagerContract.getCurrentCycleIndex().call()
+        return tokeManagerContract.getCurrentCycleIndex()
       } catch (e) {
         console.error(`Failed to get currentCycleIndex: ${e}`)
         return 0
@@ -694,7 +694,7 @@ export class FoxyApi {
 
     const currentCycleStart = await (async () => {
       try {
-        return tokeManagerContract.getCurrentCycle().call()
+        return tokeManagerContract.getCurrentCycle()
       } catch (e) {
         console.error(`Failed to get currentCycle: ${e}`)
         return 0
@@ -854,7 +854,7 @@ export class FoxyApi {
 
     let coolDownInfo
     try {
-      const coolDown = await stakingContract.coolDownInfo(userAddress).call()
+      const coolDown = await stakingContract.coolDownInfo(userAddress)
       coolDownInfo = {
         ...coolDown,
         endEpoch: coolDown.expiry,
@@ -864,7 +864,7 @@ export class FoxyApi {
     }
     let epoch
     try {
-      epoch = await stakingContract.epoch().call()
+      epoch = await stakingContract.epoch()
     } catch (e) {
       throw new Error(`Failed to get epoch: ${e}`)
     }
@@ -894,7 +894,7 @@ export class FoxyApi {
 
     const contract = new ethers.Contract(tokenContractAddress, erc20Abi, this.provider)
     try {
-      const balance = await contract.balanceOf(userAddress).call()
+      const balance = await contract.balanceOf(userAddress)
       return bnOrZero(balance)
     } catch (e) {
       throw new Error(`Failed to get balance: ${e}`)
@@ -908,13 +908,13 @@ export class FoxyApi {
 
     let liquidityReserveAddress
     try {
-      liquidityReserveAddress = await stakingContract.LIQUIDITY_RESERVE().call()
+      liquidityReserveAddress = await stakingContract.LIQUIDITY_RESERVE()
     } catch (e) {
       throw new Error(`Failed to get liquidityReserve address ${e}`)
     }
     const liquidityReserveContract = this.getLiquidityReserveContract(liquidityReserveAddress)
     try {
-      const feeInBasisPoints = await liquidityReserveContract.fee().call()
+      const feeInBasisPoints = await liquidityReserveContract.fee()
       return bnOrZero(feeInBasisPoints).div(10000) // convert from basis points to decimal percentage
     } catch (e) {
       throw new Error(`Failed to get instantUnstake fee ${e}`)
@@ -926,7 +926,7 @@ export class FoxyApi {
     const contract = new ethers.Contract(tokenContractAddress, erc20Abi, this.provider)
 
     try {
-      const totalSupply = await contract.totalSupply().call()
+      const totalSupply = await contract.totalSupply()
       return bnOrZero(totalSupply)
     } catch (e) {
       throw new Error(`Failed to get totalSupply: ${e}`)
@@ -962,7 +962,7 @@ export class FoxyApi {
 
     let coolDownInfo
     try {
-      coolDownInfo = await stakingContract.coolDownInfo(userAddress).call()
+      coolDownInfo = await stakingContract.coolDownInfo(userAddress)
     } catch (e) {
       throw new Error(`Failed to get coolDowninfo: ${e}`)
     }
@@ -987,14 +987,14 @@ export class FoxyApi {
     )
     const latestCycleIndex = await (async () => {
       try {
-        return rewardHashContract.latestCycleIndex().call()
+        return rewardHashContract.latestCycleIndex()
       } catch (e) {
         throw new Error(`Failed to get latestCycleIndex, ${e}`)
       }
     })()
     const cycleHashes = await (async () => {
       try {
-        return rewardHashContract.cycleHashes(latestCycleIndex).call()
+        return rewardHashContract.cycleHashes(latestCycleIndex)
       } catch (e) {
         throw new Error(`Failed to get latestCycleIndex, ${e}`)
       }

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -359,7 +359,7 @@ export class FoxyApi {
     try {
       const estimatedGas = await stakingContract.estimateGas['stake(uint256)'](
         this.normalizeAmount(amountDesired),
-        userAddress,
+        { from: userAddress },
       )
       return estimatedGas.toString()
     } catch (e) {

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -382,11 +382,10 @@ export class FoxyApi {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
     const depositTokenContract = new ethers.Contract(tokenContractAddress, erc20Abi, this.provider)
-    const data: string = depositTokenContract
-      .approve(contractAddress, amount ? numberToHex(bnOrZero(amount).toString()) : MAX_ALLOWANCE)
-      .encodeABI({
-        from: userAddress,
-      })
+    const data: string = depositTokenContract.interface.encodeFunctionData('approve', [
+      contractAddress,
+      amount ? numberToHex(bnOrZero(amount).toString()) : MAX_ALLOWANCE,
+    ])
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const chainReferenceAsNumber = Number(this.ethereumChainReference)

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -163,7 +163,7 @@ export class FoxyApi {
 
   private getStakingContract(contractAddress: string): ethers.Contract {
     const stakingContract = this.foxyStakingContracts.find(
-      (item) => toLower(item.options.address) === toLower(contractAddress),
+      (item) => toLower(item.address) === toLower(contractAddress),
     )
     if (!stakingContract) throw new Error('Not a valid contract address')
     return stakingContract
@@ -171,7 +171,7 @@ export class FoxyApi {
 
   private getLiquidityReserveContract(liquidityReserveAddress: string): ethers.Contract {
     const liquidityReserveContract = this.liquidityReserveContracts.find(
-      (item) => toLower(item.options.address) === toLower(liquidityReserveAddress),
+      (item) => toLower(item.address) === toLower(liquidityReserveAddress),
     )
     if (!liquidityReserveContract) throw new Error('Not a valid reserve contract address')
     return liquidityReserveContract
@@ -198,7 +198,7 @@ export class FoxyApi {
       const opportunities = await Promise.all(
         this.foxyAddresses.map(async (addresses) => {
           const stakingContract = this.foxyStakingContracts.find(
-            (item) => toLower(item.options.address) === toLower(addresses.staking),
+            (item) => toLower(item.address) === toLower(addresses.staking),
           )
           try {
             const expired = await stakingContract?.methods.pauseStaking().call()
@@ -569,7 +569,7 @@ export class FoxyApi {
 
     const requestedWithdrawals = await (async () => {
       try {
-        return tokePoolContract.methods.requestedWithdrawals(stakingContract.options.address).call()
+        return tokePoolContract.methods.requestedWithdrawals(stakingContract.address).call()
       } catch (e) {
         console.error(`Failed to get requestedWithdrawals: ${e}`)
         return {}

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -321,7 +321,10 @@ export class FoxyApi {
 
     try {
       const estimatedGas = isDelayed
-        ? await stakingContract.estimateGas.unstake(this.normalizeAmount(amountDesired), true)
+        ? await stakingContract.estimateGas['unstake(uint256,bool)'](
+            this.normalizeAmount(amountDesired),
+            true,
+          )
         : await stakingContract.estimateGas.instantUnstake(true)
       return estimatedGas.toString()
     } catch (e) {
@@ -354,7 +357,7 @@ export class FoxyApi {
     const stakingContract = this.getStakingContract(contractAddress)
 
     try {
-      const estimatedGas = await stakingContract.estimateGas.stake(
+      const estimatedGas = await stakingContract.estimateGas['stake(uint256)'](
         this.normalizeAmount(amountDesired),
         userAddress,
       )

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -245,7 +245,7 @@ export class FoxyApi {
     return this.provider.getTransactionReceipt(txid)
   }
 
-  async estimateClaimWithdrawGas(input: ClaimWithdrawal): Promise<BigNumber> {
+  async estimateClaimWithdrawGas(input: ClaimWithdrawal): Promise<string> {
     const { claimAddress, userAddress, contractAddress } = input
     const addressToClaim = claimAddress ?? userAddress
     this.verifyAddresses([addressToClaim, userAddress, contractAddress])
@@ -254,15 +254,13 @@ export class FoxyApi {
 
     try {
       const estimatedGas = await stakingContract.estimateGas.claimWithdraw(addressToClaim)
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateSendWithdrawalRequestsGas(
-    input: TxInputWithoutAmountAndWallet,
-  ): Promise<BigNumber> {
+  async estimateSendWithdrawalRequestsGas(input: TxInputWithoutAmountAndWallet): Promise<string> {
     const { userAddress, contractAddress } = input
     this.verifyAddresses([userAddress, contractAddress])
 
@@ -270,13 +268,13 @@ export class FoxyApi {
 
     try {
       const estimatedGas = await stakingContract.estimateGas.sendWithdrawalRequests()
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateAddLiquidityGas(input: EstimateGasTxInput): Promise<BigNumber> {
+  async estimateAddLiquidityGas(input: EstimateGasTxInput): Promise<string> {
     const { amountDesired, userAddress, contractAddress } = input
     this.verifyAddresses([userAddress, contractAddress])
     if (!amountDesired.gt(0)) throw new Error('Must send valid amount')
@@ -287,13 +285,13 @@ export class FoxyApi {
       const estimatedGas = await liquidityReserveContract.estimateGas.addLiquidity(
         this.normalizeAmount(amountDesired),
       )
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateRemoveLiquidityGas(input: EstimateGasTxInput): Promise<BigNumber> {
+  async estimateRemoveLiquidityGas(input: EstimateGasTxInput): Promise<string> {
     const { amountDesired, userAddress, contractAddress } = input
     this.verifyAddresses([userAddress, contractAddress])
     if (!amountDesired.gt(0)) throw new Error('Must send valid amount')
@@ -304,13 +302,13 @@ export class FoxyApi {
       const estimatedGas = await liquidityReserveContract.estimateGas.removeLiquidity(
         this.normalizeAmount(amountDesired),
       )
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateWithdrawGas(input: WithdrawEstimateGasInput): Promise<BigNumber> {
+  async estimateWithdrawGas(input: WithdrawEstimateGasInput): Promise<string> {
     const { amountDesired, userAddress, contractAddress, type } = input
     this.verifyAddresses([userAddress, contractAddress])
 
@@ -323,13 +321,13 @@ export class FoxyApi {
       const estimatedGas = isDelayed
         ? await stakingContract.estimateGas.unstake(this.normalizeAmount(amountDesired), true)
         : await stakingContract.estimateGas.instantUnstake(true)
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateApproveGas(input: EstimateGasApproveInput): Promise<BigNumber> {
+  async estimateApproveGas(input: EstimateGasApproveInput): Promise<string> {
     const { userAddress, tokenContractAddress, contractAddress } = input
     this.verifyAddresses([userAddress, contractAddress, tokenContractAddress])
 
@@ -340,13 +338,13 @@ export class FoxyApi {
         contractAddress,
         MAX_ALLOWANCE,
       )
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
   }
 
-  async estimateDepositGas(input: EstimateGasTxInput): Promise<BigNumber> {
+  async estimateDepositGas(input: EstimateGasTxInput): Promise<string> {
     const { amountDesired, userAddress, contractAddress } = input
     this.verifyAddresses([userAddress, contractAddress])
     if (!amountDesired.gt(0)) throw new Error('Must send valid amount')
@@ -358,7 +356,7 @@ export class FoxyApi {
         this.normalizeAmount(amountDesired),
         userAddress,
       )
-      return bnOrZero(estimatedGas.toString())
+      return estimatedGas.toString()
     } catch (e) {
       throw new Error(`Failed to get gas ${e}`)
     }
@@ -377,9 +375,9 @@ export class FoxyApi {
     this.verifyAddresses([userAddress, contractAddress, tokenContractAddress])
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateApproveGas(input)
+      estimatedGas = await this.estimateApproveGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -392,7 +390,6 @@ export class FoxyApi {
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
-    const estimatedGas = estimatedGasBN.toString()
     const payload = {
       bip44Params,
       chainId: chainReferenceAsNumber,
@@ -438,9 +435,9 @@ export class FoxyApi {
     if (!amountDesired.gt(0)) throw new Error('Must send valid amount')
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateDepositGas(input)
+      estimatedGas = await this.estimateDepositGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -456,7 +453,6 @@ export class FoxyApi {
       })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -484,9 +480,9 @@ export class FoxyApi {
     this.verifyAddresses([userAddress, contractAddress])
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateWithdrawGas(input)
+      estimatedGas = await this.estimateWithdrawGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -505,7 +501,6 @@ export class FoxyApi {
         })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -607,9 +602,9 @@ export class FoxyApi {
     this.verifyAddresses([userAddress, contractAddress, addressToClaim])
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateClaimWithdrawGas(input)
+      estimatedGas = await this.estimateClaimWithdrawGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -624,7 +619,6 @@ export class FoxyApi {
     })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -720,9 +714,9 @@ export class FoxyApi {
     this.verifyAddresses([userAddress, contractAddress])
     if (!wallet || !contractAddress) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateSendWithdrawalRequestsGas(input)
+      estimatedGas = await this.estimateSendWithdrawalRequestsGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -737,7 +731,6 @@ export class FoxyApi {
     })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -768,9 +761,9 @@ export class FoxyApi {
 
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateAddLiquidityGas(input)
+      estimatedGas = await this.estimateAddLiquidityGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -784,7 +777,6 @@ export class FoxyApi {
       })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,
@@ -814,9 +806,9 @@ export class FoxyApi {
     if (!amountDesired.gt(0)) throw new Error('Must send valid amount')
     if (!wallet) throw new Error('Missing inputs')
 
-    let estimatedGasBN: BigNumber
+    let estimatedGas: string
     try {
-      estimatedGasBN = await this.estimateRemoveLiquidityGas(input)
+      estimatedGas = await this.estimateRemoveLiquidityGas(input)
     } catch (e) {
       throw new Error(`Estimate Gas Error: ${e}`)
     }
@@ -830,7 +822,6 @@ export class FoxyApi {
       })
 
     const { nonce, gasPrice } = await this.getGasPriceAndNonce(userAddress)
-    const estimatedGas = estimatedGasBN.toString()
     const chainReferenceAsNumber = Number(this.ethereumChainReference)
     const payload = {
       bip44Params,

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -177,8 +177,10 @@ export class FoxyApi {
     return liquidityReserveContract
   }
 
-  private async getGasPriceAndNonce(userAddress: string) {
-    let nonce: number
+  private async getGasPriceAndNonce(
+    userAddress: string,
+  ): Promise<{ nonce: string; gasPrice: string }> {
+    let nonce
     try {
       nonce = await this.provider.getTransactionCount(userAddress)
     } catch (e) {
@@ -190,7 +192,7 @@ export class FoxyApi {
     } catch (e) {
       throw new Error(`Get gasPrice Error: ${e}`)
     }
-    return { nonce: String(nonce), gasPrice }
+    return { nonce: nonce.toString(), gasPrice }
   }
 
   async getFoxyOpportunities() {
@@ -235,9 +237,9 @@ export class FoxyApi {
     }
   }
 
-  async getGasPrice() {
+  async getGasPrice(): Promise<string> {
     const gasPrice = await this.provider.getGasPrice()
-    return gasPrice
+    return gasPrice.toString()
   }
 
   async getTxReceipt({ txid }: TxReceipt): Promise<ethers.providers.TransactionReceipt> {
@@ -418,7 +420,7 @@ export class FoxyApi {
     } catch (e) {
       throw new Error(`Failed to get allowance ${e}`)
     }
-    return allowance
+    return allowance.toString()
   }
 
   async deposit(input: TxInput): Promise<string> {

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -117,7 +117,7 @@ export class FoxyApi {
    * to exponential notation ('1.6e+21') in javascript.
    * @param amount
    */
-  private normalizeAmount(amount: BigNumber) {
+  private normalizeAmount(amount: BigNumber): ethers.BigNumber {
     return ethers.BigNumber.from(amount.toFixed())
   }
 

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -182,7 +182,7 @@ export class FoxyApi {
   ): Promise<{ nonce: string; gasPrice: string }> {
     let nonce
     try {
-      nonce = await this.provider.getTransactionCount(userAddress)
+      nonce = (await this.provider.getTransactionCount(userAddress)).toString()
     } catch (e) {
       throw new Error(`Get nonce Error: ${e}`)
     }
@@ -192,7 +192,7 @@ export class FoxyApi {
     } catch (e) {
       throw new Error(`Get gasPrice Error: ${e}`)
     }
-    return { nonce: nonce.toString(), gasPrice }
+    return { nonce, gasPrice }
   }
 
   async getFoxyOpportunities() {

--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -455,7 +455,6 @@ export class FoxyApi {
     }
 
     const stakingContract = this.getStakingContract(contractAddress)
-    // const userChecksum = ethers.utils.getAddress(userAddress)
 
     const data = stakingContract.interface.encodeFunctionData('stake(uint256,address)', [
       this.normalizeAmount(amountDesired),

--- a/packages/investor-foxy/src/api/foxy-types.ts
+++ b/packages/investor-foxy/src/api/foxy-types.ts
@@ -2,7 +2,7 @@ import { AssetId } from '@shapeshiftoss/caip'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, WithdrawType } from '@shapeshiftoss/types'
 import { BigNumber } from 'bignumber.js'
-import { Contract } from 'web3-eth-contract'
+import ethers from 'ethers'
 
 export type FoxyAddressesType = {
   staking: string
@@ -149,7 +149,7 @@ export type RebaseHistory = {
 }
 
 export type StakingContract = {
-  stakingContract: Contract
+  stakingContract: ethers.ethers.Contract
 }
 
 // this comment only exists to publish this package - delete me if you see me


### PR DESCRIPTION
### Description

This switches the current investor-foxy API implementation from web3.js to ethers.js, to be able to use JsonRpcBatchProvider.

web3.js also provides a `BatchRequest` API, unfortunately after spending more than a day on it, it seems like that API is rugged currently and isn't compatible with our programmatic calls with blockNumber specified. 

- [x] Base migration from web3.js to ethers - compiles
- [x] Regression test that values are correct
- [ ] ~~Batch promises together so the underlying JSON RPC calls are automagically batched by `JsonRpcBatchProvider`~~ This will better live in a follow-up PR. Let's get the switch to ethers.js merged first, and then we can improve the business logic

### Issue

N/A

### Risks

Everything FOXy could be borked - test locally against latest `@shapeshiftoss/investor-foxy`. 