### PR TITLE
fix: use json response instead of text response for generated fetch api

### DIFF
--- a/packages/unchained-client/generator/post_process.sh
+++ b/packages/unchained-client/generator/post_process.sh
@@ -2,9 +2,12 @@
 # there is a PR active to bake this into the generator that we can upgrade to when released:
 # https://github.com/OpenAPITools/openapi-generator/pull/11674
 
-SED_COMMAND='1s;^;// @ts-nocheck\n;'
+SED_COMMAND_1='1s;^;// @ts-nocheck\n;'
+SED_COMMAND_2='s;runtime\.TextApiResponse;runtime.JSONApiResponse;'
 if [ "$(uname)" != "Darwin" ]; then
-  sed -i "$SED_COMMAND" $1
+  sed -i "$SED_COMMAND_1" $1
+  sed -i "$SED_COMMAND_2" $1
 else
-  sed -i '' "$SED_COMMAND" $1
+  sed -i '' "$SED_COMMAND_1" $1
+  sed -i '' "$SED_COMMAND_2" $1
 fi

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -15,7 +15,7 @@
     "build:local": "yarn clean && yarn generate:local && tsc -p tsconfig.build.json",
     "dev": "tsc --watch",
     "clean": "rm -rf dist src/generated tsconfig.build.tsbuildinfo",
-    "generate": "TS_POST_PROCESS_FILE=./generator/ts-nocheck.sh JAVA_OPTS='-Dlog.level=error' openapi-generator-cli generate && rm openapitools.json",
+    "generate": "TS_POST_PROCESS_FILE=./generator/post_process.sh JAVA_OPTS='-Dlog.level=error' openapi-generator-cli generate && rm openapitools.json",
     "generate:dev": "cp generator/openapitools-dev.json openapitools.json && yarn generate",
     "generate:prod": "cp generator/openapitools-prod.json openapitools.json && yarn generate",
     "generate:local": "cp generator/openapitools-local.json openapitools.json && yarn generate",


### PR DESCRIPTION
The default parsing strategy for typescript-fetch is to use `.text()` for primitive response types. We have two unchained endpoints (`/gas/estimate` and `/send`) that currently return plain text responses. This resulted in a value `'"some string"'` being returned by the generated typescript client.

Using `json()` to parse these responses strips the quotes as desired and is the quick fix to prevent blocking lib/releases. Note, I have not tested against any other primitive type responses other than strings, but for our purposes at this time it works. Longer term fix would be to update the response payloads to be json across the board even if only returning a single string response and then we could remove the post processing to change parsing strategy.