### PR TITLE
feat(swapper): add dynamic slippage

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -130,6 +130,7 @@ export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
   allowanceContract: string
   minimumCryptoHuman: string
   maximum: string
+  recommendedSlippage?: string
 
   /** @deprecated Use minimumCryptoHuman instead */
   minimum?: string

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -284,5 +284,8 @@ export interface Swapper<T extends ChainId> {
    */
   filterAssetIdsBySellable(assetIds: AssetId[]): AssetId[]
 
+  /**
+   * Get transactions related to a trade
+   */
   getTradeTxs(tradeResult: TradeResult): Promise<TradeTxs>
 }

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -131,7 +131,7 @@ export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
   minimumCryptoHuman: string
   maximum: string
 
-  /** @deprecated Use sellAmountCryptoHuman instead */
+  /** @deprecated Use minimumCryptoHuman instead */
   minimum?: string
 }
 

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
@@ -35,7 +35,7 @@ describe('getSlippage', () => {
   describe('getSingleSwapSlippage', () => {
     it('should return slippage for BTC -> RUNE single swap', async () => {
       const slippage = await getSingleSwapSlippage({
-        inputAmount: bn(100000000), // 1 BTC
+        inputAmountThorPrecision: bn(100000000), // 1 BTC
         pool: btcThornodePool,
         toRune: true,
       }).toNumber()
@@ -45,7 +45,7 @@ describe('getSlippage', () => {
     it('should return slippage for RUNE -> ETH single swap', async () => {
       const firstSwapOutput = getSwapOutput(bn(100000000), btcThornodePool, true)
       const slippage = await getSingleSwapSlippage({
-        inputAmount: firstSwapOutput,
+        inputAmountThorPrecision: firstSwapOutput,
         pool: ethThornodePool,
         toRune: false,
       }).toNumber()
@@ -56,7 +56,7 @@ describe('getSlippage', () => {
   describe('getDoubleSwapSlippage', () => {
     it('should return slippage for BTC -> RUNE -> ETH double swap', async () => {
       const slippage = await getDoubleSwapSlippage({
-        inputAmount: bn(100000000), // 1 ETH
+        inputAmountThorPrecision: bn(100000000), // 1 ETH
         sellPool: btcThornodePool,
         buyPool: ethThornodePool,
       }).toNumber()
@@ -67,7 +67,7 @@ describe('getSlippage', () => {
   describe('getSlippage', () => {
     it('should return slippage for BTC -> RUNE -> ETH double swap', async () => {
       const slippage = await getSlippage({
-        inputAmount: bn(100000000), // 1 ETH
+        inputAmountThorPrecision: bn(100000000), // 1 ETH
         daemonUrl: '',
         buyAssetId: ethAssetId,
         sellAssetId: btcAssetId,
@@ -77,7 +77,7 @@ describe('getSlippage', () => {
 
     it('should return slippage for RUNE -> ETH single swap', async () => {
       const slippage = await getSlippage({
-        inputAmount: bn(100000000), // 1 RUNE
+        inputAmountThorPrecision: bn(100000000), // 1 RUNE
         daemonUrl: '',
         buyAssetId: ethAssetId,
         sellAssetId: thorchainAssetId,
@@ -87,7 +87,7 @@ describe('getSlippage', () => {
 
     it('should return slippage for ETH -> RUNE single swap', async () => {
       const slippage = await getSlippage({
-        inputAmount: bn(100000000), // 1 ETH
+        inputAmountThorPrecision: bn(100000000), // 1 ETH
         daemonUrl: '',
         buyAssetId: thorchainAssetId,
         sellAssetId: ethAssetId,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
@@ -16,8 +16,8 @@ jest.mock('../utils/thorService')
 const mockedAxios = jest.mocked(thorService, true)
 
 describe('getSlippage', () => {
-  const expectedBtcRuneSlippage = 0.0010973599869752281
-  const expectedRuneEthSlippage = 0.001655144396331673
+  const expectedBtcRuneSlippage = bn('0.00109735998697522801')
+  const expectedRuneEthSlippage = bn('0.00165514439633167301')
 
   beforeEach(() => {
     mockedAxios.get.mockImplementation((url) => {
@@ -38,8 +38,8 @@ describe('getSlippage', () => {
         inputAmountThorPrecision: bn(100000000), // 1 BTC
         pool: btcThornodePool,
         toRune: true,
-      }).toNumber()
-      expect(slippage).toEqual(expectedBtcRuneSlippage)
+      }).toPrecision()
+      expect(slippage).toEqual(expectedBtcRuneSlippage.toPrecision())
     })
 
     it('should return slippage for RUNE -> ETH single swap', async () => {
@@ -48,8 +48,8 @@ describe('getSlippage', () => {
         inputAmountThorPrecision: firstSwapOutput,
         pool: ethThornodePool,
         toRune: false,
-      }).toNumber()
-      expect(slippage).toEqual(expectedRuneEthSlippage)
+      }).toPrecision()
+      expect(slippage).toEqual(expectedRuneEthSlippage.toPrecision())
     })
   })
 
@@ -59,8 +59,8 @@ describe('getSlippage', () => {
         inputAmountThorPrecision: bn(100000000), // 1 ETH
         sellPool: btcThornodePool,
         buyPool: ethThornodePool,
-      }).toNumber()
-      expect(slippage).toEqual(expectedBtcRuneSlippage + expectedRuneEthSlippage)
+      }).toPrecision()
+      expect(slippage).toEqual(expectedBtcRuneSlippage.plus(expectedRuneEthSlippage).toPrecision())
     })
   })
 
@@ -72,7 +72,9 @@ describe('getSlippage', () => {
         buyAssetId: ethAssetId,
         sellAssetId: btcAssetId,
       })
-      expect(slippage.toNumber()).toEqual(expectedBtcRuneSlippage + expectedRuneEthSlippage)
+      expect(slippage.toPrecision()).toEqual(
+        expectedBtcRuneSlippage.plus(expectedRuneEthSlippage).toPrecision(),
+      )
     })
 
     it('should return slippage for RUNE -> ETH single swap', async () => {
@@ -82,7 +84,7 @@ describe('getSlippage', () => {
         buyAssetId: ethAssetId,
         sellAssetId: thorchainAssetId,
       })
-      expect(slippage.toNumber()).toEqual(0.00000016161699588038)
+      expect(slippage.toPrecision()).toEqual('1.6161699588038e-7')
     })
 
     it('should return slippage for ETH -> RUNE single swap', async () => {
@@ -92,7 +94,7 @@ describe('getSlippage', () => {
         buyAssetId: thorchainAssetId,
         sellAssetId: ethAssetId,
       })
-      expect(slippage.toNumber()).toEqual(0.00010927540718746784)
+      expect(slippage.toPrecision()).toEqual('0.00010927540718746784')
     })
   })
 })

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.test.ts
@@ -1,0 +1,65 @@
+import { bn } from '../../utils/bignumber'
+import { getSwapOutput } from '../utils/getTradeRate/getTradeRate'
+import {
+  btcThornodePool,
+  ethThornodePool,
+  mockInboundAddresses,
+  thornodePools,
+} from '../utils/test-data/responses'
+import { thorService } from '../utils/thorService'
+import { getDoubleSwapSlippage, getSingleSwapSlippage } from './getSlippage'
+
+jest.mock('../utils/thorService')
+
+const mockedAxios = jest.mocked(thorService, true)
+
+describe('getSlippage', () => {
+  const expectedBtcRuneSlippage = 0.0010973599869752281
+  const expectedRuneEthSlippage = 0.001655144396331673
+
+  beforeEach(() => {
+    mockedAxios.get.mockImplementation((url) => {
+      console.log('xxx url', url)
+      switch (url) {
+        case 'lcd/thorchain/pools':
+          return Promise.resolve({ data: thornodePools })
+        case '/lcd/thorchain/inbound_addresses':
+          return Promise.resolve({ data: mockInboundAddresses })
+        default:
+          return Promise.resolve({ data: undefined })
+      }
+    })
+  })
+
+  describe('getSingleSwapSlippage', () => {
+    it('should return slippage for BTC -> RUNE single swap', async () => {
+      const slippage = await getSingleSwapSlippage({
+        inputAmount: bn(100000000), // 1BTC
+        pool: btcThornodePool,
+        toRune: true,
+      }).toNumber()
+      expect(slippage).toEqual(expectedBtcRuneSlippage)
+    })
+
+    it('should return slippage for RUNE -> ETH single swap', async () => {
+      const firstSwapOutput = getSwapOutput(bn(100000000), btcThornodePool, true)
+      const slippage = await getSingleSwapSlippage({
+        inputAmount: firstSwapOutput,
+        pool: ethThornodePool,
+        toRune: false,
+      }).toNumber()
+      expect(slippage).toEqual(expectedRuneEthSlippage)
+    })
+  })
+
+  describe('getDoubleSwapSlippage', () => {
+    it('should return slippage for BTC -> RUNE -> ETH double swap', async () => {
+      const slippage = await getDoubleSwapSlippage({
+        inputAmount: bn(100000000), // 1ETH
+        sellPool: btcThornodePool,
+        buyPool: ethThornodePool,
+      }).toNumber()
+      expect(slippage).toEqual(expectedBtcRuneSlippage + expectedRuneEthSlippage)
+    })
+  })
+})

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
@@ -1,0 +1,93 @@
+import { adapters, AssetId } from '@shapeshiftoss/caip'
+import { AssertionError } from 'assert'
+
+import { BN } from '../../utils/bignumber'
+import { ThornodePoolResponse } from '../types'
+import { getSwapOutput } from '../utils/getTradeRate/getTradeRate'
+import { isRune } from '../utils/isRune/isRune'
+import { thorService } from '../utils/thorService'
+
+type GetSingleSwapSlippageArgs = {
+  inputAmount: BN
+  pool: ThornodePoolResponse
+  toRune: boolean
+}
+
+// Calculate swap slippage
+const getSingleSwapSlippage = ({ inputAmount, pool, toRune }: GetSingleSwapSlippageArgs): BN => {
+  // formula: (inputAmount) / (inputAmount + inputBalance)
+  const inputBalance = toRune ? pool.balance_asset : pool.balance_rune // input is asset if toRune
+  const denominator = inputAmount.plus(inputBalance)
+  return inputAmount.div(denominator)
+}
+
+type GetDoubleSwapSlippageArgs = {
+  inputAmount: BN
+  sellPool: ThornodePoolResponse
+  buyPool: ThornodePoolResponse
+}
+
+// Calculate swap slippage for double swap
+const getDoubleSwapSlippage = ({
+  inputAmount,
+  sellPool,
+  buyPool,
+}: GetDoubleSwapSlippageArgs): BN => {
+  // formula: calcSwapSlip1(input1) + calcSwapSlip2(calcSwapOutput1 => input2)
+  const firstSwapSlippage = getSingleSwapSlippage({ inputAmount, pool: sellPool, toRune: true })
+  const firstSwapOutput = getSwapOutput(inputAmount, sellPool, true)
+  const secondSwapSlippage = getSingleSwapSlippage({
+    inputAmount: firstSwapOutput,
+    pool: buyPool,
+    toRune: false,
+  })
+  return firstSwapSlippage.plus(secondSwapSlippage)
+}
+
+type GetSlippageArgs = {
+  inputAmount: BN
+  daemonUrl: string
+  buyAssetId: AssetId
+  sellAssetId: AssetId
+}
+
+export const getSlippage = async ({
+  inputAmount,
+  daemonUrl,
+  buyAssetId,
+  sellAssetId,
+}: GetSlippageArgs): Promise<BN> => {
+  const { data: poolData } = await thorService.get<ThornodePoolResponse[]>(
+    `${daemonUrl}/lcd/thorchain/pools`,
+  )
+
+  const buyPoolId = adapters.assetIdToPoolAssetId({ assetId: buyAssetId })
+  const sellPoolId = adapters.assetIdToPoolAssetId({ assetId: sellAssetId })
+  const buyPool = buyPoolId ? poolData.find((response) => response.asset === buyPoolId) : null
+  const sellPool = sellPoolId ? poolData.find((response) => response.asset === sellPoolId) : null
+  const toRune = isRune(buyAssetId)
+  const fromRune = isRune(sellAssetId)
+
+  // asserts x is type doesn't work when using arrow functions
+  function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
+    if (val === undefined || val === null) {
+      throw new AssertionError({ message: `Expected 'val' to be defined, but received ${val}` })
+    }
+  }
+
+  switch (true) {
+    case toRune: {
+      assertIsDefined(sellPool)
+      return getSingleSwapSlippage({ inputAmount, pool: sellPool, toRune })
+    }
+    case fromRune: {
+      assertIsDefined(buyPool)
+      return getSingleSwapSlippage({ inputAmount, pool: buyPool, toRune })
+    }
+    default: {
+      assertIsDefined(sellPool)
+      assertIsDefined(buyPool)
+      return getDoubleSwapSlippage({ inputAmount, sellPool, buyPool })
+    }
+  }
+}

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
@@ -1,6 +1,6 @@
 import { adapters, AssetId } from '@shapeshiftoss/caip'
-import { AssertionError } from 'assert'
 
+import { assertIsDefined } from '../../../utils'
 import { BN } from '../../utils/bignumber'
 import { ThornodePoolResponse } from '../types'
 import { getSwapOutput } from '../utils/getTradeRate/getTradeRate'
@@ -13,7 +13,6 @@ type GetSingleSwapSlippageArgs = {
   toRune: boolean
 }
 
-// Calculate swap slippage
 export const getSingleSwapSlippage = ({
   inputAmountThorPrecision,
   pool,
@@ -31,13 +30,12 @@ type GetDoubleSwapSlippageArgs = {
   buyPool: ThornodePoolResponse
 }
 
-// Calculate swap slippage for double swap
 export const getDoubleSwapSlippage = ({
   inputAmountThorPrecision,
   sellPool,
   buyPool,
 }: GetDoubleSwapSlippageArgs): BN => {
-  // formula: calcSwapSlip1(input1) + calcSwapSlip2(calcSwapOutput1 => input2)
+  // formula: getSwapOutput(input1) + getSingleSwapSlippage(getSwapOutput(input1) => input2)
   const firstSwapSlippage = getSingleSwapSlippage({
     inputAmountThorPrecision,
     pool: sellPool,
@@ -75,13 +73,6 @@ export const getSlippage = async ({
   const sellPool = sellPoolId ? poolData.find((response) => response.asset === sellPoolId) : null
   const toRune = isRune(buyAssetId)
   const fromRune = isRune(sellAssetId)
-
-  // asserts x is type doesn't work when using arrow functions
-  function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
-    if (val === undefined || val === null) {
-      throw new AssertionError({ message: `Expected 'val' to be defined, but received ${val}` })
-    }
-  }
 
   switch (true) {
     case toRune: {

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getSlippage.ts
@@ -14,7 +14,11 @@ type GetSingleSwapSlippageArgs = {
 }
 
 // Calculate swap slippage
-const getSingleSwapSlippage = ({ inputAmount, pool, toRune }: GetSingleSwapSlippageArgs): BN => {
+export const getSingleSwapSlippage = ({
+  inputAmount,
+  pool,
+  toRune,
+}: GetSingleSwapSlippageArgs): BN => {
   // formula: (inputAmount) / (inputAmount + inputBalance)
   const inputBalance = toRune ? pool.balance_asset : pool.balance_rune // input is asset if toRune
   const denominator = inputAmount.plus(inputBalance)
@@ -28,7 +32,7 @@ type GetDoubleSwapSlippageArgs = {
 }
 
 // Calculate swap slippage for double swap
-const getDoubleSwapSlippage = ({
+export const getDoubleSwapSlippage = ({
   inputAmount,
   sellPool,
   buyPool,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -28,6 +28,7 @@ import { getUsdRate } from '../utils/getUsdRate/getUsdRate'
 import { isRune } from '../utils/isRune/isRune'
 import { getEvmTxFees } from '../utils/txFeeHelpers/evmTxFees/getEvmTxFees'
 import { getUtxoTxFees } from '../utils/txFeeHelpers/utxoTxFees/getUtxoTxFees'
+import { getSlippage } from './getSlippage'
 
 type CommonQuoteFields = Omit<TradeQuote<ChainId>, 'allowanceContract' | 'feeData'>
 
@@ -82,6 +83,13 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       buyAsset.assetId,
     )
 
+    const recommendedSlippage = await getSlippage({
+      inputAmount: bn(sellAmountCryptoPrecision),
+      daemonUrl: deps.daemonUrl,
+      buyAssetId: buyAsset.assetId,
+      sellAssetId: sellAsset.assetId,
+    })
+
     const estimatedBuyAssetTradeFeeFeeAssetCryptoHuman = isRune(buyAsset.assetId)
       ? RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN.toString()
       : fromBaseUnit(bnOrZero(buyAssetAddressData?.outbound_fee), THORCHAIN_FIXED_PRECISION)
@@ -115,6 +123,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       sellAsset,
       bip44Params,
       minimumCryptoHuman: minimumSellAssetAmountPaddedCryptoHuman,
+      recommendedSlippage: recommendedSlippage.toString(),
     }
 
     const { chainNamespace } = fromAssetId(sellAsset.assetId)

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -83,8 +83,13 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       buyAsset.assetId,
     )
 
+    const sellAmountThorPrecision = toBaseUnit(
+      fromBaseUnit(sellAmountCryptoPrecision, sellAsset.precision),
+      THORCHAIN_FIXED_PRECISION,
+    )
+
     const recommendedSlippage = await getSlippage({
-      inputAmount: bn(sellAmountCryptoPrecision),
+      inputAmountThorPrecision: bn(sellAmountThorPrecision),
       daemonUrl: deps.daemonUrl,
       buyAssetId: buyAsset.assetId,
       sellAssetId: sellAsset.assetId,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -128,7 +128,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       sellAsset,
       bip44Params,
       minimumCryptoHuman: minimumSellAssetAmountPaddedCryptoHuman,
-      recommendedSlippage: recommendedSlippage.toString(),
+      recommendedSlippage: recommendedSlippage.toPrecision(),
     }
 
     const { chainNamespace } = fromAssetId(sellAsset.assetId)

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
@@ -51,7 +51,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '6.2049517907881932',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('580583')
+    expect(limit).toBe('577495')
   })
 
   it('should get limit when buy asset is EVM non-fee asset and sell asset is a UTXO', async () => {
@@ -71,7 +71,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '6.2049517907881932',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('57559')
+    expect(limit).toBe('57086')
   })
 
   it('should get limit when buy asset is RUNE and sell asset is not', async () => {
@@ -91,7 +91,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '0.0318228582',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('2413645592')
+    expect(limit).toBe('2401313546')
   })
 
   it('should get limit when sell asset is RUNE and buy asset is not', async () => {
@@ -113,6 +113,6 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '0.0000000026',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('36362463774')
+    expect(limit).toBe('36177023955')
   })
 })

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
@@ -4,6 +4,7 @@ import max from 'lodash/max'
 
 import { SwapError, SwapErrorTypes } from '../../../../api'
 import { bn, bnOrZero, fromBaseUnit, toBaseUnit } from '../../../utils/bignumber'
+import { ALLOWABLE_MARKET_MOVEMENT } from '../../../utils/constants'
 import { RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN } from '../../constants'
 import { ThorchainSwapperDeps } from '../../types'
 import { THORCHAIN_FIXED_PRECISION } from '../constants'
@@ -100,6 +101,7 @@ export const getLimit = async ({
     expectedBuyAmountCryptoPrecision8,
   )
     .times(bn(1).minus(slippageTolerance))
+    .times(bn(1).minus(ALLOWABLE_MARKET_MOVEMENT))
     .minus(highestPossibleFeeCryptoPrecision8 ?? 0)
     .decimalPlaces(0)
 

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
@@ -10,12 +10,11 @@ import { thorService } from '../thorService'
 
 const THOR_PRECISION = 8
 
-const getSwapOutput = (inputAmount: BN, pool: ThornodePoolResponse, toRune: boolean): BN => {
-  const x = inputAmount
-  const X = toRune ? pool.balance_asset : pool.balance_rune
-  const Y = toRune ? pool.balance_rune : pool.balance_asset
-  const numerator = bn(x).times(X).times(Y)
-  const denominator = bn(x).plus(X).pow(2)
+export const getSwapOutput = (inputAmount: BN, pool: ThornodePoolResponse, toRune: boolean): BN => {
+  const inputBalance = toRune ? pool.balance_asset : pool.balance_rune
+  const outputBalance = toRune ? pool.balance_rune : pool.balance_asset
+  const numerator = bn(inputAmount).times(inputBalance).times(outputBalance)
+  const denominator = bn(inputAmount).plus(inputBalance).pow(2)
   return numerator.div(denominator)
 }
 

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
@@ -13,8 +13,8 @@ const THOR_PRECISION = 8
 export const getSwapOutput = (inputAmount: BN, pool: ThornodePoolResponse, toRune: boolean): BN => {
   const inputBalance = toRune ? pool.balance_asset : pool.balance_rune
   const outputBalance = toRune ? pool.balance_rune : pool.balance_asset
-  const numerator = bn(inputAmount).times(inputBalance).times(outputBalance)
-  const denominator = bn(inputAmount).plus(inputBalance).pow(2)
+  const numerator = inputAmount.times(inputBalance).times(outputBalance)
+  const denominator = inputAmount.plus(inputBalance).pow(2)
   return numerator.div(denominator)
 }
 

--- a/packages/swapper/src/swappers/thorchain/utils/test-data/responses.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/test-data/responses.ts
@@ -52,6 +52,13 @@ export const usdcThornodePool: ThornodePoolResponse = {
   synth_units: '1936419947970',
 }
 
+export const thornodePools: ThornodePoolResponse[] = [
+  btcThornodePool,
+  ethThornodePool,
+  foxThornodePool,
+  usdcThornodePool,
+]
+
 export const mockInboundAddresses: InboundAddressResponse[] = [
   {
     chain: 'BCH',

--- a/packages/swapper/src/swappers/utils/constants.ts
+++ b/packages/swapper/src/swappers/utils/constants.ts
@@ -1,2 +1,3 @@
 export const APPROVAL_GAS_LIMIT = '100000' // Most approvals are around 40k, we've seen 72k in the wild, so 100000 for safety.
 export const DEFAULT_SLIPPAGE = '0.03' // 3%
+export const ALLOWABLE_MARKET_MOVEMENT = '0.005' // 0.5% is what https://app.thorswap.finance/ uses

--- a/packages/swapper/src/utils.ts
+++ b/packages/swapper/src/utils.ts
@@ -1,0 +1,8 @@
+import { AssertionError } from 'assert'
+
+// asserts x is type doesn't work when using arrow functions
+export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
+  if (val === undefined || val === null) {
+    throw new AssertionError({ message: `Expected 'val' to be defined, but received ${val}` })
+  }
+}


### PR DESCRIPTION
- Add `recommendedSlippage` as an optional property of `TradeQuote`. This will be consumed by `web` when fetching the quote and used to set the local state slippage value, which is then passed into `buildTrade`. This architecture allows us to override the `recommendedSlippage` with advanced trade settings in the future, as well as display the recommended slippage in the UI.
- Implemented `recommendedSlippage` for Thorswap. The logic handles the liquidity impact to pools when trading RUNE assets (one hop) and none-RUNE assets (two hops).

Contributes to https://github.com/shapeshift/lib/issues/1094

Unblocks https://github.com/shapeshift/web/pull/3419