### PR TITLE
chore: add `bip44Params` to investor children

### DIFF
--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -38,14 +38,14 @@
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"
   }

--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -35,18 +35,18 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^8.0.0",
+    "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.33.0",
-    "@shapeshiftoss/investor": "^1.0.1",
-    "@shapeshiftoss/types": "^8.1.0"
+    "@shapeshiftoss/hdwallet-core": "^1.35.0",
+    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^8.0.0",
+    "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.33.0",
-    "@shapeshiftoss/investor": "^1.0.1",
-    "@shapeshiftoss/types": "^8.1.0",
-    "@shapeshiftoss/unchained-client": "^10.0.1"
+    "@shapeshiftoss/hdwallet-core": "^1.35.0",
+    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/types": "^8.3.1",
+    "@shapeshiftoss/unchained-client": "^10.0.2"
   }
 }

--- a/packages/investor-idle/src/IdleOpportunity.ts
+++ b/packages/investor-idle/src/IdleOpportunity.ts
@@ -8,7 +8,7 @@ import {
   InvestorOpportunity,
 } from '@shapeshiftoss/investor'
 import { Logger } from '@shapeshiftoss/logger'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import type { BigNumber } from 'bignumber.js'
 import toLower from 'lodash/toLower'
 import Web3 from 'web3'
@@ -449,6 +449,7 @@ export class IdleOpportunity
     wallet: HDWallet
     tx: PreparedTransaction
     feePriority?: FeePriority
+    bip44Params: BIP44Params
   }): Promise<string> {
     const { wallet, tx, feePriority } = input
     const feeSpeed: FeePriority = feePriority ? feePriority : 'fast'

--- a/packages/investor-idle/src/IdleOpportunity.ts
+++ b/packages/investor-idle/src/IdleOpportunity.ts
@@ -36,7 +36,7 @@ export type PreparedTransaction = {
   value: '0'
 }
 
-const feeMultipier: Record<FeePriority, number> = Object.freeze({
+const feeMultiplier: Record<FeePriority, number> = Object.freeze({
   fast: 1,
   average: 0.8,
   slow: 0.5,
@@ -455,7 +455,7 @@ export class IdleOpportunity
     const feeSpeed: FeePriority = feePriority ? feePriority : 'fast'
     const chainAdapter = this.#internals.chainAdapter
 
-    const gasPrice = numberToHex(bnOrZero(tx.gasPrice).times(feeMultipier[feeSpeed]).toString())
+    const gasPrice = numberToHex(bnOrZero(tx.gasPrice).times(feeMultiplier[feeSpeed]).toString())
     const txToSign: ETHSignTx = {
       ...tx,
       gasPrice,

--- a/packages/investor-idle/src/IdleOpportunity.ts
+++ b/packages/investor-idle/src/IdleOpportunity.ts
@@ -451,7 +451,7 @@ export class IdleOpportunity
     feePriority?: FeePriority
     bip44Params: BIP44Params
   }): Promise<string> {
-    const { wallet, tx, feePriority } = input
+    const { wallet, tx, feePriority, bip44Params } = input
     const feeSpeed: FeePriority = feePriority ? feePriority : 'fast'
     const chainAdapter = this.#internals.chainAdapter
 
@@ -463,7 +463,7 @@ export class IdleOpportunity
       gasLimit: numberToHex(tx.estimatedGas.times(1.5).integerValue().toString()),
       nonce: numberToHex(tx.nonce),
       value: numberToHex(tx.value),
-      addressNList: toAddressNList(chainAdapter.buildBIP44Params({ accountNumber: 0 })),
+      addressNList: toAddressNList(bip44Params),
     }
 
     // console.log('signAndBroadcast', txToSign)

--- a/packages/investor-idle/src/idlecli.ts
+++ b/packages/investor-idle/src/idlecli.ts
@@ -58,11 +58,13 @@ const main = async (): Promise<void> => {
   const approvalPreparedTx = await opportunity.prepareApprove(address)
   const withdrawPreparedTx = await opportunity.prepareDeposit({ address, amount: bn(1000) })
   const depositPreparedTx = await opportunity.prepareWithdrawal({ address, amount: bn(1000) })
+  const bip44Params = chainAdapter.getBIP44Params({ accountNumber: 0 })
 
   const signedTx = await opportunity.signAndBroadcast({
     wallet,
     tx: depositPreparedTx,
     feePriority: 'fast',
+    bip44Params,
   })
   console.info(
     JSON.stringify(

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -36,18 +36,18 @@
     "web3-utils": "1.7.4"
   },
   "peerDependencies": {
-    "@shapeshiftoss/caip": "^8.0.0",
+    "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.33.0",
-    "@shapeshiftoss/investor": "^1.0.1",
-    "@shapeshiftoss/types": "^8.1.0"
+    "@shapeshiftoss/hdwallet-core": "^1.35.0",
+    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
-    "@shapeshiftoss/caip": "^8.0.0",
+    "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.33.0",
-    "@shapeshiftoss/investor": "^1.0.1",
-    "@shapeshiftoss/types": "^8.1.0",
-    "@shapeshiftoss/unchained-client": "^10.0.1"
+    "@shapeshiftoss/hdwallet-core": "^1.35.0",
+    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/types": "^8.3.1",
+    "@shapeshiftoss/unchained-client": "^10.0.2"
   }
 }

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -39,14 +39,14 @@
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"
   }

--- a/packages/investor-yearn/src/YearnOpportunity.ts
+++ b/packages/investor-yearn/src/YearnOpportunity.ts
@@ -40,7 +40,7 @@ export type PreparedTransaction = {
   value: '0'
 }
 
-const feeMultipier: Record<FeePriority, number> = Object.freeze({
+const feeMultiplier: Record<FeePriority, number> = Object.freeze({
   fast: 1,
   average: 0.8,
   slow: 0.5,
@@ -185,7 +185,7 @@ export class YearnOpportunity
     const feeSpeed: FeePriority = feePriority ? feePriority : 'fast'
     const chainAdapter = this.#internals.chainAdapter
 
-    const gasPrice = numberToHex(bnOrZero(tx.gasPrice).times(feeMultipier[feeSpeed]).toString())
+    const gasPrice = numberToHex(bnOrZero(tx.gasPrice).times(feeMultiplier[feeSpeed]).toString())
     const txToSign: ETHSignTx = {
       ...tx,
       gasPrice,

--- a/packages/investor-yearn/src/YearnOpportunity.ts
+++ b/packages/investor-yearn/src/YearnOpportunity.ts
@@ -8,8 +8,7 @@ import {
   InvestorOpportunity,
 } from '@shapeshiftoss/investor'
 import { Logger } from '@shapeshiftoss/logger'
-import { KnownChainIds } from '@shapeshiftoss/types'
-import { BIP44Params } from '@shapeshiftoss/types'
+import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import { type ChainId, type Vault, type VaultMetadata, Yearn } from '@yfi/sdk'
 import type { BigNumber } from 'bignumber.js'
 import isNil from 'lodash/isNil'
@@ -177,7 +176,7 @@ export class YearnOpportunity
     wallet: HDWallet
     tx: PreparedTransaction
     feePriority?: FeePriority
-    bip44Params?: BIP44Params
+    bip44Params: BIP44Params
   }): Promise<string> {
     const { bip44Params, wallet, tx, feePriority } = input
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,6 +2884,16 @@
     rxjs "^6.4.0"
     type-assertions "^1.1.0"
 
+"@shapeshiftoss/hdwallet-core@^1.35.0":
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.35.0.tgz#fe056d61c79a43d40951bb92a58ec4655681f514"
+  integrity sha512-QENbf7kLEUWFHuw4X6uZQJTyDPFAVRTJCnJ+wpTLw1CgvmDcBSTrRR/X/HF2Ao6M86Fm6GtKY/hfdEV3JKHc0w==
+  dependencies:
+    eventemitter2 "^5.0.1"
+    lodash "^4.17.21"
+    rxjs "^6.4.0"
+    type-assertions "^1.1.0"
+
 "@shapeshiftoss/hdwallet-core@latest":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.19.0.tgz#7eeae9be9f90fff53887611c6ac02c334781baa3"
@@ -2920,19 +2930,6 @@
     tendermint-tx-builder "^1.0.9"
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
-
-"@shapeshiftoss/investor-foxy@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-foxy/-/investor-foxy-5.0.1.tgz#1b8befc2335bd89103d3a3556a1d6d2856f806c2"
-  integrity sha512-q/rj1ofOdyiS8xbYZOJ3DOyulEoR7nmLILTQeVHZ7XEPaY+sfO2Cb+WU70xzlu0/gG84PIej5tM0s6rU82sUeg==
-  dependencies:
-    "@ethersproject/providers" "^5.5.3"
-    axios "^0.26.1"
-    bignumber.js "^9.0.2"
-    lodash "^4.17.21"
-    web3 "1.7.4"
-    web3-core "1.7.4"
-    web3-utils "1.7.4"
 
 "@shapeshiftoss/investor@^1.0.1":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,6 +2931,11 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
+"@shapeshiftoss/investor@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor/-/investor-3.0.0.tgz#d748f4ff6378d0351b57deb72ad5d829651e0edf"
+  integrity sha512-dR+qXunrTojB1HI1NtGFJpUnxVLjrV/rWOZiv/WRxUVWHAwKdj0tZC0A4k3fKVSaA0q/z5aucKvG3q/oJX3qgQ==
+
 "@shapeshiftoss/proto-tx-builder@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/proto-tx-builder/-/proto-tx-builder-0.3.0.tgz#713413b3352d73bcc1ea1b04068522216950d38a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,11 +2931,6 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
-"@shapeshiftoss/investor@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor/-/investor-1.0.2.tgz#32ed90a96e122bb8f6dfdea088a2df9b88527eef"
-  integrity sha512-COHhutd7gPe9tUCdog8YK9OXSU5tu5eXlNdS0g+3XEv4DloaS/q0va/azfNUOj3bPFInsIHY/bojqUm61dDSbA==
-
 "@shapeshiftoss/proto-tx-builder@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/proto-tx-builder/-/proto-tx-builder-0.3.0.tgz#713413b3352d73bcc1ea1b04068522216950d38a"


### PR DESCRIPTION
Contributes to https://github.com/shapeshift/lib/issues/999.

Requires https://github.com/shapeshift/lib/pull/1061 to be merged, and an updated `@shapeshiftoss/investor` major version to be published (assumably `3.0.0`).

TODO once changes in https://github.com/shapeshift/lib/pull/1061 published:

```diff
--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -39,14 +39,14 @@
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"
   }
```

```diff
--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -38,14 +38,14 @@
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.35.0",
-    "@shapeshiftoss/investor": "^2.1.1",
+    "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"
   }
```