### PR TITLE
chore(swapper): use and export a `SwapperName` enum

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -181,7 +181,7 @@ export type ApprovalNeededOutput = {
 }
 
 export enum SwapperName {
-  Thorchain = 'Thorchain',
+  Thorchain = 'THORChain',
   Osmosis = 'Osmosis',
   CowSwap = 'CowSwap',
   Zrx = '0x',

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -180,6 +180,14 @@ export type ApprovalNeededOutput = {
   approvalNeeded: boolean
 }
 
+export enum SwapperName {
+  Thorchain = 'Thorchain',
+  Osmosis = 'Osmosis',
+  CowSwap = 'CowSwap',
+  Zrx = '0x',
+  Test = 'Test',
+}
+
 export enum SwapperType {
   ZrxEthereum = '0xEthereum',
   ZrxAvalanche = '0xAvalanche',

--- a/packages/swapper/src/swappers/cow/CowSwapper.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.ts
@@ -14,6 +14,7 @@ import {
   ExecuteTradeInput,
   GetTradeQuoteInput,
   Swapper,
+  SwapperName,
   SwapperType,
   TradeQuote,
   TradeResult,
@@ -36,7 +37,7 @@ export type CowSwapperDeps = {
 }
 
 export class CowSwapper implements Swapper<KnownChainIds.EthereumMainnet> {
-  readonly name = 'CowSwap'
+  readonly name = SwapperName.CowSwap
   deps: CowSwapperDeps
 
   constructor(deps: CowSwapperDeps) {

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.test.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.test.ts
@@ -1,5 +1,6 @@
 import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 
+import { SwapperName } from '../../api'
 import { OsmosisSwapper } from './OsmosisSwapper'
 
 describe('OsmosisSwapper', () => {
@@ -11,7 +12,7 @@ describe('OsmosisSwapper', () => {
 
   describe('name', () => {
     it('returns the correct human readable swapper name', () => {
-      expect(swapper.name).toEqual('Osmosis')
+      expect(swapper.name).toEqual(SwapperName.Osmosis)
     })
   })
 })

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -19,6 +19,7 @@ import {
   SwapError,
   SwapErrorTypes,
   Swapper,
+  SwapperName,
   SwapperType,
   Trade,
   TradeQuote,
@@ -43,7 +44,7 @@ import {
 import { OsmosisTradeResult, OsmoSwapperDeps } from './utils/types'
 
 export class OsmosisSwapper implements Swapper<ChainId> {
-  readonly name = 'Osmosis'
+  readonly name = SwapperName.Osmosis
   supportedAssetIds: string[]
   deps: OsmoSwapperDeps
 

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -7,6 +7,7 @@ import {
   SwapError,
   SwapErrorTypes,
   Swapper,
+  SwapperName,
   SwapperType,
   Trade,
   TradeQuote,
@@ -19,7 +20,7 @@ import {
  * Meant for local testing only
  */
 export class TestSwapper implements Swapper<ChainId> {
-  readonly name = 'Test'
+  readonly name = SwapperName.Test
   supportAssets: string[]
 
   // noop for test

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.test.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.test.ts
@@ -2,6 +2,7 @@ import { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import axios from 'axios'
 import Web3 from 'web3'
 
+import { SwapperName } from '../../api'
 import { ThorchainSwapper } from './ThorchainSwapper'
 import { thorService } from './utils/thorService'
 
@@ -19,7 +20,7 @@ describe('ThorchainSwapper', () => {
 
   describe('name', () => {
     it('returns the correct human readable swapper name', () => {
-      expect(swapper.name).toEqual('Thorchain')
+      expect(swapper.name).toEqual(SwapperName.Thorchain)
     })
   })
 

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -23,6 +23,7 @@ import {
   SwapError,
   SwapErrorTypes,
   Swapper,
+  SwapperName,
   SwapperType,
   Trade,
   TradeQuote,
@@ -46,7 +47,7 @@ import { thorService } from './utils/thorService'
 export * from './types'
 
 export class ThorchainSwapper implements Swapper<ChainId> {
-  readonly name = 'Thorchain'
+  readonly name = SwapperName.Thorchain
   private sellSupportedChainIds: Record<ChainId, boolean> = {
     [KnownChainIds.EthereumMainnet]: true,
     [KnownChainIds.BitcoinMainnet]: true,

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -14,6 +14,7 @@ import {
   SwapError,
   SwapErrorTypes,
   Swapper,
+  SwapperName,
   SwapperType,
   TradeQuote,
   TradeResult,
@@ -29,7 +30,7 @@ import { zrxBuildTrade } from './zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from './zrxExecuteTrade/zrxExecuteTrade'
 
 export class ZrxSwapper<T extends EvmSupportedChainIds> implements Swapper<T> {
-  readonly name = '0x'
+  readonly name = SwapperName.Zrx
   deps: ZrxSwapperDeps
   chainId: ChainId
 


### PR DESCRIPTION
Use a `SwapperName` enum when referring to the swapper name.

Makes the `web` implementation for `https://github.com/shapeshift/web/issues/3019` tidier.