### PR TITLE
perf(swapper): add caching to swapper requests

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^0.26.1",
+    "axios-cache-adapter": "^2.7.3",
     "bignumber.js": "^9.0.2",
     "lodash": "^4.17.21",
     "retry-axios": "^2.6.0",
@@ -44,9 +45,9 @@
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.41.0",
     "@shapeshiftoss/types": "^8.1.0",
+    "@shapeshiftoss/unchained-client": "^10.0.1",
     "@types/readline-sync": "^1.4.4",
     "readline-sync": "^1.4.10",
-    "web3-utils": "1.7.4",
-    "@shapeshiftoss/unchained-client": "^10.0.1"
+    "web3-utils": "1.7.4"
   }
 }

--- a/packages/swapper/src/swappers/cow/utils/cowService.ts
+++ b/packages/swapper/src/swappers/cow/utils/cowService.ts
@@ -1,11 +1,18 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 
-const axiosConfig = {
+import { createCache } from '../../../utils'
+
+const maxAge = 5 * 1000 // 5 seconds
+const cachedUrls = ['/mainnet/api/v1/quote']
+const cache = createCache(maxAge, cachedUrls)
+
+const axiosConfig: AxiosRequestConfig = {
   timeout: 10000,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
+  adapter: cache.adapter,
 }
 
 export const cowService = axios.create(axiosConfig)

--- a/packages/swapper/src/swappers/thorchain/utils/thorService.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/thorService.ts
@@ -1,11 +1,23 @@
 import axios from 'axios'
 
+import { createCache } from '../../../utils'
+
+// Important: maxAge should be small because inbound address info must be recent
+const maxAge = 5 * 1000 // 5 seconds
+const cachedUrls = [
+  '/lcd/thorchain/pools',
+  '/lcd/thorchain/inbound_addresses',
+  '/lcd/thorchain/pool/',
+]
+const cache = createCache(maxAge, cachedUrls)
+
 const axiosConfig = {
   timeout: 10000,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
+  adapter: cache.adapter,
 }
 
 export const thorService = axios.create(axiosConfig)

--- a/packages/swapper/src/swappers/zrx/utils/zrxService.ts
+++ b/packages/swapper/src/swappers/zrx/utils/zrxService.ts
@@ -1,11 +1,18 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 
+import { createCache } from '../../../utils'
+
+const maxAge = 5 * 1000 // 5 seconds
+const cachedUrls = ['/swap/v1/price']
+const cache = createCache(maxAge, cachedUrls)
+
 const axiosConfig: AxiosRequestConfig = {
   timeout: 10000,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
+  adapter: cache.adapter,
 }
 
 export const zrxServiceFactory = (baseUrl: string): AxiosInstance =>

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.test.ts
@@ -1,5 +1,6 @@
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { AxiosAdapter } from 'axios'
 import Web3 from 'web3'
 
 import { ApprovalNeededInput } from '../../../api'
@@ -15,6 +16,9 @@ jest.mock('axios', () => ({
   create: jest.fn(() => ({
     get: jest.fn(),
   })),
+}))
+jest.mock('axios-cache-adapter', () => ({
+  setupCache: jest.fn().mockReturnValue({ adapter: {} as AxiosAdapter }),
 }))
 
 // @ts-ignore

--- a/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.test.ts
@@ -1,4 +1,5 @@
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { AxiosAdapter } from 'axios'
 import Web3 from 'web3'
 
 import { setupDeps } from '../../utils/test-data/setupDeps'
@@ -9,6 +10,9 @@ import { zrxApproveAmount, zrxApproveInfinite } from './zrxApprove'
 const zrxService = zrxServiceFactory('https://api.0x.org/')
 
 jest.mock('web3')
+jest.mock('axios-cache-adapter', () => ({
+  setupCache: jest.fn().mockReturnValue({ adapter: {} as AxiosAdapter }),
+}))
 jest.mock('../../utils/helpers/helpers', () => ({
   grantAllowance: jest.fn(() => 'grantAllowanceTxId'),
 }))

--- a/packages/swapper/src/utils.ts
+++ b/packages/swapper/src/utils.ts
@@ -1,4 +1,5 @@
 import { AssertionError } from 'assert'
+import { setupCache } from 'axios-cache-adapter'
 
 // asserts x is type doesn't work when using arrow functions
 export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
@@ -6,3 +7,12 @@ export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
     throw new AssertionError({ message: `Expected 'val' to be defined, but received ${val}` })
   }
 }
+
+const getRequestFilter = (cachedUrls: string[]) => (request: Request) =>
+  !cachedUrls.some((url) => request.url.includes(url))
+
+export const createCache = (maxAge: number, cachedUrls: string[]) =>
+  setupCache({
+    maxAge,
+    exclude: { filter: getRequestFilter(cachedUrls) },
+  })

--- a/packages/swapper/src/utils.ts
+++ b/packages/swapper/src/utils.ts
@@ -1,5 +1,5 @@
 import { AssertionError } from 'assert'
-import { setupCache } from 'axios-cache-adapter'
+import { ISetupCache, setupCache } from 'axios-cache-adapter'
 
 // asserts x is type doesn't work when using arrow functions
 export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
@@ -11,7 +11,7 @@ export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
 const getRequestFilter = (cachedUrls: string[]) => (request: Request) =>
   !cachedUrls.some((url) => request.url.includes(url))
 
-export const createCache = (maxAge: number, cachedUrls: string[]) => {
+export const createCache = (maxAge: number, cachedUrls: string[]): ISetupCache => {
   const filter = getRequestFilter(cachedUrls)
   return setupCache({
     maxAge,

--- a/packages/swapper/src/utils.ts
+++ b/packages/swapper/src/utils.ts
@@ -11,8 +11,13 @@ export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
 const getRequestFilter = (cachedUrls: string[]) => (request: Request) =>
   !cachedUrls.some((url) => request.url.includes(url))
 
-export const createCache = (maxAge: number, cachedUrls: string[]) =>
-  setupCache({
+export const createCache = (maxAge: number, cachedUrls: string[]) => {
+  const filter = getRequestFilter(cachedUrls)
+  return setupCache({
     maxAge,
-    exclude: { filter: getRequestFilter(cachedUrls) },
+    exclude: { filter, query: false },
+    clearOnStale: true,
+    readOnError: false,
+    readHeaders: false,
   })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4105,6 +4105,14 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios-cache-adapter@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/axios-cache-adapter/-/axios-cache-adapter-2.7.3.tgz#0d1eefa0f25b88f42a95c7528d7345bde688181d"
+  integrity sha512-A+ZKJ9lhpjthOEp4Z3QR/a9xC4du1ALaAsejgRGrH9ef6kSDxdFrhRpulqsh9khsEnwXxGfgpUuDp1YXMNMEiQ==
+  dependencies:
+    cache-control-esm "1.0.0"
+    md5 "^2.2.1"
+
 axios-rate-limit@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz#03241d24c231c47432dab6e8234cfde819253c2e"
@@ -4742,6 +4750,11 @@ cacache@^16.0.0, cacache@^16.0.6, cacache@^16.1.0:
     tar "^6.1.11"
     unique-filename "^2.0.0"
 
+cache-control-esm@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cache-control-esm/-/cache-control-esm-1.0.0.tgz#417647ecf1837a5e74155f55d5a4ae32a84e2581"
+  integrity sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g==
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -4859,6 +4872,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
 
 chokidar@^3.5.1:
   version "3.5.3"
@@ -5524,6 +5542,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 crypto-browserify@3.12.0, crypto-browserify@^3.12.0:
   version "3.12.0"
@@ -8080,7 +8103,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@^1.0.2:
+is-buffer@^1.0.2, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -9662,6 +9685,15 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+md5@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
- Adds caching to select swapper-related `GET` requests by including a cache adapter in 0x, THORSwapper, and CoW Swap services.
- Takes an opt-in approach to caching - we want to be explicit about what we cache, as some responses _must_ be current (order status)
- We use a max age of 5 seconds as a minimum bound for effectiveness, but not so large that we get stale data for crucial responses (e.g. THORSwapper inbound addresses)
- Reduces swapper-related requests by about 60%.

Contributes to https://github.com/shapeshift/web/issues/3466