### PR TITLE
chore: add Osmosis to Dex enum

### DIFF
--- a/packages/unchained-client/src/types.ts
+++ b/packages/unchained-client/src/types.ts
@@ -3,6 +3,7 @@ export enum Dex {
   Thor = 'THORChain',
   Zrx = '0x',
   CowSwap = 'CowSwap',
+  Osmosis = 'Osmosis',
 }
 
 export interface Fee {


### PR DESCRIPTION
Adds an `Osmosis` key to the `Dex` enum as part of some work to lift our TX URL handling logic in `web` to support conditional logic app wide, and fix https://github.com/shapeshift/web/issues/3446.