### PR TITLE
chore: downgrade yearnsdk to fix broken endpoints

### DIFF
--- a/packages/asset-service/package.json
+++ b/packages/asset-service/package.json
@@ -46,7 +46,7 @@
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/investor-idle": "^2.0.1",
     "@types/node-polyglot": "^2.4.2",
-    "@yfi/sdk": "^2.1.0",
+    "@yfi/sdk": "^1.2.0",
     "colorthief": "^2.3.2",
     "dotenv": "^14.3.0",
     "web3": "1.7.4"

--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@shapeshiftoss/types": "^8.1.0",
-    "@yfi/sdk": "^2.1.0",
+    "@yfi/sdk": "^1.2.0",
     "axios": "^0.26.1",
     "ts-node": "^10.7.0"
   }

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.3",
-    "@yfi/sdk": "^2.1.0",
+    "@yfi/sdk": "^1.2.0",
     "bignumber.js": "^9.0.2",
     "lodash": "^4.17.21",
     "web3": "1.7.4",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.3",
-    "@yfi/sdk": "^2.1.0",
+    "@yfi/sdk": "^1.2.0",
     "axios": "^0.26.1",
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.2",

--- a/packages/market-service/src/yearn/yearnMockData.ts
+++ b/packages/market-service/src/yearn/yearnMockData.ts
@@ -311,7 +311,6 @@ export const mockYearnTokenRestData: Token[] = [
     decimals: '8',
     priceUsdc: '50000000000',
     supported: {},
-    dataSource: 'vaults',
   },
   {
     address: '0x19D3364A399d251E894aC732651be8B0E4e85001',
@@ -320,6 +319,5 @@ export const mockYearnTokenRestData: Token[] = [
     decimals: '18',
     priceUsdc: '990000',
     supported: {},
-    dataSource: 'vaults',
   },
 ]

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -22,7 +22,7 @@
     "type-check": "tsc --project ./tsconfig.build.json --noEmit"
   },
   "dependencies": {
-    "@yfi/sdk": "^2.1.0",
+    "@yfi/sdk": "^1.2.0",
     "bignumber.js": "^9.0.2",
     "ethers": "^5.5.3",
     "isomorphic-ws": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,13 +3680,13 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yfi/sdk@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-2.1.0.tgz#24ac7d0c1eace1345c62017c84ac259673f51b25"
-  integrity sha512-x5l4+yTkQ7uXlkBQdueYDXbFqZ2sXq0gNMK6QPnUfd2J7aBbtAp4qCLa46a86DSHsUPzoT4rBmau0tUWVZU9Bg==
+"@yfi/sdk@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.2.0.tgz#b0635ced261cab41c57272ebb00ea7041702d74b"
+  integrity sha512-o0GE+enTlUDwuP+W7TD7/5r5s2xuMTj93vPpUmDYePOunx3B85jwEl2FLUugTOdsku8eKhLLhLJTx6fJmSJLAw==
   dependencies:
     bignumber.js "9.0.1"
-    cross-fetch "3.1.5"
+    cross-fetch "3.1.4"
     dotenv "10.0.0"
     emittery "0.8.1"
     type-fest "1.2.1"
@@ -5475,12 +5475,12 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+cross-fetch@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "2.6.1"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -10155,17 +10155,22 @@ node-emoji@^1.10.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2.6.7, node-fetch@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@^2.6.1:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
- the recent upgrade of yearn sdk package has resulted in security access errors in web, downgrade to previous working version until it can be looked into further