### PR TITLE
feat(chain-adapters): make bip44Params required in `chain-adapters`

### DIFF
--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -83,7 +83,7 @@ export type FeeDataEstimate<T extends ChainId> = {
 
 export type SubscribeTxsInput = {
   wallet: HDWallet
-  bip44Params?: BIP44Params
+  bip44Params: BIP44Params
   accountType?: UtxoAccountType
 }
 
@@ -166,7 +166,7 @@ export type BuildSendTxInput<T extends ChainId> = {
   to: string
   value: string
   wallet: HDWallet
-  bip44Params?: BIP44Params // TODO maybe these shouldnt be optional
+  bip44Params: BIP44Params
   sendMax?: boolean
   memo?: string
 } & ChainSpecificBuildTxData<T>
@@ -204,7 +204,7 @@ export interface TxHistoryInput {
 
 export type GetAddressInputBase = {
   wallet: HDWallet
-  bip44Params?: BIP44Params
+  bip44Params: BIP44Params
   /**
    * Request that the address be shown to the user by the device, if supported
    */

--- a/packages/investor-foxy/src/foxycli.ts
+++ b/packages/investor-foxy/src/foxycli.ts
@@ -54,7 +54,8 @@ const main = async (): Promise<void> => {
     foxyAddresses,
   })
 
-  const userAddress = await api.adapter.getAddress({ wallet })
+  const bip44Params = api.adapter.getBIP44Params({ accountNumber: 0 })
+  const userAddress = await api.adapter.getAddress({ wallet, bip44Params })
   console.info('current user address ', userAddress)
 
   const circulatingSupply = async () => {

--- a/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
@@ -24,7 +24,7 @@ export async function cowApprovalNeeded(
       })
     }
 
-    const receiveAddress = await adapter.getAddress({ wallet })
+    const receiveAddress = await adapter.getAddress({ wallet, bip44Params: quote.bip44Params })
 
     const allowanceResult = await getERC20Allowance({
       web3,

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -52,7 +52,7 @@ export async function cowBuildTrade(
 
     const buyToken =
       buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_MARKER_ADDRESS
-    const receiveAddress = await adapter.getAddress({ wallet })
+    const receiveAddress = await adapter.getAddress({ wallet, bip44Params })
     const normalizedSellAmount = normalizeAmount(sellAmount)
 
     /**


### PR DESCRIPTION
A subset of the type changes made in https://github.com/shapeshift/lib/pull/1054 to keep changes contained to the `chain-adapters` package and allow for a more manageable `web` migration.

The associated `web` PR: https://github.com/shapeshift/web/pull/3040 (note they can be merged independently).

This is a breaking change.

Contributes to https://github.com/shapeshift/lib/issues/1001