### PR TITLE
chore: improve typing with enums

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -21,7 +21,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { Message, ValidatorAction } from '../types'
+import { ChainAdapterName, Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.CosmosMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.CosmosMainnet
@@ -47,7 +47,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
   }
 
   getDisplayName() {
-    return 'Cosmos'
+    return ChainAdapterName.Cosmos
   }
 
   getType(): KnownChainIds.CosmosMainnet {

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -21,7 +21,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { Message, ValidatorAction } from '../types'
+import { ChainAdapterName, Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OsmosisMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OsmosisMainnet
@@ -47,7 +47,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
   }
 
   getDisplayName() {
-    return 'Osmosis'
+    return ChainAdapterName.Osmosis
   }
 
   getType(): KnownChainIds.OsmosisMainnet {

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -15,7 +15,7 @@ import {
 import { toAddressNList } from '../../utils'
 import { bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
-import { Message } from '../types'
+import { ChainAdapterName, Message } from '../types'
 
 // https://dev.thorchain.org/thorchain-dev/interface-guide/fees#thorchain-native-rune
 // static automatic outbound fee as defined by: https://thornode.ninerealms.com/thorchain/constants
@@ -52,7 +52,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
   }
 
   getDisplayName() {
-    return 'Thorchain'
+    return ChainAdapterName.Thorchain
   }
 
   getType(): KnownChainIds.ThorchainMainnet {

--- a/packages/chain-adapters/src/cosmossdk/types.ts
+++ b/packages/chain-adapters/src/cosmossdk/types.ts
@@ -4,6 +4,18 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 import * as types from '../types'
 import { CosmosSdkChainId } from './CosmosSdkBaseAdapter'
 
+export enum ChainAdapterName {
+  Thorchain = 'THORChain',
+  Osmosis = 'Osmosis',
+  Ethereum = 'Ethereum',
+  Avalanche = 'Avalanche',
+  Cosmos = 'Cosmos',
+  Bitcoin = 'Bitcoin',
+  BitcoinCash = 'Bitcoin Cash',
+  Dogecoin = 'Dogecoin',
+  Litecoin = 'Litecoin',
+}
+
 export type Account = {
   sequence: string
   accountNumber: string

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -2,6 +2,7 @@ import { ASSET_REFERENCE, AssetId, avalancheAssetId, fromAssetId } from '@shapes
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import BigNumber from 'bignumber.js'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import { FeeDataEstimate, GasFeeDataEstimate, GetFeeDataInput } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
@@ -34,7 +35,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   }
 
   getDisplayName() {
-    return 'Avalanche'
+    return ChainAdapterName.Avalanche
   }
 
   getType(): KnownChainIds.AvalancheMainnet {

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -2,8 +2,8 @@ import { ASSET_REFERENCE, AssetId, avalancheAssetId, fromAssetId } from '@shapes
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import BigNumber from 'bignumber.js'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import { FeeDataEstimate, GasFeeDataEstimate, GetFeeDataInput } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -3,6 +3,7 @@ import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 import BigNumber from 'bignumber.js'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import {
   FeeDataEstimate,
@@ -42,7 +43,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
   }
 
   getDisplayName() {
-    return 'Ethereum'
+    return ChainAdapterName.Ethereum
   }
 
   getType(): KnownChainIds.EthereumMainnet {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -3,8 +3,8 @@ import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 import BigNumber from 'bignumber.js'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import {
   FeeDataEstimate,
   GasFeeDataEstimate,

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
@@ -1,6 +1,7 @@
 import { ASSET_REFERENCE, AssetId, btcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
@@ -37,7 +38,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.BitcoinMainnet> 
   }
 
   getDisplayName() {
-    return 'Bitcoin'
+    return ChainAdapterName.Bitcoin
   }
 
   getType(): KnownChainIds.BitcoinMainnet {

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
@@ -1,8 +1,8 @@
 import { ASSET_REFERENCE, AssetId, btcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.BitcoinMainnet]

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
@@ -1,6 +1,7 @@
 import { ASSET_REFERENCE, AssetId, bchAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
@@ -33,7 +34,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.BitcoinCashMainn
   }
 
   getDisplayName() {
-    return 'Bitcoin Cash'
+    return ChainAdapterName.BitcoinCash
   }
 
   getType(): KnownChainIds.BitcoinCashMainnet {

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
@@ -1,8 +1,8 @@
 import { ASSET_REFERENCE, AssetId, bchAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.BitcoinCashMainnet]

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
@@ -1,6 +1,7 @@
 import { ASSET_REFERENCE, AssetId, dogeAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
@@ -33,7 +34,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.DogecoinMainnet>
   }
 
   getDisplayName() {
-    return 'Dogecoin'
+    return ChainAdapterName.Dogecoin
   }
 
   getType(): KnownChainIds.DogecoinMainnet {

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
@@ -1,8 +1,8 @@
 import { ASSET_REFERENCE, AssetId, dogeAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.DogecoinMainnet]

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
@@ -1,8 +1,8 @@
 import { ASSET_REFERENCE, AssetId, ltcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
+import { ChainAdapterName } from '../../cosmossdk/types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.LitecoinMainnet]

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
@@ -1,6 +1,7 @@
 import { ASSET_REFERENCE, AssetId, ltcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import { ChainAdapterName } from 'packages/chain-adapters/src/cosmossdk/types'
 
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
@@ -37,7 +38,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.LitecoinMainnet>
   }
 
   getDisplayName() {
-    return 'Litecoin'
+    return ChainAdapterName.Litecoin
   }
 
   getType(): KnownChainIds.LitecoinMainnet {

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -166,7 +166,7 @@ export type ApprovalNeededInput<C extends ChainId> = {
 }
 
 export type SwapSource = {
-  name: string
+  name: SwapperName
   proportion: string
 }
 
@@ -231,7 +231,7 @@ export enum SwapErrorTypes {
 }
 export interface Swapper<T extends ChainId> {
   /** Human-readable swapper name */
-  readonly name: string
+  readonly name: SwapperName
 
   /** perform any necessary async initialization */
   initialize?(): Promise<void>

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -3,7 +3,7 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
-import { SwapperType, TradeResult } from '../../api'
+import { SwapperName, SwapperType, TradeResult } from '../../api'
 import { BTC, ETH, FOX, WBTC, WETH } from '../utils/test-data/assets'
 import { setupBuildTrade, setupQuote } from '../utils/test-data/setupSwapQuote'
 import { cowApprovalNeeded } from './cowApprovalNeeded/cowApprovalNeeded'
@@ -204,7 +204,7 @@ describe('CowSwapper', () => {
       const cowSwapTrade: CowTrade<KnownChainIds.EthereumMainnet> = {
         sellAmountCryptoPrecision: '1000000000000000000',
         buyAmountCryptoPrecision: '14501811818247595090576',
-        sources: [{ name: 'CowSwap', proportion: '1' }],
+        sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
         buyAsset: FOX,
         sellAsset: WETH,
         bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -4,7 +4,7 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
-import { BuildTradeInput } from '../../../api'
+import { BuildTradeInput, SwapperName } from '../../../api'
 import { IsApprovalRequiredArgs } from '../../utils/helpers/helpers'
 import { ETH, FOX, WBTC, WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
@@ -126,7 +126,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000',
   buyAmountCryptoPrecision: '14501811818247595090576', // 14501 FOX
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: FOX,
   sellAsset: WETH,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },
@@ -149,7 +149,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFee: CowTrade<KnownChainIds.Ethere
   },
   sellAmountCryptoPrecision: '100000000',
   buyAmountCryptoPrecision: '19136098853078932263', // 19.13 WETH
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: WETH,
   sellAsset: WBTC,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },
@@ -171,7 +171,7 @@ const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000000',
   buyAmountCryptoPrecision: '46868859830863283',
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -4,7 +4,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import { ethers } from 'ethers'
 import Web3 from 'web3'
 
-import { ExecuteTradeInput } from '../../../api'
+import { ExecuteTradeInput, SwapperName } from '../../../api'
 import { ETH, FOX, WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowTrade } from '../types'
@@ -60,7 +60,7 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000',
   buyAmountCryptoPrecision: '14501811818247595090576',
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: FOX,
   sellAsset: ETH,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },
@@ -82,7 +82,7 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '20200000000000000',
   buyAmountCryptoPrecision: '272522025311597443544',
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: FOX,
   sellAsset: WETH,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },
@@ -104,7 +104,7 @@ const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000000',
   buyAmountCryptoPrecision: '46868859830863283',
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -3,7 +3,7 @@ import { ethereum, FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
-import { GetTradeQuoteInput, TradeQuote } from '../../../api'
+import { GetTradeQuoteInput, SwapperName, TradeQuote } from '../../../api'
 import { ETH, FOX, WETH } from '../../utils/test-data/assets'
 import { CowSwapperDeps } from '../CowSwapper'
 import { DEFAULT_APP_DATA } from '../utils/constants'
@@ -131,7 +131,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000',
   buyAmountCryptoPrecision: '14501811818247595090576', // 14501 FOX
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,
   sellAsset: WETH,
@@ -154,7 +154,7 @@ const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
   },
   sellAmountCryptoPrecision: '1000000000000000000000',
   buyAmountCryptoPrecision: '46868859830863283',
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: ETH,
   sellAsset: FOX,
@@ -177,7 +177,7 @@ const expectedTradeQuoteSmallAmountWethToFox: TradeQuote<KnownChainIds.EthereumM
   },
   sellAmountCryptoPrecision: '1000000000000',
   buyAmountCryptoPrecision: '145018118182475950905', // 14501 FOX
-  sources: [{ name: 'CowSwap', proportion: '1' }],
+  sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,
   sellAsset: WETH,

--- a/packages/swapper/src/swappers/cow/utils/constants.ts
+++ b/packages/swapper/src/swappers/cow/utils/constants.ts
@@ -1,9 +1,11 @@
 import { AddressZero } from '@ethersproject/constants'
 
+import { SwapperName } from '../../../api'
+
 export const MAX_ALLOWANCE = '100000000000000000000000000'
 export const MAX_COWSWAP_TRADE = '100000000000000000000000000'
 export const MIN_COWSWAP_VALUE_USD = 20
-export const DEFAULT_SOURCE = [{ name: 'CowSwap', proportion: '1' }]
+export const DEFAULT_SOURCE = [{ name: SwapperName.CowSwap, proportion: '1' }]
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = '0x68a7b5781dfe48bd5d7aeb11261c17517f5c587da682e4fade9b6a00a59b8970'
 export const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -195,7 +195,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       sellAmountCryptoPrecision: sellAmountCryptoBase, // TODO(gomes): wat?
       sellAsset,
       bip44Params,
-      sources: [{ name: 'Osmosis', proportion: '100' }],
+      sources: [{ name: SwapperName.Osmosis, proportion: '100' }],
     }
   }
 

--- a/packages/swapper/src/swappers/osmosis/utils/constants.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/constants.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_SOURCE = [{ name: 'Osmosis', proportion: '1' }]
+import { SwapperName } from '../../../api'
+
+export const DEFAULT_SOURCE = [{ name: SwapperName.Osmosis, proportion: '1' }]
 export const MAX_SWAPPER_SELL = '100000000000000000000000000'
 export const OSMOSIS_PRECISION = 6
 export const COSMO_OSMO_CHANNEL = 'channel-141'

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -2,6 +2,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
 import type { GetTradeQuoteInput, TradeQuote } from '../../../api'
+import { SwapperName } from '../../../api'
 import { ETH, FOX } from '../../utils/test-data/assets'
 import { setupQuote } from '../../utils/test-data/setupSwapQuote'
 import type { ThorchainSwapperDeps } from '../types'
@@ -29,7 +30,7 @@ const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
     networkFee: '700000',
   },
   rate: '0.0000784',
-  sources: [{ name: 'thorchain', proportion: '1' }],
+  sources: [{ name: SwapperName.Thorchain, proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,
   bip44Params: { purpose: 44, coinType: 60, accountNumber: 0 },

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -9,6 +9,7 @@ import {
   GetUtxoTradeQuoteInput,
   SwapError,
   SwapErrorTypes,
+  SwapperName,
   TradeQuote,
   UtxoSupportedChainIds,
 } from '../../../api'
@@ -123,7 +124,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       maximum: MAX_THORCHAIN_TRADE,
       sellAmountCryptoPrecision,
       buyAmountCryptoPrecision,
-      sources: [{ name: 'thorchain', proportion: '1' }],
+      sources: [{ name: SwapperName.Thorchain, proportion: '1' }],
       buyAsset,
       sellAsset,
       bip44Params,


### PR DESCRIPTION
We use strings in places where we should be using enums, which can, and does lead to errors.
E.g. we are currently passing the string `thorchain` as the THORSwapper name, when it should be `THORChain`.