### PR TITLE
fix: utxo base adapter get address

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -140,7 +140,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
       throw new Error('accountNumber must be >= 0')
     }
 
-    if (index && index < 0) {
+    if (index !== undefined && index < 0) {
       throw new Error('index must be >= 0')
     }
 

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -133,14 +133,14 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   getBIP44Params({
     accountNumber,
     accountType,
-    index = 0,
+    index,
     isChange = false,
   }: GetBIP44ParamsInput): BIP44Params {
     if (accountNumber < 0) {
       throw new Error('accountNumber must be >= 0')
     }
 
-    if (index < 0) {
+    if (index && index < 0) {
       throw new Error('index must be >= 0')
     }
 
@@ -191,7 +191,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     wallet,
     accountNumber,
     accountType = this.defaultUtxoAccountType,
-    index = 0,
+    index,
     isChange = false,
     showOnDevice = false,
   }: GetAddressInput): Promise<string> {

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -339,15 +339,23 @@ describe('BitcoinChainAdapter', () => {
   })
 
   describe('getAddress', () => {
+    beforeEach(() => {
+      args.providers = {} as any
+      args.providers.http = {
+        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
+      } as any
+    })
     it("should return a p2pkh address for valid derivation root path parameters (m/44'/0'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('1FH6ehAd5ZFXCM1cLGzHxK1s4dGdq1JusM')
     })
@@ -386,11 +394,13 @@ describe('BitcoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('1K2oFer6nGoXSPspeB5Qvt4htJvw3y31XW')
     })
@@ -399,11 +409,13 @@ describe('BitcoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.SegwitNative,
+        index,
       })
       expect(addr).toStrictEqual('bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa')
     })
@@ -442,11 +454,13 @@ describe('BitcoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.SegwitNative,
+        index,
       })
       expect(addr).toStrictEqual('bc1qgawuludfvrdxfq0x55k26ydtg2hrx64jp3u6am')
     })
@@ -459,8 +473,14 @@ describe('BitcoinChainAdapter', () => {
 
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
-      await adapter.getAddress({ accountNumber, wallet, accountType: UtxoAccountType.SegwitNative })
+      await adapter.getAddress({
+        accountNumber,
+        wallet,
+        accountType: UtxoAccountType.SegwitNative,
+        index,
+      })
 
       expect(wallet.btcGetAddress).toHaveBeenCalledWith({
         addressNList: [2147483732, 2147483648, 2147483649, 0, 0],
@@ -509,9 +529,9 @@ describe('BitcoinChainAdapter', () => {
         UtxoAccountType.SegwitNative,
       ]
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 0, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 49, coinType: 0, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 84, coinType: 0, accountNumber: 0, isChange: false, index: 0 },
+        { purpose: 44, coinType: 0, accountNumber: 0, isChange: false, index: undefined },
+        { purpose: 49, coinType: 0, accountNumber: 0, isChange: false, index: undefined },
+        { purpose: 84, coinType: 0, accountNumber: 0, isChange: false, index: undefined },
       ]
       accountTypes.forEach((accountType, i) => {
         const r = adapter.getBIP44Params({ accountNumber: 0, accountType })
@@ -524,10 +544,11 @@ describe('BitcoinChainAdapter', () => {
         UtxoAccountType.SegwitP2sh,
         UtxoAccountType.SegwitNative,
       ]
+      const index = undefined
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 0, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 49, coinType: 0, accountNumber: 1, isChange: false, index: 0 },
-        { purpose: 84, coinType: 0, accountNumber: 2, isChange: false, index: 0 },
+        { purpose: 44, coinType: 0, accountNumber: 0, isChange: false, index },
+        { purpose: 49, coinType: 0, accountNumber: 1, isChange: false, index },
+        { purpose: 84, coinType: 0, accountNumber: 2, isChange: false, index },
       ]
       accountTypes.forEach((accountType, accountNumber) => {
         const r = adapter.getBIP44Params({ accountNumber, accountType })

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -339,12 +339,6 @@ describe('BitcoinChainAdapter', () => {
   })
 
   describe('getAddress', () => {
-    beforeEach(() => {
-      args.providers = {} as any
-      args.providers.http = {
-        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
-      } as any
-    })
     it("should return a p2pkh address for valid derivation root path parameters (m/44'/0'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
@@ -379,6 +373,7 @@ describe('BitcoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
       const isChange = true
 
       const addr: string | undefined = await adapter.getAddress({
@@ -386,6 +381,7 @@ describe('BitcoinChainAdapter', () => {
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
         isChange,
+        index,
       })
       expect(addr).toStrictEqual('13ZD8S4qR6h4GvkAZ2ht7rpr15TFXYxGCx')
     })
@@ -439,6 +435,7 @@ describe('BitcoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
       const isChange = true
 
       const addr: string | undefined = await adapter.getAddress({
@@ -446,6 +443,7 @@ describe('BitcoinChainAdapter', () => {
         accountNumber,
         accountType: UtxoAccountType.SegwitNative,
         isChange,
+        index,
       })
       expect(addr).toStrictEqual('bc1qhazdhyg6ukkvnnlucxamjc3dmkj2zyfte0lqa9')
     })

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -360,15 +360,24 @@ describe('BitcoinCashChainAdapter', () => {
   })
 
   describe('getAddress', () => {
+    beforeEach(() => {
+      args.providers = {} as any
+      args.providers.http = {
+        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
+      } as any
+    })
+
     it("should return a p2pkh address for valid derivation root path parameters (m/44'/145'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoincash.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         accountNumber,
         wallet,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('bitcoincash:qzqxk2q6rhy3j9fnnc00m08g4n5dm827xv2dmtjzzp')
     })
@@ -407,11 +416,13 @@ describe('BitcoinCashChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoincash.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         accountNumber,
         wallet,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('bitcoincash:qz62eyfnv6lec8wwd3zg2ml4cvm4wr4caq4n3kdz56')
     })
@@ -422,8 +433,9 @@ describe('BitcoinCashChainAdapter', () => {
 
       const adapter = new bitcoincash.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
-      await adapter.getAddress({ accountNumber, wallet, accountType: UtxoAccountType.P2pkh })
+      await adapter.getAddress({ accountNumber, wallet, accountType: UtxoAccountType.P2pkh, index })
 
       expect(wallet.btcGetAddress).toHaveBeenCalledWith({
         addressNList: [2147483692, 2147483793, 2147483649, 0, 0],
@@ -467,7 +479,13 @@ describe('BitcoinCashChainAdapter', () => {
     })
     it('should properly map account types to purposes', async () => {
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: expectedCoinType, accountNumber: 0, isChange: false, index: 0 },
+        {
+          purpose: 44,
+          coinType: expectedCoinType,
+          accountNumber: 0,
+          isChange: false,
+          index: undefined,
+        },
       ]
       const accountTypes = adapter.getSupportedAccountTypes()
       accountTypes.forEach((accountType, i) => {
@@ -478,7 +496,13 @@ describe('BitcoinCashChainAdapter', () => {
     it('should respect accountNumber', async () => {
       const accountTypes = adapter.getSupportedAccountTypes()
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: expectedCoinType, accountNumber: 0, isChange: false, index: 0 },
+        {
+          purpose: 44,
+          coinType: expectedCoinType,
+          accountNumber: 0,
+          isChange: false,
+          index: undefined,
+        },
       ]
       accountTypes.forEach((accountType, accountNumber) => {
         const r = adapter.getBIP44Params({ accountNumber, accountType })

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -360,13 +360,6 @@ describe('BitcoinCashChainAdapter', () => {
   })
 
   describe('getAddress', () => {
-    beforeEach(() => {
-      args.providers = {} as any
-      args.providers.http = {
-        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
-      } as any
-    })
-
     it("should return a p2pkh address for valid derivation root path parameters (m/44'/145'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoincash.ChainAdapter(args)
@@ -401,6 +394,7 @@ describe('BitcoinCashChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new bitcoincash.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
       const isChange = true
 
       const addr: string | undefined = await adapter.getAddress({
@@ -408,6 +402,7 @@ describe('BitcoinCashChainAdapter', () => {
         wallet,
         accountType: UtxoAccountType.P2pkh,
         isChange,
+        index,
       })
       expect(addr).toStrictEqual('bitcoincash:qzh9hc7v8qa2dgx59pylharhp02ps96rputhg7w79h')
     })

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -347,13 +347,6 @@ describe('DogecoinChainAdapter', () => {
   })
 
   describe('getAddress', () => {
-    beforeEach(() => {
-      args.providers = {} as any
-      args.providers.http = {
-        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
-      } as any
-    })
-
     it("should return a p2pkh address for valid first receive index (m/44'/3'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new dogecoin.ChainAdapter(args)
@@ -389,6 +382,7 @@ describe('DogecoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new dogecoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
       const isChange = true
 
       const addr: string | undefined = await adapter.getAddress({
@@ -396,6 +390,7 @@ describe('DogecoinChainAdapter', () => {
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
         isChange,
+        index,
       })
       expect(addr).toStrictEqual('DPCPWrTEMLXhP8o57jH3i6ZbwAQwNHNFdq')
     })

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -347,15 +347,24 @@ describe('DogecoinChainAdapter', () => {
   })
 
   describe('getAddress', () => {
+    beforeEach(() => {
+      args.providers = {} as any
+      args.providers.http = {
+        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
+      } as any
+    })
+
     it("should return a p2pkh address for valid first receive index (m/44'/3'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new dogecoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       console.info(`addr: ${addr}`)
       expect(addr).toStrictEqual('DQTjL9vfXVbMfCGM49KWeYvvvNzRPaoiFp')
@@ -395,11 +404,13 @@ describe('DogecoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new dogecoin.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('DSpBqkDV8g7C2MwpT2xmeyvsB89P5qmCbq')
     })
@@ -441,7 +452,7 @@ describe('DogecoinChainAdapter', () => {
     })
     it('should properly map account types to purposes', async () => {
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 3, accountNumber: 0, isChange: false, index: 0 },
+        { purpose: 44, coinType: 3, accountNumber: 0, isChange: false, index: undefined },
       ]
       const accountTypes = adapter.getSupportedAccountTypes()
       accountTypes.forEach((accountType, i) => {
@@ -452,7 +463,7 @@ describe('DogecoinChainAdapter', () => {
     it('should respect accountNumber', async () => {
       const accountTypes = adapter.getSupportedAccountTypes()
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 3, accountNumber: 0, isChange: false, index: 0 },
+        { purpose: 44, coinType: 3, accountNumber: 0, isChange: false, index: undefined },
       ]
       accountTypes.forEach((accountType, accountNumber) => {
         const r = adapter.getBIP44Params({ accountNumber, accountType })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -355,11 +355,13 @@ describe('LitecoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new litecoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         accountNumber,
         wallet,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('LYXTv5RdsPYKC4qGmb6x6SuKoFMxUdSjLQ')
     })
@@ -398,11 +400,13 @@ describe('LitecoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new litecoin.ChainAdapter(args)
       const accountNumber = 1
+      const index = 0
 
       const addr: string | undefined = await adapter.getAddress({
         wallet,
         accountNumber,
         accountType: UtxoAccountType.P2pkh,
+        index,
       })
       expect(addr).toStrictEqual('LeRfQnpXQDe8nth9EWkduPnfkYuD1ASwAb')
     })
@@ -444,10 +448,11 @@ describe('LitecoinChainAdapter', () => {
         UtxoAccountType.SegwitP2sh,
         UtxoAccountType.SegwitNative,
       ]
+      const index = undefined
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 2, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 49, coinType: 2, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 84, coinType: 2, accountNumber: 0, isChange: false, index: 0 },
+        { purpose: 44, coinType: 2, accountNumber: 0, isChange: false, index },
+        { purpose: 49, coinType: 2, accountNumber: 0, isChange: false, index },
+        { purpose: 84, coinType: 2, accountNumber: 0, isChange: false, index },
       ]
       accountTypes.forEach((accountType, i) => {
         const r = adapter.getBIP44Params({ accountNumber: 0, accountType })
@@ -460,10 +465,11 @@ describe('LitecoinChainAdapter', () => {
         UtxoAccountType.SegwitP2sh,
         UtxoAccountType.SegwitNative,
       ]
+      const index = undefined
       const expected: BIP44Params[] = [
-        { purpose: 44, coinType: 2, accountNumber: 0, isChange: false, index: 0 },
-        { purpose: 49, coinType: 2, accountNumber: 1, isChange: false, index: 0 },
-        { purpose: 84, coinType: 2, accountNumber: 2, isChange: false, index: 0 },
+        { purpose: 44, coinType: 2, accountNumber: 0, isChange: false, index },
+        { purpose: 49, coinType: 2, accountNumber: 1, isChange: false, index },
+        { purpose: 84, coinType: 2, accountNumber: 2, isChange: false, index },
       ]
       accountTypes.forEach((accountType, accountNumber) => {
         const r = adapter.getBIP44Params({ accountNumber, accountType })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -344,13 +344,6 @@ describe('LitecoinChainAdapter', () => {
   })
 
   describe('getAddress', () => {
-    beforeEach(() => {
-      args.providers = {} as any
-      args.providers.http = {
-        getAccount: jest.fn().mockResolvedValue(getAccountMockResponse),
-      } as any
-    })
-
     it("should return a p2pkh address for valid first receive index (m/44'/2'/0'/0/0)", async () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new litecoin.ChainAdapter(args)
@@ -385,6 +378,7 @@ describe('LitecoinChainAdapter', () => {
       const wallet: HDWallet = await getWallet()
       const adapter = new litecoin.ChainAdapter(args)
       const accountNumber = 0
+      const index = 0
       const isChange = true
 
       const addr: string | undefined = await adapter.getAddress({
@@ -392,6 +386,7 @@ describe('LitecoinChainAdapter', () => {
         wallet,
         accountType: UtxoAccountType.P2pkh,
         isChange,
+        index,
       })
       expect(addr).toStrictEqual('LfYSvfC3L9XyFGL42zjodCiwTSoh772XD9')
     })


### PR DESCRIPTION
defaulting to `index = 0` in `getBIP44Params` was a mistake - the `getAddress` function expects undefined as a valid input, which it uses to grab the next receive address. by explicitly passing 0, we were generating a valid address for index 0, but always index 0, because of `getBIP44Params` defaulting to 0 rather than undefined.

this is not an issue for evm or cosmossdk adapters, as while technically we can generate addresses with `index > 0`, this isn't a normal convention.

- fix: don't default index to 0 for utxo base adapter
- test: update tests to mock next address index correctly
