### PR TITLE
fix(swapper): cowswap quote rate

### DIFF
--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -22,6 +22,7 @@ import {
   getNowPlusThirtyMinutesTimestamp,
   getUsdRate,
 } from '../utils/helpers/helpers'
+
 export async function getCowSwapTradeQuote(
   deps: CowSwapperDeps,
   input: GetTradeQuoteInput,
@@ -106,7 +107,13 @@ export async function getCowSwapTradeQuote(
       },
     } = quoteResponse
 
-    const rate = bn(buyAmountCryptoBaseUnit).div(sellAmountCryptoBaseUnit).toString()
+    const buyCryptoAmount = bn(buyAmountCryptoBaseUnit).div(
+      bn(10).exponentiatedBy(buyAsset.precision),
+    )
+    const sellCryptoAmount = bn(sellAmountCryptoBaseUnit).div(
+      bn(10).exponentiatedBy(sellAsset.precision),
+    )
+    const rate = buyCryptoAmount.div(sellCryptoAmount).toString()
 
     const data = getApproveContractData({
       web3,


### PR DESCRIPTION
Fixes a regression in https://github.com/shapeshift/lib/pull/1122: https://github.com/shapeshift/lib/pull/1122/files#diff-19676c94d85c0baf6d1d359ea9be6657fb3a009be5536ea8c01bdba4d78ec2b6L103-L105.

The regression caused CoW Swap rates to be calculated incorrectly in `getCowSwapTradeQuote`.

Note, this regression is not yet in production - we haven't yet bumped swapper to the next major version in `web`.

Testing:

- Get a CoW Swap quote and confirm that the rate is correct.

Before: 

![image](https://user-images.githubusercontent.com/97164662/208801857-1a2d98e7-ae2c-4621-921b-d1870e0fe37f.png)

Fixed: 

![image](https://user-images.githubusercontent.com/97164662/208801877-18525e95-3013-4433-897a-ba7b9bd50819.png)
