### PR TITLE
chore: use EVM-centric naming

### DIFF
--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -122,11 +122,11 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       case CHAIN_NAMESPACE.Evm:
         return (async (): Promise<TradeQuote<EvmSupportedChainIds>> => {
           const sellChainFeeAssetId = sellAdapter.getFeeAssetId()
-          const ethAddressData = await getInboundAddressDataForChain(
+          const evmAddressData = await getInboundAddressDataForChain(
             deps.daemonUrl,
             sellChainFeeAssetId,
           )
-          const router = ethAddressData?.router
+          const router = evmAddressData?.router
           if (!router)
             throw new SwapError(
               `[getThorTradeQuote] No router address found for ${sellChainFeeAssetId}`,

--- a/packages/swapper/src/swappers/thorchain/utils/constants.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/constants.ts
@@ -1,7 +1,7 @@
 export const MAX_THORCHAIN_TRADE = '100000000000000000000000000'
 export const MAX_ALLOWANCE = '100000000000000000000000000'
 export const THOR_MINIMUM_PADDING = 1.2
-export const THOR_ETH_GAS_LIMIT = '100000' // for sends of eth / erc20 into thorchain router
+export const THOR_EVM_GAS_LIMIT = '100000' // for sends of eth / erc20 into thorchain router
 export const THORCHAIN_FIXED_PRECISION = 8 // limit values are precision 8 regardless of the chain
 export const THORCHAIN_AFFILIATE_NAME = 'ss'
 export const THORCHAIN_AFFILIATE_BIPS = '0' // affiliate fee in basis points (100 = 1%)

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../api'
 import { bn, bnOrZero } from '../../../../utils/bignumber'
 import { APPROVAL_GAS_LIMIT } from '../../../../utils/constants'
-import { THOR_ETH_GAS_LIMIT } from '../../constants'
+import { THOR_EVM_GAS_LIMIT } from '../../constants'
 
 type GetEvmTxFeesArgs = {
   adapter: EvmSupportedChainAdapter
@@ -26,9 +26,10 @@ export const getEvmTxFees = async ({
   try {
     const gasFeeData = await adapter.getGasFeeData()
 
-    // this is a good value to cover all thortrades out of eth/erc20
+    // this is a good value to cover all thortrades out of EVMs
     // in the future we may want to look at doing this more precisely and in a future-proof way
-    const gasLimit = THOR_ETH_GAS_LIMIT
+    // TODO: calculate this dynamically
+    const gasLimit = THOR_EVM_GAS_LIMIT
 
     const feeDataOptions = {
       fast: {


### PR DESCRIPTION
Update some naming to make it clear that the values and functions are used for all EVMs, not just Ethereum.

Note, the hardcoded gas limit value still needs to be replaced (though it does work for Ethereum and Avalanche). 
I've reached out to 9R for more info on how best to do this.