### PR TITLE
fix(swapper): fix rune as sell asset

### DIFF
--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -55,6 +55,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
     [KnownChainIds.LitecoinMainnet]: true,
     [KnownChainIds.BitcoinCashMainnet]: true,
     [KnownChainIds.CosmosMainnet]: true,
+    [KnownChainIds.ThorchainMainnet]: true,
   }
 
   private buySupportedChainIds: Record<ChainId, boolean> = {
@@ -64,6 +65,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
     [KnownChainIds.LitecoinMainnet]: true,
     [KnownChainIds.BitcoinCashMainnet]: true,
     [KnownChainIds.CosmosMainnet]: true,
+    [KnownChainIds.ThorchainMainnet]: true,
   }
 
   private supportedSellAssetIds: AssetId[] = []

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
@@ -52,6 +52,17 @@ export const getPriceRatio = async (
       return bn(runeBalance).dividedBy(sellAssetBalance).toString()
     }
 
+    if (isRune(sellAssetId) && buyPool) {
+      const buyAssetBalance = bnOrZero(buyPool.balance_asset)
+      const runeBalance = bnOrZero(buyPool.balance_rune)
+      // guard against division by zero
+      if (buyAssetBalance.eq(0))
+        throw new SwapError(
+          `[getPriceRatio] zero buy asset balance sellAssetId ${sellAssetId} buyAssetId ${buyAssetId}`,
+        )
+      return bn(buyAssetBalance).dividedBy(runeBalance).toString()
+    }
+
     if (!buyPool || !sellPool) {
       throw new SwapError(`[getPriceRatio]: pools not found`, {
         code: SwapErrorTypes.RESPONSE_ERROR,


### PR DESCRIPTION
Fixes quote when sell asset is native RUNE and no amounts have been entered yet.

Closes https://github.com/shapeshift/web/issues/3066

**Before**

<img width="396" alt="Screen Shot 2022-10-23 at 6 09 00 pm" src="https://user-images.githubusercontent.com/97164662/197379025-d28a84c8-7212-45d9-9416-87c5d3464f56.png">

**After**

<img width="398" alt="Screen Shot 2022-10-23 at 6 05 51 pm" src="https://user-images.githubusercontent.com/97164662/197378935-9eddaa5a-db3f-4240-a884-dd520a805549.png">
