### PR TITLE
feat: rename Avalanche displayName -> Avalanche C-Chain

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -21,7 +21,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterName, Message, ValidatorAction } from '../types'
+import { ChainAdapterDisplayName, Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.CosmosMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.CosmosMainnet
@@ -47,7 +47,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
   }
 
   getDisplayName() {
-    return ChainAdapterName.Cosmos
+    return ChainAdapterDisplayName.Cosmos
   }
 
   getType(): KnownChainIds.CosmosMainnet {

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -10,6 +10,7 @@ import {
   BuildRedelegateTxInput,
   BuildSendTxInput,
   BuildUndelegateTxInput,
+  ChainAdapterDisplayName,
   FeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
@@ -21,7 +22,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterDisplayName, Message, ValidatorAction } from '../types'
+import { Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.CosmosMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.CosmosMainnet

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -21,7 +21,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterName, Message, ValidatorAction } from '../types'
+import { ChainAdapterDisplayName, Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OsmosisMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OsmosisMainnet
@@ -47,7 +47,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
   }
 
   getDisplayName() {
-    return ChainAdapterName.Osmosis
+    return ChainAdapterDisplayName.Osmosis
   }
 
   getType(): KnownChainIds.OsmosisMainnet {

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -10,6 +10,7 @@ import {
   BuildRedelegateTxInput,
   BuildSendTxInput,
   BuildUndelegateTxInput,
+  ChainAdapterDisplayName,
   FeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
@@ -21,7 +22,7 @@ import {
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterDisplayName, Message, ValidatorAction } from '../types'
+import { Message, ValidatorAction } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OsmosisMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OsmosisMainnet

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -15,7 +15,7 @@ import {
 import { toAddressNList } from '../../utils'
 import { bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterName, Message } from '../types'
+import { ChainAdapterDisplayName, Message } from '../types'
 
 // https://dev.thorchain.org/thorchain-dev/interface-guide/fees#thorchain-native-rune
 // static automatic outbound fee as defined by: https://thornode.ninerealms.com/thorchain/constants
@@ -52,7 +52,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
   }
 
   getDisplayName() {
-    return ChainAdapterName.Thorchain
+    return ChainAdapterDisplayName.Thorchain
   }
 
   getType(): KnownChainIds.ThorchainMainnet {

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -7,6 +7,7 @@ import { ErrorHandler } from '../../error/ErrorHandler'
 import {
   BuildDepositTxInput,
   BuildSendTxInput,
+  ChainAdapterDisplayName,
   FeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
@@ -15,7 +16,7 @@ import {
 import { toAddressNList } from '../../utils'
 import { bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
-import { ChainAdapterDisplayName, Message } from '../types'
+import { Message } from '../types'
 
 // https://dev.thorchain.org/thorchain-dev/interface-guide/fees#thorchain-native-rune
 // static automatic outbound fee as defined by: https://thornode.ninerealms.com/thorchain/constants

--- a/packages/chain-adapters/src/cosmossdk/types.ts
+++ b/packages/chain-adapters/src/cosmossdk/types.ts
@@ -4,18 +4,6 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 import * as types from '../types'
 import { CosmosSdkChainId } from './CosmosSdkBaseAdapter'
 
-export enum ChainAdapterName {
-  Thorchain = 'THORChain',
-  Osmosis = 'Osmosis',
-  Ethereum = 'Ethereum',
-  Avalanche = 'Avalanche C-Chain',
-  Cosmos = 'Cosmos',
-  Bitcoin = 'Bitcoin',
-  BitcoinCash = 'Bitcoin Cash',
-  Dogecoin = 'Dogecoin',
-  Litecoin = 'Litecoin',
-}
-
 export type Account = {
   sequence: string
   accountNumber: string

--- a/packages/chain-adapters/src/cosmossdk/types.ts
+++ b/packages/chain-adapters/src/cosmossdk/types.ts
@@ -8,7 +8,7 @@ export enum ChainAdapterName {
   Thorchain = 'THORChain',
   Osmosis = 'Osmosis',
   Ethereum = 'Ethereum',
-  Avalanche = 'Avalanche',
+  Avalanche = 'Avalanche C-Chain',
   Cosmos = 'Cosmos',
   Bitcoin = 'Bitcoin',
   BitcoinCash = 'Bitcoin Cash',

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -133,8 +133,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
       const { erc20ContractAddress, gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas } =
         tx.chainSpecific
 
-      if (!tx.to) throw new Error(`${this.getDisplayName()}ChainAdapter: to is required`)
-      if (!tx.value) throw new Error(`${this.getDisplayName()}ChainAdapter: value is required`)
+      if (!tx.to) throw new Error(`${this.getDisplayName()} ChainAdapter: to is required`)
+      if (!tx.value) throw new Error(`${this.getDisplayName()} ChainAdapter: value is required`)
 
       const destAddress = erc20ContractAddress ?? to
 

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -406,7 +406,7 @@ describe('AvalancheChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'AvalancheChainAdapter: to is required',
+        'Avalanche C-Chain ChainAdapter: to is required',
       )
     })
 
@@ -420,7 +420,7 @@ describe('AvalancheChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'AvalancheChainAdapter: value is required',
+        'Avalanche C-Chain ChainAdapter: value is required',
       )
     })
 

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -19,6 +19,7 @@ import { numberToHex } from 'web3-utils'
 
 import {
   BuildSendTxInput,
+  ChainAdapterDisplayName,
   SignMessageInput,
   SignTxInput,
   ValidAddressResultType,
@@ -406,7 +407,7 @@ describe('AvalancheChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'Avalanche C-Chain ChainAdapter: to is required',
+        `${ChainAdapterDisplayName.Avalanche} ChainAdapter: to is required`,
       )
     })
 
@@ -420,7 +421,7 @@ describe('AvalancheChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'Avalanche C-Chain ChainAdapter: value is required',
+        `${ChainAdapterDisplayName.Avalanche} ChainAdapter: value is required`,
       )
     })
 

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -3,7 +3,7 @@ import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import BigNumber from 'bignumber.js'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GasFeeDataEstimate, GetFeeDataInput } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
@@ -35,7 +35,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   }
 
   getDisplayName() {
-    return ChainAdapterName.Avalanche
+    return ChainAdapterDisplayName.Avalanche
   }
 
   getType(): KnownChainIds.AvalancheMainnet {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -466,7 +466,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'EthereumChainAdapter: to is required',
+        'Ethereum ChainAdapter: to is required',
       )
     })
 
@@ -504,7 +504,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'EthereumChainAdapter: value is required',
+        'Ethereum ChainAdapter: value is required',
       )
     })
 

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -14,6 +14,7 @@ import { numberToHex } from 'web3-utils'
 
 import {
   BuildSendTxInput,
+  ChainAdapterDisplayName,
   SignMessageInput,
   SignTxInput,
   ValidAddressResultType,
@@ -466,7 +467,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'Ethereum ChainAdapter: to is required',
+        `${ChainAdapterDisplayName.Ethereum} ChainAdapter: to is required`,
       )
     })
 
@@ -504,7 +505,7 @@ describe('EthereumChainAdapter', () => {
       } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
 
       await expect(adapter.buildSendTransaction(tx)).rejects.toThrow(
-        'Ethereum ChainAdapter: value is required',
+        `${ChainAdapterDisplayName.Ethereum} ChainAdapter: value is required`,
       )
     })
 

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -4,7 +4,7 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 import BigNumber from 'bignumber.js'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import {
   FeeDataEstimate,
   GasFeeDataEstimate,
@@ -43,7 +43,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
   }
 
   getDisplayName() {
-    return ChainAdapterName.Ethereum
+    return ChainAdapterDisplayName.Ethereum
   }
 
   getType(): KnownChainIds.EthereumMainnet {

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -250,3 +250,15 @@ export type ZrxFeeResult = {
 export type ZrxGasApiResponse = {
   result: ZrxFeeResult[]
 }
+
+export enum ChainAdapterDisplayName {
+  Thorchain = 'THORChain',
+  Osmosis = 'Osmosis',
+  Ethereum = 'Ethereum',
+  Avalanche = 'Avalanche C-Chain',
+  Cosmos = 'Cosmos',
+  Bitcoin = 'Bitcoin',
+  BitcoinCash = 'Bitcoin Cash',
+  Dogecoin = 'Dogecoin',
+  Litecoin = 'Litecoin',
+}

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.ts
@@ -2,7 +2,7 @@ import { ASSET_REFERENCE, AssetId, btcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.BitcoinMainnet]
@@ -38,7 +38,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.BitcoinMainnet> 
   }
 
   getDisplayName() {
-    return ChainAdapterName.Bitcoin
+    return ChainAdapterDisplayName.Bitcoin
   }
 
   getType(): KnownChainIds.BitcoinMainnet {

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.ts
@@ -2,7 +2,7 @@ import { ASSET_REFERENCE, AssetId, bchAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.BitcoinCashMainnet]
@@ -34,7 +34,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.BitcoinCashMainn
   }
 
   getDisplayName() {
-    return ChainAdapterName.BitcoinCash
+    return ChainAdapterDisplayName.BitcoinCash
   }
 
   getType(): KnownChainIds.BitcoinCashMainnet {

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
@@ -2,7 +2,7 @@ import { ASSET_REFERENCE, AssetId, dogeAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.DogecoinMainnet]
@@ -34,7 +34,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.DogecoinMainnet>
   }
 
   getDisplayName() {
-    return ChainAdapterName.Dogecoin
+    return ChainAdapterDisplayName.Dogecoin
   }
 
   getType(): KnownChainIds.DogecoinMainnet {

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.ts
@@ -2,7 +2,7 @@ import { ASSET_REFERENCE, AssetId, ltcAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterName } from '../../cosmossdk/types'
+import { ChainAdapterDisplayName } from '../../types'
 import { ChainAdapterArgs, UtxoBaseAdapter } from '../UtxoBaseAdapter'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.LitecoinMainnet]
@@ -38,7 +38,7 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.LitecoinMainnet>
   }
 
   getDisplayName() {
-    return ChainAdapterName.Litecoin
+    return ChainAdapterDisplayName.Litecoin
   }
 
   getType(): KnownChainIds.LitecoinMainnet {


### PR DESCRIPTION
#### Description

Required for https://github.com/shapeshift/web/pull/2348

MetaMask is a smart fox. It detects that "Avalanche" (the name of the X chain) doesn't match the 43114 ChainId and throws some warnings when trying to programmatically add it in https://github.com/shapeshift/web/pull/2348

<img width="772" alt="image" src="https://user-images.githubusercontent.com/17035424/206297605-b8f80587-dc22-41c3-a346-3521ceaa5747.png">

After renaming it to `Avalanche C-Chain`, this goes away and this is the only warning we're getting (WRT using our own JSON-RPC node):

<img width="617" alt="image" src="https://user-images.githubusercontent.com/17035424/206297845-4337f08b-bed4-459f-8a5e-99a4c43f2b6a.png">