### PR TITLE
fix: return idle raw TVL values

### DIFF
--- a/packages/investor-idle/src/IdleOpportunity.ts
+++ b/packages/investor-idle/src/IdleOpportunity.ts
@@ -158,8 +158,8 @@ export class IdleOpportunity
     this.expired = false
     this.apy = bnOrZero(vault.apr).div(100)
     this.tvl = {
-      balanceUsdc: normalizeAmount(vault.tvl, 6),
-      balance: normalizeAmount(vault.underlyingTVL),
+      balanceUsdc: bnOrZero(vault.tvl),
+      balance: bnOrZero(vault.underlyingTVL),
       assetId: toAssetId({
         chainId: 'eip155:1',
         assetNamespace: 'erc20',


### PR DESCRIPTION
#### Description

TVL parsing in investor-idle is wrong, confirmed the intent was to trim
the values to 6 significant digits (the decimal places of USDC the TVL
is denoted in), but this effectively parsed the numbers as way bigger
ones (e.g trillions instead of millions)

This PR removes the parsing and returns the raw numbers from Idle's API, so that web can
apply the parsing it needs.
