### PR TITLE
feat(types): add binance, kava, terra, secret to KnownChainIds

### DIFF
--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -16,6 +16,10 @@ export enum KnownChainIds {
   CosmosMainnet = 'cosmos:cosmoshub-4',
   OsmosisMainnet = 'cosmos:osmosis-1',
   ThorchainMainnet = 'cosmos:thorchain-mainnet-v1',
+  BinanceMainnet = 'cosmos:binance-chain-tigris',
+  KavaMainnet = 'cosmos:kava_2222-10',
+  TerraMainnet = 'cosmos:phoenix-1',
+  SecretMainnet = 'cosmos:secret-4',
 }
 
 export enum WithdrawType {


### PR DESCRIPTION
This enables cosmos-sdk assets {binance, kava, terra, secret} 

**NOTE: DO NOT MERGE UNTIL SUPPORT FOR THESE ASSETS HAS BEEN ADDED THROUGH THE REST OF THE STACK**