### PR TITLE
fix: add floor of 0 to limit

### DIFF
--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
@@ -94,15 +94,16 @@ export const getLimit = async ({
   })()
 
   const highestPossibleFeeCryptoPrecision8 = max([
-    buyAssetTradeFeeCryptoPrecision8,
-    refundFeeBuyAssetCryptoPrecision8,
+    // both fees are denominated in buy asset crypto precision 8
+    bnOrZero(buyAssetTradeFeeCryptoPrecision8).toNumber(),
+    bnOrZero(refundFeeBuyAssetCryptoPrecision8).toNumber(),
   ])
 
   const expectedBuyAmountAfterHighestFeeCryptoPrecision8 = bnOrZero(
     expectedBuyAmountCryptoPrecision8,
   )
     .times(bn(1).minus(slippageTolerance))
-    .minus(bnOrZero(highestPossibleFeeCryptoPrecision8))
+    .minus(highestPossibleFeeCryptoPrecision8 ?? 0)
     .decimalPlaces(0)
 
   // expectedBuyAmountAfterHighestFeeCryptoPrecision8 can be negative if the sell asset has a higher inbound_fee

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
@@ -98,9 +98,17 @@ export const getLimit = async ({
     refundFeeBuyAssetCryptoPrecision8,
   ])
 
-  return bnOrZero(expectedBuyAmountCryptoPrecision8)
+  const expectedBuyAmountAfterHighestFeeCryptoPrecision8 = bnOrZero(
+    expectedBuyAmountCryptoPrecision8,
+  )
     .times(bn(1).minus(slippageTolerance))
     .minus(bnOrZero(highestPossibleFeeCryptoPrecision8))
     .decimalPlaces(0)
-    .toString()
+
+  // expectedBuyAmountAfterHighestFeeCryptoPrecision8 can be negative if the sell asset has a higher inbound_fee
+  // (a refund) than the buy asset's inbound_fee + buy amount.
+  // I.e. we've come this far - we don't have enough to refund, so the limit can slide all the way to 0.
+  return expectedBuyAmountAfterHighestFeeCryptoPrecision8.isPositive()
+    ? expectedBuyAmountAfterHighestFeeCryptoPrecision8.toString()
+    : '0'
 }


### PR DESCRIPTION
If we are sending a small amount to do a Thor trade, and the `outbound_fee` of the sell asset is high, it's possible that the refund fee is higher than the value of the trade.

In this case the limit should be 0 (but not negative), as in "finish this trade no matter what, as the amount is too small to refund it anyway".

The current logic, however, lets the memo limit go negative, which causes an error when executing the TX, e.g. https://live.blockcypher.com/btc/tx/60897031eec3714b079a8d5acb055e84f214bf037863fdcdd11d430c0ca71b5e/