### PR TITLE
chore: blacklist erc20 rune from swapping

### DIFF
--- a/packages/swapper/src/swappers/cow/utils/blacklist.ts
+++ b/packages/swapper/src/swappers/cow/utils/blacklist.ts
@@ -3,4 +3,9 @@
 export const COWSWAP_UNSUPPORTED_ASSETS = Object.freeze([
   // Foxy token unsupported by cowswap
   'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
+  /**
+   * ERC20 RUNE - we don't want people buying this instead of native RUNE
+   * as it's exchangeable value for native RUNE is currently decaying from 1 towards 0
+   */
+  'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb',
 ])

--- a/packages/swapper/src/swappers/zrx/utils/blacklist.ts
+++ b/packages/swapper/src/swappers/zrx/utils/blacklist.ts
@@ -3,4 +3,9 @@
 export const UNSUPPORTED_ASSETS = Object.freeze([
   // Foxy token unsupported by zrx
   'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
+  /**
+   * ERC20 RUNE - we don't want people buying this instead of native RUNE
+   * as it's exchangeable value for native RUNE is currently decaying from 1 towards 0
+   */
+  'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb',
 ])


### PR DESCRIPTION
see comment in code - ERC20 rune is being deprecated and users should upgrade to native rune

we don't want people buying this asset by mistake

cannot buy

<img width="412" alt="image" src="https://user-images.githubusercontent.com/88504456/195701024-82478cfd-a91f-480b-8445-18ad9cc157e8.png">

but are able to sell

<img width="398" alt="image" src="https://user-images.githubusercontent.com/88504456/195703240-60b72d38-990e-4b77-aa9e-561ec4892dda.png">


