### PR TITLE
feat(swapper): remove deprecated QuoteFeeData fields

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -48,11 +48,6 @@ export type QuoteFeeData<T extends ChainId> = {
   networkFee: string // fee paid to the network from the fee asset
   buyAssetTradeFeeUsd: string // fee taken out of the trade from the buyAsset
   sellAssetTradeFeeUsd?: string // fee taken out of the trade from the sellAsset
-
-  /** @deprecated Use networkFee instead */
-  fee: string
-  /** @deprecated Use sellAssetTradeFeeUsd instead */
-  tradeFee: string // fee taken out of the trade from the buyAsset
 } & ChainSpecificQuoteFeeData<T>
 
 export type ByPairInput = {

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -212,12 +212,10 @@ describe('CowSwapper', () => {
         feeAmountInSellToken: '14557942658757988',
         rate: '14716.04718939437505555958',
         feeData: {
-          fee: '14557942658757988',
           chainSpecific: {
             estimatedGas: '100000',
             gasPrice: '79036500000',
           },
-          tradeFee: '0',
           buyAssetTradeFeeUsd: '0',
           sellAssetTradeFeeUsd: '0',
           networkFee: '14557942658757988',

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -116,12 +116,10 @@ const expectedApiInputFoxToEth: CowSwapSellQuoteApiInput = {
 const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     networkFee: '0',
     sellAssetTradeFeeUsd: '17.95954294012756741283729339486489192096',
@@ -140,13 +138,11 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
 const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '19.13939810252384532346', // 19.14 WETH per WBTC
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
       approvalFee: '7903650000000000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     networkFee: '0',
     sellAssetTradeFeeUsd: '3.6162531444',
@@ -165,12 +161,10 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
 const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '0.00004995640398295996',
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     networkFee: '0',
     sellAssetTradeFeeUsd: '5.3955565850972847808512',

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -113,13 +113,11 @@ export async function cowBuildTrade(
     const trade: CowTrade<KnownChainIds.EthereumMainnet> = {
       rate,
       feeData: {
-        fee: '0', // TODO: remove once web has been updated
         networkFee: '0', // no miner fee for CowSwap
         chainSpecific: {
           estimatedGas: feeData.chainSpecific.gasLimit,
           gasPrice: feeData.chainSpecific.gasPrice,
         },
-        tradeFee: '0', // TODO: remove once web has been updated
         buyAssetTradeFeeUsd: '0', // Trade fees for buy Asset are always 0 since trade fees are subtracted from sell asset
         sellAssetTradeFeeUsd,
       },

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -50,12 +50,10 @@ const hashOrderMock = jest.mocked(hashOrder, true)
 const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958',
   feeData: {
-    fee: '14557942658757988',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     sellAssetTradeFeeUsd: '0',
     networkFee: '14557942658757988',
@@ -74,12 +72,10 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958',
   feeData: {
-    fee: '14557942658757988',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     sellAssetTradeFeeUsd: '0',
     networkFee: '14557942658757988',
@@ -98,12 +94,10 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
 const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '0.00004995640398295996',
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
     },
-    tradeFee: '5.3955565850972847808512',
     buyAssetTradeFeeUsd: '5.3955565850972847808512',
     sellAssetTradeFeeUsd: '0',
     networkFee: '0',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -120,13 +120,11 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   minimum: '0.011624',
   maximum: '100000000000000000000000000',
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
       approvalFee: '7903650000000000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     sellAssetTradeFeeUsd: '17.95954294012756741283729339486489192096',
     networkFee: '0',
@@ -145,13 +143,11 @@ const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
   minimum: '229.09507445589919816724',
   maximum: '100000000000000000000000000',
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
       approvalFee: '7903650000000000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     sellAssetTradeFeeUsd: '5.3955565850972847808512',
     networkFee: '0',
@@ -170,13 +166,11 @@ const expectedTradeQuoteSmallAmountWethToFox: TradeQuote<KnownChainIds.EthereumM
   minimum: '0.011624',
   maximum: '100000000000000000000000000',
   feeData: {
-    fee: '0',
     chainSpecific: {
       estimatedGas: '100000',
       gasPrice: '79036500000',
       approvalFee: '7903650000000000',
     },
-    tradeFee: '0',
     buyAssetTradeFeeUsd: '0',
     sellAssetTradeFeeUsd: '1.79595429401274711874033728120645035672',
     networkFee: '0',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -135,7 +135,6 @@ export async function getCowSwapTradeQuote(
       minimum,
       maximum,
       feeData: {
-        fee: '0', // TODO: remove once web has been updated
         networkFee: '0', // no miner fee for CowSwap
         chainSpecific: {
           estimatedGas: feeData.chainSpecific.gasLimit,
@@ -144,7 +143,6 @@ export async function getCowSwapTradeQuote(
             .multipliedBy(bnOrZero(feeData.chainSpecific.gasPrice))
             .toString(),
         },
-        tradeFee: '0', // TODO: remove once web has been updated
         buyAssetTradeFeeUsd: '0', // Trade fees for buy Asset are always 0 since trade fees are subtracted from sell asset
         sellAssetTradeFeeUsd,
       },

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -186,8 +186,6 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       buyAmount,
       buyAsset,
       feeData: {
-        fee,
-        tradeFee: buyAssetTradeFeeUsd,
         networkFee: fee,
         sellAssetTradeFeeUsd: '0',
         buyAssetTradeFeeUsd,
@@ -232,8 +230,6 @@ export class OsmosisSwapper implements Swapper<ChainId> {
     return {
       buyAsset,
       feeData: {
-        fee,
-        tradeFee: buyAssetTradeFeeUsd,
         networkFee: fee,
         sellAssetTradeFeeUsd: '0',
         buyAssetTradeFeeUsd,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -36,9 +36,7 @@ const quoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
   buyAmount: '784000000000000',
   feeData: {
-    fee: '700000',
     chainSpecific: { estimatedGas: '100000', approvalFee: '700000', gasPrice: '7' },
-    tradeFee: '0.471220133939775024',
     buyAssetTradeFeeUsd: '0.471220133939775024',
     sellAssetTradeFeeUsd: '0',
     networkFee: '700000',

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -184,9 +184,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
             ...commonQuoteFields,
             allowanceContract: '0x0', // not applicable to cosmos
             feeData: {
-              fee: feeData.fast.txFee,
               networkFee: feeData.fast.txFee,
-              tradeFee: buyAssetTradeFeeUsdOrDefault,
               buyAssetTradeFeeUsd: buyAssetTradeFeeUsdOrDefault,
               sellAssetTradeFeeUsd: '0',
               chainSpecific: { estimatedGas: feeData.fast.chainSpecific.gasLimit },

--- a/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.test.ts
@@ -32,9 +32,7 @@ describe('thorTradeApprovalNeeded', () => {
         ...tradeQuote,
         sellAmount: '10',
         feeData: {
-          fee: '0',
           chainSpecific: { gasPrice: '1000' },
-          tradeFee: '0',
           networkFee: '0',
           sellAssetTradeFeeUsd: '0',
           buyAssetTradeFeeUsd: '0',
@@ -56,9 +54,7 @@ describe('thorTradeApprovalNeeded', () => {
         ...tradeQuote,
         sellAmount: '10',
         feeData: {
-          fee: '0',
           chainSpecific: { gasPrice: '1000' },
-          tradeFee: '0',
           networkFee: '0',
           sellAssetTradeFeeUsd: '0',
           buyAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/thorchain/utils/cosmos/cosmosTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/cosmos/cosmosTxData.ts
@@ -75,7 +75,7 @@ export const cosmosTxData = async (input: {
       wallet,
       memo,
       gas: (quote as TradeQuote<KnownChainIds.CosmosMainnet>).feeData.chainSpecific.estimatedGas,
-      fee: quote.feeData.fee,
+      fee: quote.feeData.networkFee,
     })
     return buildTxResponse.txToSign
   }
@@ -97,7 +97,7 @@ export const cosmosTxData = async (input: {
     memo,
     chainSpecific: {
       gas: (quote as TradeQuote<KnownChainIds.CosmosMainnet>).feeData.chainSpecific.estimatedGas,
-      fee: quote.feeData.fee,
+      fee: quote.feeData.networkFee,
     },
   })
 

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/btcTxFees/getBtcTxFees.ts
@@ -45,9 +45,7 @@ export const getBtcTxFees = async ({
     const satsPerByte = feeMultiplier.times(feeData.chainSpecific.satoshiPerByte).dp(0).toString()
 
     return {
-      fee: networkFee,
       networkFee,
-      tradeFee: buyAssetTradeFeeUsd,
       buyAssetTradeFeeUsd,
       sellAssetTradeFeeUsd: '0',
       chainSpecific: {

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/ethTxFees/getEthTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/ethTxFees/getEthTxFees.ts
@@ -49,7 +49,6 @@ export const getEthTxFees = async ({
     const feeData = feeDataOptions['fast']
 
     return {
-      fee: feeData.txFee, // TODO: remove once web has been updated
       networkFee: feeData.txFee,
       chainSpecific: {
         estimatedGas: feeData.chainSpecific.gasLimit,
@@ -60,7 +59,6 @@ export const getEthTxFees = async ({
             .multipliedBy(bnOrZero(feeData.chainSpecific.gasPrice))
             .toString(),
       },
-      tradeFee: buyAssetTradeFeeUsd, // TODO: remove once web has been updated
       buyAssetTradeFeeUsd,
       sellAssetTradeFeeUsd: '0',
     }

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -18,8 +18,6 @@ export const setupQuote = () => {
     minimum: '0',
     maximum: '999999999999',
     feeData: {
-      fee: '0', // TODO: remove once web has been updated
-      tradeFee: '0', // TODO: remove once web has been updated
       chainSpecific: {},
       sellAssetTradeFeeUsd: '0',
       networkFee: '0',

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -44,13 +44,11 @@ describe('getZrxTradeQuote', () => {
     )
     const quote = await swapper.getTradeQuote(quoteInput)
     expect(quote.feeData).toStrictEqual({
-      fee: '1500000000',
       chainSpecific: {
         estimatedGas: '1500000',
         gasPrice: '1000',
         approvalFee: '100000000',
       },
-      tradeFee: '0',
       buyAssetTradeFeeUsd: '0',
       networkFee: '1500000000',
       sellAssetTradeFeeUsd: '0',
@@ -93,13 +91,11 @@ describe('getZrxTradeQuote', () => {
     )
     const quote = await swapper.getTradeQuote(quoteInput)
     expect(quote?.feeData).toStrictEqual({
-      fee: '0',
       chainSpecific: {
         estimatedGas: '0',
         approvalFee: '0',
         gasPrice: undefined,
       },
-      tradeFee: '0',
       sellAssetTradeFeeUsd: '0',
       buyAssetTradeFeeUsd: '0',
       networkFee: '0',

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -98,13 +98,11 @@ export async function getZrxTradeQuote<T extends EvmSupportedChainIds>(
       minimum,
       maximum,
       feeData: {
-        fee,
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),
           gasPrice,
           approvalFee,
         },
-        tradeFee: '0',
         networkFee: fee,
         buyAssetTradeFeeUsd: '0',
         sellAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
+++ b/packages/swapper/src/swappers/zrx/utils/test-data/setupZrxSwapQuote.ts
@@ -39,9 +39,7 @@ export const setupExecuteTrade = () => {
     depositAddress: '0x0',
     receiveAddress: '0x0',
     feeData: {
-      fee: '0',
       chainSpecific: {},
-      tradeFee: '0',
       buyAssetTradeFeeUsd: '0',
       sellAssetTradeFeeUsd: '0',
       networkFee: '0',

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
@@ -65,9 +65,7 @@ describe('zrxApprovalNeeded', () => {
         ...tradeQuote,
         sellAmount: '10',
         feeData: {
-          fee: '0',
           chainSpecific: { gasPrice: '1000' },
-          tradeFee: '0',
           buyAssetTradeFeeUsd: '0',
           sellAssetTradeFeeUsd: '0',
           networkFee: '0',
@@ -97,9 +95,7 @@ describe('zrxApprovalNeeded', () => {
         ...tradeQuote,
         sellAmount: '10',
         feeData: {
-          fee: '0',
           chainSpecific: { gasPrice: '1000' },
-          tradeFee: '0',
           buyAssetTradeFeeUsd: '0',
           sellAssetTradeFeeUsd: '0',
           networkFee: '0',

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -89,9 +89,7 @@ describe('zrxBuildTrade', () => {
     txData: quoteResponse.data,
     rate: quoteResponse.price,
     feeData: {
-      fee: (Number(quoteResponse.gas) * Number(quoteResponse.gasPrice)).toString(),
       chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' },
-      tradeFee: '0',
       networkFee: (Number(quoteResponse.gas) * Number(quoteResponse.gasPrice)).toString(),
       sellAssetTradeFeeUsd: '0',
       buyAssetTradeFeeUsd: '0',
@@ -159,8 +157,6 @@ describe('zrxBuildTrade', () => {
         gasPrice,
         estimatedGas,
       },
-      fee: bnOrZero(gasPrice).multipliedBy(estimatedGas).toString(),
-      tradeFee: '0',
       buyAssetTradeFeeUsd: '0',
       sellAssetTradeFeeUsd: '0',
       networkFee: bnOrZero(gasPrice).multipliedBy(estimatedGas).toString(),

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -107,13 +107,11 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
       rate: data.price,
       depositAddress: data.to,
       feeData: {
-        fee: networkFee,
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),
           gasPrice: data.gasPrice,
           approvalFee: approvalRequired ? approvalFee : undefined,
         },
-        tradeFee: '0',
         networkFee,
         buyAssetTradeFeeUsd: '0',
         sellAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -34,9 +34,7 @@ describe('ZrxExecuteTrade', () => {
     txData: '0x123',
     rate: '1',
     feeData: {
-      fee: '0',
       chainSpecific: { approvalFee: '123600000', estimatedGas: '1235', gasPrice: '1236' },
-      tradeFee: '0',
       buyAssetTradeFeeUsd: '0',
       sellAssetTradeFeeUsd: '0',
       networkFee: '0',


### PR DESCRIPTION
BREAKING CHANGE: removes deprecated fields from QuoteFeeData.

Leaving in draft until a consuming `web` PR is ready.