### PR TITLE
fix: normalize deposit amount for approval

### DIFF
--- a/packages/investor-foxy/src/api/api.ts
+++ b/packages/investor-foxy/src/api/api.ts
@@ -403,7 +403,10 @@ export class FoxyApi {
     }
     const depositTokenContract = new this.web3.eth.Contract(erc20Abi, tokenContractAddress)
     const data: string = depositTokenContract.methods
-      .approve(contractAddress, amount ? numberToHex(bnOrZero(amount).toString()) : MAX_ALLOWANCE)
+      .approve(
+        contractAddress,
+        amount ? numberToHex(this.normalizeAmount(bnOrZero(amount))) : MAX_ALLOWANCE,
+      )
       .encodeABI({
         from: userAddress,
       })


### PR DESCRIPTION
- use `normalizeAmount` for `approve()` as `numberToHex()` will puke on scientific notation format string (`1e+22`)