### PR TITLE
feat(swapper): update ThornodePoolResponse to the latest /lcd/thorchain/pools schema

### DIFF
--- a/packages/swapper/src/swappers/thorchain/types.ts
+++ b/packages/swapper/src/swappers/thorchain/types.ts
@@ -14,8 +14,12 @@ export type ThornodePoolResponse = {
   pending_inbound_asset: string
   pending_inbound_rune: string
   pool_units: string
+  savers_depth: string
+  savers_units: string
   status: string
+  synth_mint_paused: boolean
   synth_supply: string
+  synth_supply_remaining: string
   synth_units: string
 }
 

--- a/packages/swapper/src/swappers/thorchain/utils/test-data/responses.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/test-data/responses.ts
@@ -8,9 +8,13 @@ export const btcThornodePool: ThornodePoolResponse = {
   pending_inbound_asset: '0',
   pending_inbound_rune: '0',
   pool_units: '545894929144923',
+  savers_depth: '41416604834',
+  savers_units: '41128793233',
+  synth_mint_paused: false,
   status: 'Available',
-  synth_supply: '3281284823',
-  synth_units: '9838954536080',
+  synth_supply: '44718623180',
+  synth_supply_remaining: '8963246519',
+  synth_units: '142965023220851',
 }
 
 export const ethThornodePool: ThornodePoolResponse = {
@@ -21,9 +25,13 @@ export const ethThornodePool: ThornodePoolResponse = {
   pending_inbound_asset: '0',
   pending_inbound_rune: '0',
   pool_units: '274245264962453',
+  savers_depth: '167028916827',
+  savers_units: '165530383978',
   status: 'Available',
-  synth_supply: '3572065751',
-  synth_units: '535301524652',
+  synth_mint_paused: false,
+  synth_supply: '218601192670',
+  synth_supply_remaining: '183106737474',
+  synth_units: '36567637964216',
 }
 
 export const foxThornodePool: ThornodePoolResponse = {
@@ -34,9 +42,13 @@ export const foxThornodePool: ThornodePoolResponse = {
   pending_inbound_asset: '0',
   pending_inbound_rune: '0',
   pool_units: '10568061707512',
+  savers_depth: '0',
+  savers_units: '0',
   status: 'Available',
-  synth_supply: '17428372569375',
-  synth_units: '552604585625',
+  synth_mint_paused: false,
+  synth_supply: '3126453386967',
+  synth_supply_remaining: '161390775916374',
+  synth_units: '50300400994',
 }
 
 export const usdcThornodePool: ThornodePoolResponse = {
@@ -47,9 +59,13 @@ export const usdcThornodePool: ThornodePoolResponse = {
   pending_inbound_asset: '22020062300',
   pending_inbound_rune: '0',
   pool_units: '31954495292990',
+  savers_depth: '0',
+  savers_units: '0',
   status: 'Available',
-  synth_supply: '25598723155460',
-  synth_units: '1936419947970',
+  synth_mint_paused: false,
+  synth_supply: '20420358430864',
+  synth_supply_remaining: '102379864074658',
+  synth_units: '1423205664974',
 }
 
 export const thornodePools: ThornodePoolResponse[] = [


### PR DESCRIPTION
#### Description

Does what it says on the box - useful so we can either import this in web from swapper to type the response (probably not the best option since this is under the swapper umbrella), or at least ensure we have the most up-to-date schema to copy and paste it in web in case monkey see monkey do