### PR TITLE
chore(swapper): increase ALLOWABLE_MARKET_MOVEMENT to 1%

### DIFF
--- a/packages/swapper/src/swappers/utils/constants.ts
+++ b/packages/swapper/src/swappers/utils/constants.ts
@@ -1,3 +1,3 @@
 export const APPROVAL_GAS_LIMIT = '100000' // Most approvals are around 40k, we've seen 72k in the wild, so 100000 for safety.
 export const DEFAULT_SLIPPAGE = '0.03' // 3%
-export const ALLOWABLE_MARKET_MOVEMENT = '0.005' // 0.5% is what https://app.thorswap.finance/ uses
+export const ALLOWABLE_MARKET_MOVEMENT = '0.01' // 1%

--- a/packages/unchained-client/src/cosmossdk/parser/index.ts
+++ b/packages/unchained-client/src/cosmossdk/parser/index.ts
@@ -1,7 +1,7 @@
 import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { BigNumber } from 'bignumber.js'
 
-import { TransferType, TxStatus } from '../../types'
+import { Dex, TransferType, TxStatus } from '../../types'
 import { aggregateTransfer } from '../../utils'
 import { ParsedTx, Tx } from './types'
 import { getAssetIdByDenom, metaData } from './utils'
@@ -31,6 +31,7 @@ export class BaseTransactionParser<T extends Tx> {
       status: tx.confirmations > 0 ? TxStatus.Confirmed : TxStatus.Pending, // TODO: handle failed case
       transfers: [],
       txid: tx.txid,
+      trade: { dexName: Dex.Thor },
     }
 
     tx.messages.forEach((msg, i) => {

--- a/packages/unchained-client/src/evm/ethereum/parser/thor.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/thor.ts
@@ -84,15 +84,20 @@ export class Parser implements SubParser<Tx> {
 
     const [type] = decoded.args.memo.split(':')
 
-    if (SWAP_TYPES.includes(type) || type === 'OUT') {
-      return { trade: { dexName: Dex.Thor, type: TradeType.Trade, memo: decoded.args.memo }, data }
+    switch (true) {
+      case SWAP_TYPES.includes(type) || type === 'OUT':
+        return {
+          trade: { dexName: Dex.Thor, type: TradeType.Trade, memo: decoded.args.memo },
+          data,
+        }
+      case type === 'REFUND':
+        return {
+          trade: { dexName: Dex.Thor, type: TradeType.Refund, memo: decoded.args.memo },
+          data,
+        }
+      default:
+        // memo type not supported
+        return undefined
     }
-
-    if (type === 'REFUND') {
-      return { trade: { dexName: Dex.Thor, type: TradeType.Refund, memo: decoded.args.memo }, data }
-    }
-
-    // memo type not supported
-    return
   }
 }

--- a/packages/unchained-client/src/types.ts
+++ b/packages/unchained-client/src/types.ts
@@ -29,7 +29,7 @@ export interface Token {
 export interface Trade {
   dexName: Dex
   memo?: string
-  type: TradeType
+  type?: TradeType
 }
 
 // these are user facing values, and should be rendered as such


### PR DESCRIPTION
As per discussion here: https://discord.com/channels/554694662431178782/1047944010901229698/1047999778505625610, increase ALLOWABLE_MARKET_MOVEMENT to 1% to reduce the likelihood of refunds.