### PR TITLE
fix(swapper): plumb `sendMax` through ThorSwapper

### DIFF
--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -33,6 +33,7 @@ export const buildTrade = async ({
       bip44Params,
       slippage: slippageTolerance = DEFAULT_SLIPPAGE,
       wallet,
+      sendMax,
     } = input
 
     const quote = await getThorTradeQuote({ deps, input })
@@ -98,6 +99,7 @@ export const buildTrade = async ({
             .satsPerByte,
           opReturnData,
         },
+        sendMax,
       })
 
       return {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -43,6 +43,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
     bip44Params,
     chainId,
     receiveAddress,
+    sendMax,
   } = input
 
   if (!bip44Params) {
@@ -155,6 +156,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             pubkey,
             sellAdapter: sellAdapter as unknown as UtxoBaseAdapter<UtxoSupportedChainIds>,
             buyAssetTradeFeeUsd: buyAssetTradeFeeUsdOrMinimum,
+            sendMax,
           })
 
           return {

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
@@ -11,6 +11,7 @@ export const getBtcTxFees = async ({
   sellAdapter,
   pubkey,
   buyAssetTradeFeeUsd,
+  sendMax,
 }: {
   opReturnData: string
   vault: string
@@ -18,12 +19,14 @@ export const getBtcTxFees = async ({
   sellAdapter: UtxoBaseAdapter<UtxoSupportedChainIds>
   pubkey: string
   buyAssetTradeFeeUsd: string
+  sendMax: boolean
 }): Promise<QuoteFeeData<UtxoSupportedChainIds>> => {
   try {
     const feeDataOptions = await sellAdapter.getFeeData({
       to: vault,
       value: sellAmount,
       chainSpecific: { pubkey, opReturnData },
+      sendMax,
     })
 
     const feeData = feeDataOptions['fast']

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
@@ -4,6 +4,16 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import { QuoteFeeData, SwapError, SwapErrorTypes, UtxoSupportedChainIds } from '../../../../../api'
 import { bn } from '../../../../utils/bignumber'
 
+type GetBtcTxFeesInput = {
+  opReturnData: string
+  vault: string
+  sellAmount: string
+  sellAdapter: UtxoBaseAdapter<UtxoSupportedChainIds>
+  pubkey: string
+  buyAssetTradeFeeUsd: string
+  sendMax: boolean
+}
+
 export const getBtcTxFees = async ({
   opReturnData,
   vault,
@@ -12,15 +22,7 @@ export const getBtcTxFees = async ({
   pubkey,
   buyAssetTradeFeeUsd,
   sendMax,
-}: {
-  opReturnData: string
-  vault: string
-  sellAmount: string
-  sellAdapter: UtxoBaseAdapter<UtxoSupportedChainIds>
-  pubkey: string
-  buyAssetTradeFeeUsd: string
-  sendMax: boolean
-}): Promise<QuoteFeeData<UtxoSupportedChainIds>> => {
+}: GetBtcTxFeesInput): Promise<QuoteFeeData<UtxoSupportedChainIds>> => {
   try {
     const feeDataOptions = await sellAdapter.getFeeData({
       to: vault,


### PR DESCRIPTION
The ThorChain swapper isn't doing anything with the `sendMax` argument being sent from the client.

This PR plumbs it through ThorSwap's `buildTrade` and `getTradeQuote`.

To test locally, link with https://github.com/shapeshift/web/pull/2955 and click "Max" on a UTXO asset - ensure we can get to the confirm trade screen without throwing.

Contributes to https://github.com/shapeshift/web/issues/2949, though requires the `web` PR to fully close: https://github.com/shapeshift/web/pull/2955