### PR TITLE
feat(investor-yearn): set retired vaults as expired

### DIFF
--- a/packages/investor-yearn/src/YearnOpportunity.ts
+++ b/packages/investor-yearn/src/YearnOpportunity.ts
@@ -103,7 +103,10 @@ export class YearnOpportunity
     this.apy = bnOrZero(vault.metadata.apy?.net_apy)
     this.isNew = vault.metadata.apy?.type === 'new'
     this.name = `${vault.metadata.displayName} ${vault.version}`
-    this.expired = vault.metadata.depositsDisabled || bnOrZero(vault.metadata.depositLimit).lte(0)
+    this.expired =
+      vault.metadata.depositsDisabled ||
+      bnOrZero(vault.metadata.depositLimit).lte(0) ||
+      vault.metadata.migrationAvailable
     // @TODO TotalSupply from the API awas 0
     this.supply = bnOrZero(vault.metadata.totalSupply)
     this.tvl = {


### PR DESCRIPTION
### Description

Does what it says on the box, for all intents and purposes, retired vaults are effectively *expired* in our web/lib abstraction.
We should treat them that way, so that they only show up in case a user is already deposited into it so they can withdraw.

### Issue

- tackles https://github.com/shapeshift/web/issues/3529 - to be closed when consumed in web and a migration is ran there

### Screenshots

See matching web PR https://github.com/shapeshift/web/pull/3556

#### Inactive user opportunity

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/17035424/210561691-f385f789-88f5-4040-aa08-611b1bf6524d.png">

#### Deposited into opportunity / available rewards

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/17035424/210562081-4a21b898-4349-4065-a1db-df5d05e4e81b.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/210562145-d38500a9-c1f6-43cd-bd30-80fa1c440b63.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/210563721-177d8cf7-38bc-45cd-b39e-bfc725467838.png">
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/17035424/210563765-bda76de9-6625-424f-97e1-052a949ee0fc.png">