### PR TITLE
fix: rune swaps

### DIFF
--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
@@ -30,7 +30,7 @@ describe('getPriceRatio', () => {
     expect(ratio).toEqual(expectedRatio)
   })
 
-  it('should throw if  calculating a price for an unknown asset', async () => {
+  it('should throw if calculating a price for an unknown asset', async () => {
     const derpId = 'eip155:1/erc20:derp'
     const ethId = 'eip155:1/slip44:60'
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.test.ts
@@ -38,7 +38,7 @@ describe('getPriceRatio', () => {
     )
 
     await expect(getPriceRatio(deps, { buyAssetId: derpId, sellAssetId: ethId })).rejects.toThrow(
-      `[getPriceRatio]: No thorchain pool found`,
+      `[getPriceRatio]: No buyPoolId found for asset ${derpId}`,
     )
   })
 })

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
@@ -3,6 +3,7 @@ import { adapters, AssetId } from '@shapeshiftoss/caip'
 import { SwapError, SwapErrorTypes } from '../../../../api'
 import { bn } from '../../../utils/bignumber'
 import { ThorchainSwapperDeps, ThornodePoolResponse } from '../../types'
+import { isRune } from '../../utils/isRune/isRune'
 import { thorService } from '../thorService'
 
 export const getPriceRatio = async (
@@ -14,10 +15,19 @@ export const getPriceRatio = async (
     const buyPoolId = adapters.assetIdToPoolAssetId({ assetId: buyAssetId })
     const sellPoolId = adapters.assetIdToPoolAssetId({ assetId: sellAssetId })
 
-    if (!buyPoolId || !sellPoolId) {
-      throw new SwapError(`[getPriceRatio]: No thorchain pool found`, {
-        code: SwapErrorTypes.RESPONSE_ERROR,
-        details: { buyPoolId, sellPoolId },
+    if (!buyPoolId && !isRune(buyAssetId)) {
+      throw new SwapError(`[getPriceRatio]: No buyPoolId found for asset ${buyAssetId}`, {
+        code: SwapErrorTypes.POOL_NOT_FOUND,
+        fn: 'getPriceRatio',
+        details: { buyAssetId },
+      })
+    }
+
+    if (!sellPoolId && !isRune(sellAssetId)) {
+      throw new SwapError(`[getPriceRatio]: No sellPoolId found for asset ${sellAssetId}`, {
+        code: SwapErrorTypes.POOL_NOT_FOUND,
+        fn: 'getPriceRatio',
+        details: { sellAssetId },
       })
     }
 


### PR DESCRIPTION
### Description

This fixes the rune swaps (from/to) following the mergefix of https://github.com/shapeshift/lib/commit/d6ae142598d82888d2c28190293ae56fc92c56e7 which ditched some logic from https://github.com/shapeshift/lib/pull/1030

### Testing

- Link `@shapeshiftoss/swapper` with this diff in web with https://github.com/shapeshift/web/pull/2842 checked out
- RUNE swaps should be working on both sides