### PR TITLE
fix: pass back metadata to onmessage handler

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -49,6 +49,27 @@ const transformValidator = (validator: unchained.cosmossdk.types.Validator): Val
   apr: validator.apr,
 })
 
+const parsedTxToTransaction = (parsedTx: unchained.cosmossdk.ParsedTx): Transaction => ({
+  address: parsedTx.address,
+  blockHash: parsedTx.blockHash,
+  blockHeight: parsedTx.blockHeight,
+  blockTime: parsedTx.blockTime,
+  chainId: parsedTx.chainId,
+  txid: parsedTx.txid,
+  confirmations: parsedTx.confirmations,
+  fee: parsedTx.fee,
+  status: parsedTx.status,
+  trade: parsedTx.trade,
+  transfers: parsedTx.transfers.map((transfer) => ({
+    assetId: transfer.assetId,
+    from: transfer.from,
+    to: transfer.to,
+    type: transfer.type,
+    value: transfer.totalValue,
+  })),
+  data: parsedTx.data,
+})
+
 export const cosmosSdkChainIds = [
   KnownChainIds.CosmosMainnet,
   KnownChainIds.OsmosisMainnet,
@@ -198,28 +219,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
       const txs = await Promise.all(
         data.txs.map(async (tx) => {
           const parsedTx = await this.parser.parse(tx, input.pubkey)
-
-          return {
-            address: input.pubkey,
-            blockHash: parsedTx.blockHash,
-            blockHeight: parsedTx.blockHeight,
-            blockTime: parsedTx.blockTime,
-            chainId: parsedTx.chainId,
-            chain: this.getType(),
-            confirmations: parsedTx.confirmations,
-            txid: parsedTx.txid,
-            fee: parsedTx.fee,
-            status: parsedTx.status,
-            trade: parsedTx.trade,
-            transfers: parsedTx.transfers.map((transfer) => ({
-              assetId: transfer.assetId,
-              from: transfer.from,
-              to: transfer.to,
-              type: transfer.type,
-              value: transfer.totalValue,
-            })),
-            data: parsedTx.data,
-          }
+          return parsedTxToTransaction(parsedTx)
         }),
       )
 
@@ -274,27 +274,8 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
       subscriptionId,
       { topic: 'txs', addresses: [address] },
       async (msg) => {
-        const tx = await this.parser.parse(msg.data, msg.address)
-
-        onMessage({
-          address: tx.address,
-          blockHash: tx.blockHash,
-          blockHeight: tx.blockHeight,
-          blockTime: tx.blockTime,
-          chainId: tx.chainId,
-          confirmations: tx.confirmations,
-          fee: tx.fee,
-          status: tx.status,
-          trade: tx.trade,
-          transfers: tx.transfers.map((transfer) => ({
-            assetId: transfer.assetId,
-            from: transfer.from,
-            to: transfer.to,
-            type: transfer.type,
-            value: transfer.totalValue,
-          })),
-          txid: tx.txid,
-        })
+        const parsedTx = await this.parser.parse(msg.data, msg.address)
+        onMessage(parsedTxToTransaction(parsedTx))
       },
       (err) => onError({ message: err.message }),
     )

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -50,16 +50,7 @@ const transformValidator = (validator: unchained.cosmossdk.types.Validator): Val
 })
 
 const parsedTxToTransaction = (parsedTx: unchained.cosmossdk.ParsedTx): Transaction => ({
-  address: parsedTx.address,
-  blockHash: parsedTx.blockHash,
-  blockHeight: parsedTx.blockHeight,
-  blockTime: parsedTx.blockTime,
-  chainId: parsedTx.chainId,
-  txid: parsedTx.txid,
-  confirmations: parsedTx.confirmations,
-  fee: parsedTx.fee,
-  status: parsedTx.status,
-  trade: parsedTx.trade,
+  ...parsedTx,
   transfers: parsedTx.transfers.map((transfer) => ({
     assetId: transfer.assetId,
     from: transfer.from,
@@ -67,7 +58,6 @@ const parsedTxToTransaction = (parsedTx: unchained.cosmossdk.ParsedTx): Transact
     type: transfer.type,
     value: transfer.totalValue,
   })),
-  data: parsedTx.data,
 })
 
 export const cosmosSdkChainIds = [


### PR DESCRIPTION
- create shared `parsedTxToTransaction` function that both `subscribeTxs.onMessage` and `getTxHistory` can use
- metadata is now passed back in both cases resulting in correct transaction row display in the client
- may have also fixed trade confirmation display in trade modal as I am now seeing that update (although with polling it is not in sync with incoming buy side tx)