### PR TITLE
feat(market-service): idle market service

### DIFF
--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -39,7 +39,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
-    "@shapeshiftoss/investor-idle": "^2.3.1",
+    "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1"
   },
@@ -47,7 +47,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
-    "@shapeshiftoss/investor-idle": "^2.3.1",
+    "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1",
     "limiter": "^2.1.0"

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -39,6 +39,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
+    "@shapeshiftoss/investor-idle": "^2.3.1",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1"
   },
@@ -46,6 +47,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^10.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
+    "@shapeshiftoss/investor-idle": "^2.3.1",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1",
     "limiter": "^2.1.0"

--- a/packages/market-service/src/idle/idle.ts
+++ b/packages/market-service/src/idle/idle.ts
@@ -30,9 +30,6 @@ export class IdleMarketService implements MarketService {
       }),
       providerUrl: this.providerUrls.jsonRpcProviderUrl,
     })
-    ;(async () => {
-      await this.idleInvestor.initialize()
-    })()
   }
 
   async findAll() {
@@ -54,8 +51,8 @@ export class IdleMarketService implements MarketService {
       acc[assetId] = {
         price: opportunity.tvl.balanceUsdc.div(opportunity.tvl.balance).toFixed(),
         marketCap: opportunity.tvl.balanceUsdc.toFixed(), // For Idle, TVL and marketCap are effectively the same
-        volume: '0', // TODO:
-        changePercent24Hr: 0, // TODO
+        volume: '0',
+        changePercent24Hr: 0,
       }
 
       return acc
@@ -78,8 +75,8 @@ export class IdleMarketService implements MarketService {
     return {
       price: opportunity.tvl.balanceUsdc.div(opportunity.tvl.balance).toFixed(),
       marketCap: opportunity.tvl.balanceUsdc.toFixed(), // For Idle, TVL and marketCap are effectively the same
-      volume: '0', // TODO:
-      changePercent24Hr: 0, // TODO
+      volume: '0',
+      changePercent24Hr: 0,
     }
   }
 

--- a/packages/market-service/src/idle/idle.ts
+++ b/packages/market-service/src/idle/idle.ts
@@ -1,0 +1,89 @@
+import { fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { ethereum } from '@shapeshiftoss/chain-adapters'
+import { IdleInvestor } from '@shapeshiftoss/investor-idle'
+import { MarketCapResult, MarketData, MarketDataArgs } from '@shapeshiftoss/types'
+import * as unchained from '@shapeshiftoss/unchained-client'
+
+import { MarketService } from '../api'
+import { ProviderUrls } from '../market-service-manager'
+
+export class IdleMarketService implements MarketService {
+  baseUrl = ''
+  providerUrls: ProviderUrls
+  idleInvestor: IdleInvestor
+
+  constructor({ providerUrls }: { providerUrls: ProviderUrls }) {
+    this.providerUrls = providerUrls
+    this.idleInvestor = new IdleInvestor({
+      chainAdapter: new ethereum.ChainAdapter({
+        providers: {
+          ws: new unchained.ws.Client<unchained.ethereum.Tx>(
+            this.providerUrls.unchainedEthereumWsUrl,
+          ),
+          http: new unchained.ethereum.V1Api(
+            new unchained.ethereum.Configuration({
+              basePath: this.providerUrls.unchainedEthereumHttpUrl,
+            }),
+          ),
+        },
+        rpcUrl: this.providerUrls.jsonRpcProviderUrl,
+      }),
+      providerUrl: this.providerUrls.jsonRpcProviderUrl,
+    })
+    ;(async () => {
+      await this.idleInvestor.initialize()
+    })()
+  }
+
+  async findAll() {
+    const idleOpportunities = await (async () => {
+      const maybeOpportunities = await this.idleInvestor.findAll()
+      if (maybeOpportunities.length) return maybeOpportunities
+
+      await this.idleInvestor.initialize()
+      return await this.idleInvestor.findAll()
+    })()
+
+    const marketDataById = idleOpportunities.reduce((acc, opportunity) => {
+      const assetId = toAssetId({
+        assetNamespace: 'erc20',
+        assetReference: opportunity.id,
+        chainId: fromAssetId(opportunity.feeAsset.assetId).chainId,
+      })
+
+      acc[assetId] = {
+        price: opportunity.tvl.balanceUsdc.div(opportunity.tvl.balance).toFixed(),
+        marketCap: opportunity.tvl.balanceUsdc.toFixed(), // For Idle, TVL and marketCap are effectively the same
+        volume: '0', // TODO:
+        changePercent24Hr: 0, // TODO
+      }
+
+      return acc
+    }, {} as MarketCapResult)
+
+    return marketDataById
+  }
+
+  async findByAssetId({ assetId }: MarketDataArgs): Promise<MarketData | null> {
+    const opportunity = await (async () => {
+      const maybeOpportunities = await this.idleInvestor.findAll()
+      if (maybeOpportunities.length) return await this.idleInvestor.findByOpportunityId(assetId)
+
+      await this.idleInvestor.initialize()
+      return await this.idleInvestor.findByOpportunityId(assetId)
+    })()
+
+    if (!opportunity) return null
+
+    return {
+      price: opportunity.tvl.balanceUsdc.div(opportunity.tvl.balance).toFixed(),
+      marketCap: opportunity.tvl.balanceUsdc.toFixed(), // For Idle, TVL and marketCap are effectively the same
+      volume: '0', // TODO:
+      changePercent24Hr: 0, // TODO
+    }
+  }
+
+  async findPriceHistoryByAssetId() {
+    return []
+  }
+}

--- a/packages/market-service/src/market-service-manager.ts
+++ b/packages/market-service/src/market-service-manager.ts
@@ -13,6 +13,7 @@ import { MarketService } from './api'
 import { CoinCapMarketService } from './coincap/coincap'
 import { CoinGeckoMarketService } from './coingecko/coingecko'
 import { FoxyMarketService } from './foxy/foxy'
+import { IdleMarketService } from './idle/idle'
 import { OsmosisMarketService } from './osmosis/osmosis'
 import { YearnTokenMarketCapService } from './yearn/yearn-tokens'
 import { YearnVaultMarketCapService } from './yearn/yearn-vaults'
@@ -50,6 +51,7 @@ export class MarketServiceManager {
       new CoinCapMarketService(),
       new YearnVaultMarketCapService({ yearnSdk }),
       new YearnTokenMarketCapService({ yearnSdk }),
+      new IdleMarketService({ providerUrls }),
       new OsmosisMarketService(),
       new FoxyMarketService({ coinGeckoAPIKey, providerUrls }),
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,18 +3178,6 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
-"@shapeshiftoss/investor-idle@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-idle/-/investor-idle-2.3.1.tgz#41c5191354dc5f530d647958939b66887f5dc79a"
-  integrity sha512-WPeUUkIA/41tkX77TYD7I21aQvE0HBw2xAxTkxmIJvGj76MkEWgOidcwLVTlYS1Bc62ax+5Cwih4MDDY3Pnp1A==
-  dependencies:
-    "@ethersproject/providers" "^5.5.3"
-    bignumber.js "^9.0.2"
-    lodash "^4.17.21"
-    web3 "1.7.4"
-    web3-core "1.7.4"
-    web3-utils "1.7.4"
-
 "@shapeshiftoss/proto-tx-builder@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/proto-tx-builder/-/proto-tx-builder-0.4.0.tgz#970eadcd098e5851bc1938d227faa543c619c6a2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,6 +3178,18 @@
     tiny-secp256k1 "^1.1.6"
     web-encoding "^1.1.0"
 
+"@shapeshiftoss/investor-idle@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-idle/-/investor-idle-2.3.1.tgz#41c5191354dc5f530d647958939b66887f5dc79a"
+  integrity sha512-WPeUUkIA/41tkX77TYD7I21aQvE0HBw2xAxTkxmIJvGj76MkEWgOidcwLVTlYS1Bc62ax+5Cwih4MDDY3Pnp1A==
+  dependencies:
+    "@ethersproject/providers" "^5.5.3"
+    bignumber.js "^9.0.2"
+    lodash "^4.17.21"
+    web3 "1.7.4"
+    web3-core "1.7.4"
+    web3-utils "1.7.4"
+
 "@shapeshiftoss/proto-tx-builder@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/proto-tx-builder/-/proto-tx-builder-0.4.0.tgz#970eadcd098e5851bc1938d227faa543c619c6a2"


### PR DESCRIPTION
#### Description

This PR:

- uses the right calculation to get the price of Idle opportunity tokens
- adds an `idle` market-service, getting Idle opportunity tokens' price and market cap

#### Screenshots

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/17035424/203358755-5cb42e59-3415-40dd-8566-03368cd907e3.png">
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/17035424/203358823-85386a3e-4617-4b0c-a9e0-cf975861469c.png">