### PR TITLE
chore: set minimum ThorSwap sell amount to $50 on Ethereum Mainnet

### DIFF
--- a/packages/swapper/src/swappers/thorchain/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/constants.ts
@@ -2,3 +2,4 @@ import { bn } from '../utils/bignumber'
 // TODO: read from https://daemon.thorchain.shapeshift.com/lcd/thorchain/constants
 export const RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN = bn('0.02')
 export const MINIMUM_USD_TRADE_AMOUNT = bn(1)
+export const MINIMUM_USD_TRADE_AMOUNT_ETHEREUM_NETWORK = bn(42)

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -38,8 +38,8 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   feeData: {
     fee: '700000',
     chainSpecific: { estimatedGas: '100000', approvalFee: '700000', gasPrice: '7' },
-    tradeFee: '42',
-    buyAssetTradeFeeUsd: '42',
+    tradeFee: '0.471220133939775024',
+    buyAssetTradeFeeUsd: '0.471220133939775024',
     sellAssetTradeFeeUsd: '0',
     networkFee: '700000',
   },

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -30,7 +30,7 @@ Web3.mockImplementation(() => ({
 const mockedAxios = jest.mocked(thorService, true)
 
 const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
-  minimum: '0.000611179317810745884',
+  minimum: '0.025669531348051326924',
   maximum: '100000000000000000000000000',
   sellAmount: '10000000000000000000', // 1000 FOX
   allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
@@ -38,8 +38,8 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   feeData: {
     fee: '700000',
     chainSpecific: { estimatedGas: '100000', approvalFee: '700000', gasPrice: '7' },
-    tradeFee: '1',
-    buyAssetTradeFeeUsd: '1',
+    tradeFee: '42',
+    buyAssetTradeFeeUsd: '42',
     sellAssetTradeFeeUsd: '0',
     networkFee: '700000',
   },

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -130,12 +130,12 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             sellAmount: sellAmountCryptoPrecision,
             slippageTolerance: DEFAULT_SLIPPAGE,
             destinationAddress: receiveAddress,
-            buyAssetTradeFeeUsd: buyAssetTradeFeeUsdOrMinimum,
+            buyAssetTradeFeeUsd: estimatedBuyAssetTradeFeeUsd,
           })
           const feeData = await getEthTxFees({
             adapterManager: deps.adapterManager,
             sellAssetReference,
-            buyAssetTradeFeeUsd: buyAssetTradeFeeUsdOrMinimum,
+            buyAssetTradeFeeUsd: estimatedBuyAssetTradeFeeUsd,
           })
 
           return {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -12,7 +12,11 @@ import {
 } from '../../../api'
 import { bn, bnOrZero, fromBaseUnit, toBaseUnit } from '../../utils/bignumber'
 import { DEFAULT_SLIPPAGE } from '../../utils/constants'
-import { MINIMUM_USD_TRADE_AMOUNT, RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN } from '../constants'
+import {
+  MINIMUM_USD_TRADE_AMOUNT,
+  MINIMUM_USD_TRADE_AMOUNT_ETHEREUM_NETWORK,
+  RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN,
+} from '../constants'
 import { ThorchainSwapperDeps } from '../types'
 import { getThorTxInfo as getBtcThorTxInfo } from '../utils/bitcoin/utils/getThorTxData'
 import { MAX_THORCHAIN_TRADE, THOR_MINIMUM_PADDING } from '../utils/constants'
@@ -78,8 +82,13 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       .times(estimatedBuyAssetTradeFeeCryptoHuman)
       .toString()
 
-    const buyAssetTradeFeeUsdOrMinimum = MINIMUM_USD_TRADE_AMOUNT.gt(estimatedBuyAssetTradeFeeUsd)
-      ? MINIMUM_USD_TRADE_AMOUNT.toString()
+    const minimumUsdAmount =
+      chainId === KnownChainIds.EthereumMainnet
+        ? MINIMUM_USD_TRADE_AMOUNT_ETHEREUM_NETWORK
+        : MINIMUM_USD_TRADE_AMOUNT
+
+    const buyAssetTradeFeeUsdOrMinimum = minimumUsdAmount.gt(estimatedBuyAssetTradeFeeUsd)
+      ? minimumUsdAmount.toString()
       : estimatedBuyAssetTradeFeeUsd
 
     const sellAssetTradeFeeCryptoHuman = (() => {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -83,7 +83,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       .toString()
 
     const minimumUsdAmount =
-      chainId === KnownChainIds.EthereumMainnet
+      buyAsset.chainId === KnownChainIds.EthereumMainnet
         ? MINIMUM_USD_TRADE_AMOUNT_ETHEREUM_NETWORK
         : MINIMUM_USD_TRADE_AMOUNT
 


### PR DESCRIPTION
Closes https://github.com/shapeshift/web/issues/3024#event-7556633902

To test:

1. Link branch to `web`
2. Ensure ThorSwap enabled in `web`
3. Get ThorSwap quote for any trade into the Ethereum Mainnet - the minimum amount of the sell asset should be approximately equal to $50