### PR TITLE
chore: use singular naming convention for SwapErrorType

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -204,7 +204,7 @@ export type TradeTxs = {
 }
 
 // Swap Errors
-export enum SwapErrorTypes {
+export enum SwapErrorType {
   ALLOWANCE_REQUIRED_FAILED = 'ALLOWANCE_REQUIRED_FAILED',
   APPROVE_INFINITE_FAILED = 'APPROVE_INFINITE_FAILED',
   APPROVE_AMOUNT_FAILED = 'APPROVE_AMOUNT_FAILED',

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -230,6 +230,7 @@ export enum SwapErrorType {
   POOL_NOT_FOUND = 'POOL_NOT_FOUND',
   GET_TRADE_TXS_FAILED = 'GET_TRADE_TXS_FAILED',
   TRADE_FAILED = 'TRADE_FAILED',
+  OUTBOUND_CHAIN_HALTED = 'OUTBOUND_CHAIN_HALTED',
 }
 export interface Swapper<T extends ChainId> {
   /** Human-readable swapper name */

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -230,7 +230,6 @@ export enum SwapErrorType {
   POOL_NOT_FOUND = 'POOL_NOT_FOUND',
   GET_TRADE_TXS_FAILED = 'GET_TRADE_TXS_FAILED',
   TRADE_FAILED = 'TRADE_FAILED',
-  OUTBOUND_CHAIN_HALTED = 'OUTBOUND_CHAIN_HALTED',
 }
 export interface Swapper<T extends ChainId> {
   /** Human-readable swapper name */

--- a/packages/swapper/src/manager/SwapperManager.ts
+++ b/packages/swapper/src/manager/SwapperManager.ts
@@ -10,7 +10,7 @@ import {
   Swapper,
   TradeQuote,
 } from '..'
-import { SwapError, SwapErrorTypes, SwapperType } from '../api'
+import { SwapError, SwapErrorType, SwapperType } from '../api'
 import { isFulfilled } from '../typeGuards'
 import { getRatioFromQuote } from './utils'
 
@@ -20,7 +20,7 @@ type SwapperRatioTuple = readonly [swapper: Swapper<ChainId>, ratio: number | un
 function validateSwapper(swapper: Swapper<ChainId>) {
   if (!(typeof swapper === 'object' && typeof swapper.getType === 'function'))
     throw new SwapError('[validateSwapper] - invalid swapper instance', {
-      code: SwapErrorTypes.MANAGER_ERROR,
+      code: SwapErrorType.MANAGER_ERROR,
     })
 }
 
@@ -53,7 +53,7 @@ export class SwapperManager {
     const swapper = this.swappers.get(swapperType)
     if (!swapper)
       throw new SwapError('[getSwapper] - swapperType doesnt exist', {
-        code: SwapErrorTypes.MANAGER_ERROR,
+        code: SwapErrorType.MANAGER_ERROR,
         details: { swapperType },
       })
     return swapper
@@ -68,7 +68,7 @@ export class SwapperManager {
     const swapper = this.swappers.get(swapperType)
     if (!swapper)
       throw new SwapError('[removeSwapper] - swapperType doesnt exist', {
-        code: SwapErrorTypes.MANAGER_ERROR,
+        code: SwapErrorType.MANAGER_ERROR,
         details: { swapperType },
       })
     this.swappers.delete(swapperType)

--- a/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/cow/cowApprovalNeeded/cowApprovalNeeded.ts
@@ -1,7 +1,7 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorType } from '../../../api'
 import { erc20AllowanceAbi } from '../../utils/abi/erc20Allowance-abi'
 import { bnOrZero } from '../../utils/bignumber'
 import { getERC20Allowance } from '../../utils/helpers/helpers'
@@ -19,7 +19,7 @@ export async function cowApprovalNeeded(
   try {
     if (assetNamespace !== 'erc20') {
       throw new SwapError('[cowApprovalNeeded] - unsupported asset namespace', {
-        code: SwapErrorTypes.UNSUPPORTED_NAMESPACE,
+        code: SwapErrorType.UNSUPPORTED_NAMESPACE,
         details: { assetNamespace },
       })
     }
@@ -44,7 +44,7 @@ export async function cowApprovalNeeded(
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowApprovalNeeded]', {
       cause: e,
-      code: SwapErrorTypes.CHECK_APPROVAL_FAILED,
+      code: SwapErrorType.CHECK_APPROVAL_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/cowApprove/cowApprove.ts
+++ b/packages/swapper/src/swappers/cow/cowApprove/cowApprove.ts
@@ -1,6 +1,6 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { ApproveAmountInput, ApproveInfiniteInput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApproveAmountInput, ApproveInfiniteInput, SwapError, SwapErrorType } from '../../../api'
 import { erc20Abi } from '../../utils/abi/erc20-abi'
 import { grantAllowance } from '../../utils/helpers/helpers'
 import { CowSwapperDeps } from '../CowSwapper'
@@ -27,7 +27,7 @@ export async function cowApproveInfinite(
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowApproveInfinite]', {
       cause: e,
-      code: SwapErrorTypes.APPROVE_INFINITE_FAILED,
+      code: SwapErrorType.APPROVE_INFINITE_FAILED,
     })
   }
 }
@@ -54,7 +54,7 @@ export async function cowApproveAmount(
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowApproveAmount]', {
       cause: e,
-      code: SwapErrorTypes.APPROVE_AMOUNT_FAILED,
+      code: SwapErrorType.APPROVE_AMOUNT_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -2,7 +2,7 @@ import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 
-import { BuildTradeInput, SwapError, SwapErrorTypes } from '../../../api'
+import { BuildTradeInput, SwapError, SwapErrorType } from '../../../api'
 import { erc20AllowanceAbi } from '../../utils/abi/erc20Allowance-abi'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { getApproveContractData, isApprovalRequired } from '../../utils/helpers/helpers'
@@ -40,14 +40,14 @@ export async function cowBuildTrade(
 
     if (sellAssetNamespace !== 'erc20') {
       throw new SwapError('[cowBuildTrade] - Sell asset needs to be ERC-20 to use CowSwap', {
-        code: SwapErrorTypes.UNSUPPORTED_PAIR,
+        code: SwapErrorType.UNSUPPORTED_PAIR,
         details: { sellAssetNamespace },
       })
     }
 
     if (buyAssetChainId !== KnownChainIds.EthereumMainnet) {
       throw new SwapError('[cowBuildTrade] - Buy asset needs to be on ETH mainnet to use CowSwap', {
-        code: SwapErrorTypes.UNSUPPORTED_PAIR,
+        code: SwapErrorType.UNSUPPORTED_PAIR,
         details: { buyAssetChainId },
       })
     }
@@ -166,7 +166,7 @@ export async function cowBuildTrade(
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowBuildTrade]', {
       cause: e,
-      code: SwapErrorTypes.TRADE_QUOTE_FAILED,
+      code: SwapErrorType.TRADE_QUOTE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
@@ -5,7 +5,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 import { ethers } from 'ethers'
 
-import { ExecuteTradeInput, SwapError, SwapErrorTypes, TradeResult } from '../../../api'
+import { ExecuteTradeInput, SwapError, SwapErrorType, TradeResult } from '../../../api'
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowTrade } from '../types'
 import {
@@ -45,14 +45,14 @@ export async function cowExecuteTrade(
 
   if (sellAssetNamespace !== 'erc20') {
     throw new SwapError('[cowExecuteTrade] - Sell asset needs to be ERC-20 to use CowSwap', {
-      code: SwapErrorTypes.UNSUPPORTED_PAIR,
+      code: SwapErrorType.UNSUPPORTED_PAIR,
       details: { sellAssetNamespace },
     })
   }
 
   if (buyAssetChainId !== KnownChainIds.EthereumMainnet) {
     throw new SwapError('[cowExecuteTrade] - Buy asset needs to be on ETH mainnet to use CowSwap', {
-      code: SwapErrorTypes.UNSUPPORTED_PAIR,
+      code: SwapErrorType.UNSUPPORTED_PAIR,
       details: { buyAssetChainId },
     })
   }
@@ -131,7 +131,7 @@ export async function cowExecuteTrade(
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowExecuteTrade]', {
       cause: e,
-      code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+      code: SwapErrorType.EXECUTE_TRADE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.ts
+++ b/packages/swapper/src/swappers/cow/cowGetTradeTxs/cowGetTradeTxs.ts
@@ -1,4 +1,4 @@
-import { SwapError, SwapErrorTypes, TradeResult, TradeTxs } from '../../../api'
+import { SwapError, SwapErrorType, TradeResult, TradeTxs } from '../../../api'
 import { CowSwapperDeps } from '../CowSwapper'
 import { CowSwapGetOrdersResponse, CowSwapGetTradesResponse } from '../types'
 import { ORDER_STATUS_FULFILLED } from '../utils/constants'
@@ -32,7 +32,7 @@ export async function cowGetTradeTxs(deps: CowSwapperDeps, input: TradeResult): 
     if (e instanceof SwapError) throw e
     throw new SwapError('[cowGetTradeTxs]', {
       cause: e,
-      code: SwapErrorTypes.GET_TRADE_TXS_FAILED,
+      code: SwapErrorType.GET_TRADE_TXS_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -2,7 +2,7 @@ import { Asset } from '@shapeshiftoss/asset-service'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { MinMaxOutput, SwapError, SwapErrorTypes } from '../../../api'
+import { MinMaxOutput, SwapError, SwapErrorType } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { CowSwapperDeps } from '../CowSwapper'
 import { MAX_COWSWAP_TRADE, MIN_COWSWAP_VALUE_USD } from '../utils/constants'
@@ -18,7 +18,7 @@ export const getCowSwapMinMax = async (
     const { chainId: buyAssetChainId } = fromAssetId(buyAsset.assetId)
 
     if (sellAssetNamespace !== 'erc20' || buyAssetChainId !== KnownChainIds.EthereumMainnet) {
-      throw new SwapError('[getCowSwapMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })
+      throw new SwapError('[getCowSwapMinMax]', { code: SwapErrorType.UNSUPPORTED_PAIR })
     }
 
     const usdRate = await getUsdRate(deps, sellAsset)
@@ -31,6 +31,6 @@ export const getCowSwapMinMax = async (
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getCowSwapMinMax]', { cause: e, code: SwapErrorTypes.MIN_MAX_FAILED })
+    throw new SwapError('[getCowSwapMinMax]', { cause: e, code: SwapErrorType.MIN_MAX_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -2,7 +2,7 @@ import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 
-import { GetTradeQuoteInput, SwapError, SwapErrorTypes, TradeQuote } from '../../../api'
+import { GetTradeQuoteInput, SwapError, SwapErrorType, TradeQuote } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { getApproveContractData, normalizeIntegerAmount } from '../../utils/helpers/helpers'
 import { CowSwapperDeps } from '../CowSwapper'
@@ -45,7 +45,7 @@ export async function getCowSwapTradeQuote(
 
     if (sellAssetNamespace !== 'erc20') {
       throw new SwapError('[getCowSwapTradeQuote] - Sell asset needs to be ERC-20 to use CowSwap', {
-        code: SwapErrorTypes.UNSUPPORTED_PAIR,
+        code: SwapErrorType.UNSUPPORTED_PAIR,
         details: { sellAssetNamespace },
       })
     }
@@ -54,7 +54,7 @@ export async function getCowSwapTradeQuote(
       throw new SwapError(
         '[getCowSwapTradeQuote] - Buy asset needs to be on ETH mainnet to use CowSwap',
         {
-          code: SwapErrorTypes.UNSUPPORTED_PAIR,
+          code: SwapErrorType.UNSUPPORTED_PAIR,
           details: { buyAssetChainId },
         },
       )
@@ -181,13 +181,13 @@ export async function getCowSwapTradeQuote(
     ) {
       throw new SwapError('[getCowSwapTradeQuote]', {
         cause: e,
-        code: SwapErrorTypes.TRADE_QUOTE_INPUT_LOWER_THAN_FEES,
+        code: SwapErrorType.TRADE_QUOTE_INPUT_LOWER_THAN_FEES,
       })
     }
     if (e instanceof SwapError) throw e
     throw new SwapError('[getCowSwapTradeQuote]', {
       cause: e,
-      code: SwapErrorTypes.TRADE_QUOTE_FAILED,
+      code: SwapErrorType.TRADE_QUOTE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/cow/utils/helpers/helpers.ts
@@ -4,7 +4,7 @@ import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { AxiosResponse } from 'axios'
 import { ethers } from 'ethers'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { bn } from '../../../utils/bignumber'
 import { CowSwapperDeps } from '../../CowSwapper'
 import { CowSwapQuoteResponse } from '../../types'
@@ -81,7 +81,7 @@ export const getUsdRate = async ({ apiUrl }: CowSwapperDeps, input: Asset): Prom
 
   if (assetNamespace !== 'erc20') {
     throw new SwapError('[getUsdRate] - unsupported asset namespace', {
-      code: SwapErrorTypes.USD_RATE_FAILED,
+      code: SwapErrorType.USD_RATE_FAILED,
       details: { assetNamespace },
     })
   }
@@ -138,7 +138,7 @@ export const getUsdRate = async ({ apiUrl }: CowSwapperDeps, input: Asset): Prom
 
     if (!sellAmountCryptoPrecision.gt(0))
       throw new SwapError('[getUsdRate] - Failed to get sell token amount', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
 
     // dividing $1000 by amount of sell token received
@@ -147,7 +147,7 @@ export const getUsdRate = async ({ apiUrl }: CowSwapperDeps, input: Asset): Prom
     if (e instanceof SwapError) throw e
     throw new SwapError('[getUsdRate]', {
       cause: e,
-      code: SwapErrorTypes.USD_RATE_FAILED,
+      code: SwapErrorType.USD_RATE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -17,7 +17,7 @@ import {
   GetTradeQuoteInput,
   MinMaxOutput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   Swapper,
   SwapperName,
   SwapperType,
@@ -65,7 +65,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
       if (!cosmosAdapter)
         throw new SwapError('OsmosisSwapper: couldnt get cosmos adapter', {
-          code: SwapErrorTypes.GET_TRADE_TXS_FAILED,
+          code: SwapErrorType.GET_TRADE_TXS_FAILED,
         })
 
       const cosmosTxHistory = await cosmosAdapter.getTxHistory({
@@ -128,13 +128,13 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
   async approveInfinite(): Promise<string> {
     throw new SwapError('OsmosisSwapper: approveInfinite unimplemented', {
-      code: SwapErrorTypes.RESPONSE_ERROR,
+      code: SwapErrorType.RESPONSE_ERROR,
     })
   }
 
   async approveAmount(): Promise<string> {
     throw new SwapError('Osmosis: approveAmount unimplemented', {
-      code: SwapErrorTypes.RESPONSE_ERROR,
+      code: SwapErrorType.RESPONSE_ERROR,
     })
   }
 
@@ -162,7 +162,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
     if (!sellAmountCryptoBaseUnit) {
       throw new SwapError('sellAmountCryptoPrecision is required', {
-        code: SwapErrorTypes.BUILD_TRADE_FAILED,
+        code: SwapErrorType.BUILD_TRADE_FAILED,
       })
     }
 
@@ -182,7 +182,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
     if (!osmosisAdapter)
       throw new SwapError('Failed to get Osmosis adapter', {
-        code: SwapErrorTypes.BUILD_TRADE_FAILED,
+        code: SwapErrorType.BUILD_TRADE_FAILED,
       })
 
     const feeData = await osmosisAdapter.getFeeData({})
@@ -214,7 +214,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
     } = input
     if (!sellAmountCryptoBaseUnit) {
       throw new SwapError('sellAmount is required', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
     }
     const { buyAssetTradeFeeUsd, rate, buyAmountCryptoBaseUnit } = await getRateInfo(
@@ -232,7 +232,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
     if (!osmosisAdapter)
       throw new SwapError('Failed to get Osmosis adapter', {
-        code: SwapErrorTypes.TRADE_QUOTE_FAILED,
+        code: SwapErrorType.TRADE_QUOTE_FAILED,
       })
 
     const feeData = await osmosisAdapter.getFeeData({})
@@ -281,7 +281,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
     if (!cosmosAdapter || !osmosisAdapter) {
       throw new SwapError('Failed to get adapters', {
-        code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+        code: SwapErrorType.EXECUTE_TRADE_FAILED,
       })
     }
 
@@ -296,7 +296,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
       if (!sellAddress)
         throw new SwapError('Failed to get address', {
-          code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+          code: SwapErrorType.EXECUTE_TRADE_FAILED,
         })
 
       const transfer = {
@@ -328,7 +328,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       const pollResult = await pollForComplete(tradeId, this.deps.cosmosUrl)
       if (pollResult !== 'success')
         throw new SwapError('ibc transfer failed', {
-          code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+          code: SwapErrorType.EXECUTE_TRADE_FAILED,
         })
 
       ibcSellAmount = await pollForAtomChannelBalance(receiveAddress, this.deps.osmoUrl)
@@ -341,7 +341,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
 
       if (!sellAddress)
         throw new SwapError('failed to get osmoAddress', {
-          code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+          code: SwapErrorType.EXECUTE_TRADE_FAILED,
         })
     }
 
@@ -365,7 +365,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       const pollResult = await pollForComplete(tradeId, this.deps.osmoUrl)
       if (pollResult !== 'success')
         throw new SwapError('osmo swap failed', {
-          code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+          code: SwapErrorType.EXECUTE_TRADE_FAILED,
         })
 
       const amount = await pollForAtomChannelBalance(sellAddress, this.deps.osmoUrl)

--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -7,7 +7,7 @@ import { find } from 'lodash'
 import {
   CosmosSdkSupportedChainAdapters,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   TradeResult,
 } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
@@ -51,7 +51,7 @@ export const pollForComplete = async (txid: string, baseUrl: string): Promise<st
       } else if (Date.now() - startTime > timeout) {
         reject(
           new SwapError(`Couldnt find tx ${txid}`, {
-            code: SwapErrorTypes.RESPONSE_ERROR,
+            code: SwapErrorType.RESPONSE_ERROR,
           }),
         )
       } else {
@@ -68,7 +68,7 @@ export const getAtomChannelBalance = async (address: string, osmoUrl: string) =>
       return axios.get(`${osmoUrl}/bank/balances/${address}`)
     } catch (e) {
       throw new SwapError('failed to get balance', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
     }
   })()
@@ -101,7 +101,7 @@ export const pollForAtomChannelBalance = async (
       } else if (Date.now() - startTime > timeout) {
         reject(
           new SwapError(`Couldnt find channel balance for ${address}`, {
-            code: SwapErrorTypes.RESPONSE_ERROR,
+            code: SwapErrorType.RESPONSE_ERROR,
           }),
         )
       } else {
@@ -122,7 +122,7 @@ const findPool = async (sellAssetSymbol: string, buyAssetSymbol: string, osmoUrl
       return axios.get(poolsUrl)
     } catch (e) {
       throw new SwapError('failed to get pool', {
-        code: SwapErrorTypes.POOL_NOT_FOUND,
+        code: SwapErrorType.POOL_NOT_FOUND,
       })
     }
   })()
@@ -138,7 +138,7 @@ const findPool = async (sellAssetSymbol: string, buyAssetSymbol: string, osmoUrl
 
   if (!foundPool)
     throw new SwapError('could not find pool', {
-      code: SwapErrorTypes.POOL_NOT_FOUND,
+      code: SwapErrorType.POOL_NOT_FOUND,
     })
 
   const { sellAssetIndex, buyAssetIndex } = (() => {
@@ -215,7 +215,7 @@ export const performIbcTransfer = async (
       return axios.get(`${blockBaseUrl}/blocks/latest`)
     } catch (e) {
       throw new SwapError('failed to get latest block', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
     }
   })()

--- a/packages/swapper/src/swappers/test/TestSwapper.ts
+++ b/packages/swapper/src/swappers/test/TestSwapper.ts
@@ -5,7 +5,7 @@ import {
   ApprovalNeededOutput,
   BuyAssetBySellIdInput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   Swapper,
   SwapperName,
   SwapperType,
@@ -54,7 +54,7 @@ export class TestSwapper implements Swapper<ChainId> {
 
   async approveAmount(): Promise<string> {
     throw new SwapError('TestSwapper: approveAmount unimplemented', {
-      code: SwapErrorTypes.RESPONSE_ERROR,
+      code: SwapErrorType.RESPONSE_ERROR,
     })
   }
 

--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -33,7 +33,7 @@ import type {
   TradeTxs,
   UtxoSupportedChainIds,
 } from '../../api'
-import { SwapError, SwapErrorTypes, SwapperName, SwapperType } from '../../api'
+import { SwapError, SwapErrorType, SwapperName, SwapperType } from '../../api'
 import { buildTrade } from './buildThorTrade/buildThorTrade'
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import { thorTradeApprovalNeeded } from './thorTradeApprovalNeeded/thorTradeApprovalNeeded'
@@ -110,7 +110,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
       })
     } catch (e) {
       throw new SwapError('[thorchainInitialize]: initialize failed to set supportedAssetIds', {
-        code: SwapErrorTypes.INITIALIZE_FAILED,
+        code: SwapErrorType.INITIALIZE_FAILED,
         cause: e,
       })
     }
@@ -136,7 +136,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
 
   async approveAmount(): Promise<string> {
     throw new SwapError('ThorchainSwapper: approveAmount unimplemented', {
-      code: SwapErrorTypes.RESPONSE_ERROR,
+      code: SwapErrorType.RESPONSE_ERROR,
     })
   }
 
@@ -167,7 +167,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
 
       if (!adapter)
         throw new SwapError('[executeTrade]: no adapter for sell asset chain id', {
-          code: SwapErrorTypes.SIGN_AND_BROADCAST_FAILED,
+          code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
           details: { chainId: trade.sellAsset.chainId },
           fn: 'executeTrade',
         })
@@ -202,14 +202,14 @@ export class ThorchainSwapper implements Swapper<ChainId> {
         return { tradeId: txid }
       } else {
         throw new SwapError('[executeTrade]: unsupported trade', {
-          code: SwapErrorTypes.SIGN_AND_BROADCAST_FAILED,
+          code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
           fn: 'executeTrade',
         })
       }
     } catch (e) {
       if (e instanceof SwapError) throw e
       throw new SwapError('[executeTrade]: failed to sign or broadcast', {
-        code: SwapErrorTypes.SIGN_AND_BROADCAST_FAILED,
+        code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
         cause: e,
       })
     }
@@ -236,7 +236,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
       // This will detect all the errors I have seen.
       if (data?.actions[0]?.status === 'success' && data?.actions[0]?.type !== 'swap')
         throw new SwapError('[getTradeTxs]: trade failed', {
-          code: SwapErrorTypes.TRADE_FAILED,
+          code: SwapErrorType.TRADE_FAILED,
           cause: data,
         })
 
@@ -253,7 +253,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
     } catch (e) {
       if (e instanceof SwapError) throw e
       throw new SwapError('[getTradeTxs]: error', {
-        code: SwapErrorTypes.GET_TRADE_TXS_FAILED,
+        code: SwapErrorType.GET_TRADE_TXS_FAILED,
         cause: e,
       })
     }

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -8,7 +8,7 @@ import {
   EvmSupportedChainIds,
   GetUtxoTradeQuoteInput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   TradeQuote,
   UtxoSupportedChainIds,
 } from '../../../api'
@@ -42,7 +42,7 @@ export const buildTrade = async ({ deps, input }: BuildTradeArgs): Promise<ThorT
 
     if (!sellAdapter)
       throw new SwapError('[buildTrade]: unsupported sell asset', {
-        code: SwapErrorTypes.BUILD_TRADE_FAILED,
+        code: SwapErrorType.BUILD_TRADE_FAILED,
         fn: 'buildTrade',
         details: { sellAsset },
       })
@@ -131,7 +131,7 @@ export const buildTrade = async ({ deps, input }: BuildTradeArgs): Promise<ThorT
       }
     } else {
       throw new SwapError('[buildTrade]: unsupported chain id', {
-        code: SwapErrorTypes.BUILD_TRADE_FAILED,
+        code: SwapErrorType.BUILD_TRADE_FAILED,
         fn: 'buildTrade',
         details: { sellAsset },
       })
@@ -139,7 +139,7 @@ export const buildTrade = async ({ deps, input }: BuildTradeArgs): Promise<ThorT
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[buildTrade]: error building trade', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
       fn: 'buildTrade',
       cause: e,
     })

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -8,7 +8,7 @@ import {
   GetTradeQuoteInput,
   GetUtxoTradeQuoteInput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   SwapperName,
   TradeQuote,
   UtxoSupportedChainIds,
@@ -63,7 +63,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
       throw new SwapError(
         `[getThorTradeQuote] - No chain adapter found for ${chainId} or ${buyAssetChainId}.`,
         {
-          code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+          code: SwapErrorType.UNSUPPORTED_CHAIN,
           details: { sellAssetChainId: chainId, buyAssetChainId },
         },
       )
@@ -204,7 +204,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
         })()
       default:
         throw new SwapError('[getThorTradeQuote] - Asset chainId is not supported.', {
-          code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+          code: SwapErrorType.UNSUPPORTED_CHAIN,
           details: { chainId },
         })
     }
@@ -212,7 +212,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
     if (e instanceof SwapError) throw e
     throw new SwapError('[getThorTradeQuote]', {
       cause: e,
-      code: SwapErrorTypes.TRADE_QUOTE_FAILED,
+      code: SwapErrorType.TRADE_QUOTE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApprovalNeeded/thorTradeApprovalNeeded.ts
@@ -1,7 +1,7 @@
 import { CHAIN_NAMESPACE, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApprovalNeededInput, ApprovalNeededOutput, SwapError, SwapErrorType } from '../../../api'
 import { erc20AllowanceAbi } from '../../utils/abi/erc20Allowance-abi'
 import { bnOrZero } from '../../utils/bignumber'
 import { getERC20Allowance } from '../../utils/helpers/helpers'
@@ -30,7 +30,7 @@ export const thorTradeApprovalNeeded = async ({
       throw new SwapError(
         `[thorTradeApprovalNeeded] - no chain adapter found for chain Id: ${sellAsset.chainId}`,
         {
-          code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+          code: SwapErrorType.UNSUPPORTED_CHAIN,
           details: { chainId: sellAsset.chainId },
         },
       )
@@ -44,7 +44,7 @@ export const thorTradeApprovalNeeded = async ({
 
     if (!quote.allowanceContract) {
       throw new SwapError('[thorTradeApprovalNeeded] - allowanceTarget is required', {
-        code: SwapErrorTypes.VALIDATION_FAILED,
+        code: SwapErrorType.VALIDATION_FAILED,
         details: { chainId: sellAsset.chainId },
       })
     }
@@ -60,7 +60,7 @@ export const thorTradeApprovalNeeded = async ({
 
     if (!quote.feeData.chainSpecific?.gasPriceCryptoBaseUnit)
       throw new SwapError('[thorTradeApprovalNeeded] - no gas price with quote', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { feeData: quote.feeData },
       })
     return {
@@ -70,7 +70,7 @@ export const thorTradeApprovalNeeded = async ({
     if (e instanceof SwapError) throw e
     throw new SwapError('[thorTradeApprovalNeeded]', {
       cause: e,
-      code: SwapErrorTypes.CHECK_APPROVAL_FAILED,
+      code: SwapErrorType.CHECK_APPROVAL_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
+++ b/packages/swapper/src/swappers/thorchain/thorTradeApproveInfinite/thorTradeApproveInfinite.ts
@@ -1,7 +1,7 @@
 import { ethereum } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { ApproveInfiniteInput, SwapError, SwapErrorTypes } from '../../../api'
+import { ApproveInfiniteInput, SwapError, SwapErrorType } from '../../../api'
 import { erc20Abi } from '../../utils/abi/erc20-abi'
 import { APPROVAL_GAS_LIMIT } from '../../utils/constants'
 import { grantAllowance } from '../../utils/helpers/helpers'
@@ -42,7 +42,7 @@ export const thorTradeApproveInfinite = async ({
       throw new SwapError(
         `[thorTradeApproveInfinite] - No chain adapter found for ${sellAssetChainId}.`,
         {
-          code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+          code: SwapErrorType.UNSUPPORTED_CHAIN,
           details: { sellAssetChainId },
         },
       )
@@ -60,7 +60,7 @@ export const thorTradeApproveInfinite = async ({
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxApproveInfinite]', {
       cause: e,
-      code: SwapErrorTypes.APPROVE_INFINITE_FAILED,
+      code: SwapErrorType.APPROVE_INFINITE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/utils/bitcoin/utils/getThorTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/bitcoin/utils/getThorTxData.ts
@@ -1,6 +1,6 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 
-import { SwapError, SwapErrorTypes } from '../../../../../api'
+import { SwapError, SwapErrorType } from '../../../../../api'
 import type { ThorchainSwapperDeps } from '../../../types'
 import { getInboundAddressDataForChain } from '../../getInboundAddressDataForChain'
 import { getLimit } from '../../getLimit/getLimit'
@@ -39,7 +39,7 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
 
     if (!vault)
       throw new SwapError(`[getThorTxInfo]: vault not found for asset`, {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { inboundAddress, sellAsset },
       })
 
@@ -65,6 +65,6 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorTypes.TRADE_QUOTE_FAILED })
+    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorType.TRADE_QUOTE_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/utils/cosmos/getCosmosTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/cosmos/getCosmosTxData.ts
@@ -4,7 +4,7 @@ import { ChainAdapter, cosmos, thorchain } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { SwapError, SwapErrorTypes, TradeQuote } from '../../../../api'
+import { SwapError, SwapErrorType, TradeQuote } from '../../../../api'
 import type { ThorchainSwapperDeps } from '../../types'
 import { getInboundAddressDataForChain } from '../getInboundAddressDataForChain'
 import { getLimit } from '../getLimit/getLimit'
@@ -43,7 +43,7 @@ export const getCosmosTxData = async (input: GetCosmosTxDataInput) => {
 
   if (!vault && !fromThorAsset)
     throw new SwapError('[buildTrade]: no vault for chain', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
       fn: 'buildTrade',
       details: { chainId: input.chainId },
     })
@@ -79,7 +79,7 @@ export const getCosmosTxData = async (input: GetCosmosTxDataInput) => {
       default:
         if (!vault)
           throw new SwapError('[buildTrade]: no vault for chain', {
-            code: SwapErrorTypes.BUILD_TRADE_FAILED,
+            code: SwapErrorType.BUILD_TRADE_FAILED,
             fn: 'buildTrade',
             details: { chainId: input.chainId },
           })

--- a/packages/swapper/src/swappers/thorchain/utils/evm/makeTradeTx.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/evm/makeTradeTx.ts
@@ -3,7 +3,7 @@ import { fromAssetId } from '@shapeshiftoss/caip'
 import { ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { numberToHex } from 'web3-utils'
 
-import { EvmSupportedChainAdapter, SwapError, SwapErrorTypes } from '../../../../api'
+import { EvmSupportedChainAdapter, SwapError, SwapErrorType } from '../../../../api'
 import type { ThorchainSwapperDeps } from '../../types'
 import { getThorTxInfo } from './utils/getThorTxData'
 
@@ -78,7 +78,7 @@ export const makeTradeTx = async ({
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[makeTradeTx]: error making trade tx', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
       cause: e,
     })
   }

--- a/packages/swapper/src/swappers/thorchain/utils/evm/utils/getThorTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/evm/utils/getThorTxData.ts
@@ -1,7 +1,7 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { fromAssetId } from '@shapeshiftoss/caip'
 
-import { SwapError, SwapErrorTypes } from '../../../../../api'
+import { SwapError, SwapErrorType } from '../../../../../api'
 import type { ThorchainSwapperDeps } from '../../../types'
 import { getInboundAddressDataForChain } from '../../getInboundAddressDataForChain'
 import { getLimit } from '../../getLimit/getLimit'
@@ -42,7 +42,7 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
     const vault = inboundAddress?.address
     if (!inboundAddress || !router || !vault)
       throw new SwapError(`[getPriceRatio]: inboundAddress not found for ETH`, {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { inboundAddress },
       })
 
@@ -71,6 +71,6 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
     return { data, router }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorTypes.TRADE_QUOTE_FAILED })
+    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorType.TRADE_QUOTE_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
@@ -2,7 +2,7 @@ import { Asset } from '@shapeshiftoss/asset-service'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import max from 'lodash/max'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { bn, bnOrZero, fromBaseUnit, toBaseUnit } from '../../../utils/bignumber'
 import { ALLOWABLE_MARKET_MOVEMENT } from '../../../utils/constants'
 import { RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN } from '../../constants'
@@ -37,7 +37,7 @@ export const getLimit = async ({
     ?.getFeeAssetId()
   if (!sellAssetChainFeeAssetId || !buyAssetChainFeeAssetId) {
     throw new SwapError('[getLimit]: no sellAssetChainFeeAsset or buyAssetChainFeeAssetId', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
       details: { sellAssetChainFeeAssetId, buyAssetChainFeeAssetId },
     })
   }
@@ -53,7 +53,7 @@ export const getLimit = async ({
     bnOrZero(slippageTolerance).gte(0) && bnOrZero(slippageTolerance).lte(1)
   if (bnOrZero(expectedBuyAmountCryptoPrecision8).lt(0) || !isValidSlippageRange)
     throw new SwapError('[getLimit]: bad expected buy amount or bad slippage tolerance', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
       details: { expectedBuyAmountCryptoPrecision8, slippageTolerance },
     })
 

--- a/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getPriceRatio/getPriceRatio.ts
@@ -1,6 +1,6 @@
 import { adapters, AssetId } from '@shapeshiftoss/caip'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { bn, bnOrZero } from '../../../utils/bignumber'
 import { ThorchainSwapperDeps, ThornodePoolResponse } from '../../types'
 import { isRune } from '../isRune/isRune'
@@ -17,7 +17,7 @@ export const getPriceRatio = async (
 
     if (!buyPoolId && !isRune(buyAssetId)) {
       throw new SwapError(`[getPriceRatio]: No buyPoolId found for asset ${buyAssetId}`, {
-        code: SwapErrorTypes.POOL_NOT_FOUND,
+        code: SwapErrorType.POOL_NOT_FOUND,
         fn: 'getPriceRatio',
         details: { buyAssetId },
       })
@@ -25,7 +25,7 @@ export const getPriceRatio = async (
 
     if (!sellPoolId && !isRune(sellAssetId)) {
       throw new SwapError(`[getPriceRatio]: No sellPoolId found for asset ${sellAssetId}`, {
-        code: SwapErrorTypes.POOL_NOT_FOUND,
+        code: SwapErrorType.POOL_NOT_FOUND,
         fn: 'getPriceRatio',
         details: { sellAssetId },
       })
@@ -65,7 +65,7 @@ export const getPriceRatio = async (
 
     if (!buyPool || !sellPool) {
       throw new SwapError(`[getPriceRatio]: pools not found`, {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { buyPoolId, sellPoolId },
       })
     }
@@ -75,7 +75,7 @@ export const getPriceRatio = async (
 
     if (!buyPrice.gt(0) || !sellPrice.gt(0)) {
       throw new SwapError(`[getPriceRatio]: invalid pool price`, {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { buyPrice, sellPrice },
       })
     }
@@ -84,7 +84,7 @@ export const getPriceRatio = async (
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[getPriceRatio]: Thorchain getPriceRatio failed', {
-      code: SwapErrorTypes.PRICE_RATIO_FAILED,
+      code: SwapErrorType.PRICE_RATIO_FAILED,
       cause: e,
     })
   }

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
@@ -1,7 +1,7 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { adapters, AssetId } from '@shapeshiftoss/caip'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { BN, bn, bnOrZero, fromBaseUnit, toBaseUnit } from '../../../utils/bignumber'
 import { ThorchainSwapperDeps, ThornodePoolResponse } from '../../types'
 import { getPriceRatio } from '../getPriceRatio/getPriceRatio'
@@ -60,7 +60,7 @@ export const getTradeRate = async (
 
   if (!buyPoolId && !isRune(buyAssetId)) {
     throw new SwapError(`[getTradeRate]: No buyPoolId for asset ${buyAssetId}`, {
-      code: SwapErrorTypes.POOL_NOT_FOUND,
+      code: SwapErrorType.POOL_NOT_FOUND,
       fn: 'getTradeRate',
       details: { buyAssetId },
     })
@@ -68,7 +68,7 @@ export const getTradeRate = async (
 
   if (!sellPoolId && !isRune(sellAsset.assetId)) {
     throw new SwapError(`[getTradeRate]: No sellPoolId for asset ${sellAsset.assetId}`, {
-      code: SwapErrorTypes.POOL_NOT_FOUND,
+      code: SwapErrorType.POOL_NOT_FOUND,
       fn: 'getTradeRate',
       details: { sellAsset: sellAsset.assetId },
     })
@@ -83,7 +83,7 @@ export const getTradeRate = async (
 
   if (!buyPool && !isRune(buyAssetId)) {
     throw new SwapError(`[getTradeRate]: no pools found`, {
-      code: SwapErrorTypes.POOL_NOT_FOUND,
+      code: SwapErrorType.POOL_NOT_FOUND,
       fn: 'getTradeRate',
       details: { buyPoolId, sellPoolId },
     })
@@ -91,7 +91,7 @@ export const getTradeRate = async (
 
   if (!sellPool && !isRune(sellAsset.assetId)) {
     throw new SwapError(`[getTradeRate]: no pools found`, {
-      code: SwapErrorTypes.POOL_NOT_FOUND,
+      code: SwapErrorType.POOL_NOT_FOUND,
       fn: 'getTradeRate',
       details: { buyPoolId, sellPoolId },
     })

--- a/packages/swapper/src/swappers/thorchain/utils/getUsdRate/getUsdRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getUsdRate/getUsdRate.ts
@@ -1,7 +1,7 @@
 import { adapters, AssetId } from '@shapeshiftoss/caip'
 import BigNumber from 'bignumber.js'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { bn, bnOrZero } from '../../../utils/bignumber'
 import { ThornodePoolResponse } from '../../types'
 import { isRune } from '../isRune/isRune'
@@ -44,7 +44,7 @@ const getRuneUsdPrice = async (daemonUrl: string): Promise<BigNumber> => {
 
   if (!numPools) {
     throw new SwapError('[getUsdRate]: no available usd pools', {
-      code: SwapErrorTypes.USD_RATE_FAILED,
+      code: SwapErrorType.USD_RATE_FAILED,
     })
   }
 
@@ -62,7 +62,7 @@ export const getUsdRate = async (daemonUrl: string, assetId: AssetId): Promise<s
     const poolId = adapters.assetIdToPoolAssetId({ assetId })
     if (!poolId) {
       throw new SwapError(`[getUsdRate]: no pool found for assetId: ${assetId}`, {
-        code: SwapErrorTypes.USD_RATE_FAILED,
+        code: SwapErrorType.USD_RATE_FAILED,
       })
     }
 
@@ -72,7 +72,7 @@ export const getUsdRate = async (daemonUrl: string, assetId: AssetId): Promise<s
 
     if (data.status !== 'Available') {
       throw new SwapError('[getUsdRate]: pool is no longer available', {
-        code: SwapErrorTypes.USD_RATE_FAILED,
+        code: SwapErrorType.USD_RATE_FAILED,
       })
     }
 
@@ -81,7 +81,7 @@ export const getUsdRate = async (daemonUrl: string, assetId: AssetId): Promise<s
 
     if (assetBalance.isZero() || runeBalance.isZero()) {
       throw new SwapError('[getUsdRate]: pool has a zero balance', {
-        code: SwapErrorTypes.USD_RATE_FAILED,
+        code: SwapErrorType.USD_RATE_FAILED,
       })
     }
 
@@ -95,7 +95,7 @@ export const getUsdRate = async (daemonUrl: string, assetId: AssetId): Promise<s
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[getUsdRate]: Thorchain getUsdRate failed', {
-      code: SwapErrorTypes.USD_RATE_FAILED,
+      code: SwapErrorType.USD_RATE_FAILED,
       cause: e,
     })
   }

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
@@ -1,6 +1,6 @@
 import { adapters, thorchainAssetId } from '@shapeshiftoss/caip'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { THORCHAIN_AFFILIATE_BIPS, THORCHAIN_AFFILIATE_NAME } from '../constants'
 
 // BTC (and likely other utxo coins) can only support up to 80 character memos
@@ -25,7 +25,7 @@ export const makeSwapMemo = ({
   const thorId = isRune ? runeThorId : adapters.assetIdToPoolAssetId({ assetId: buyAssetId })
   if (!thorId)
     throw new SwapError('[makeSwapMemo] - undefined thorId for given buyAssetId', {
-      code: SwapErrorTypes.MAKE_MEMO_FAILED,
+      code: SwapErrorType.MAKE_MEMO_FAILED,
       details: { buyAssetId },
     })
 
@@ -43,13 +43,13 @@ export const makeSwapMemo = ({
 
   if (abbreviationAmount > 39)
     throw new SwapError('[makeSwapMemo] - too much abbreviation for accurate matching', {
-      code: SwapErrorTypes.MAKE_MEMO_FAILED,
+      code: SwapErrorType.MAKE_MEMO_FAILED,
     })
   // delimeter between ticker and id allowing us to abbreviate the id: https://dev.thorchain.org/thorchain-dev/memos#asset-notation
   const delimeterIndex = memo.indexOf('-') + 1
   if (!delimeterIndex) {
     throw new SwapError('[makeSwapMemo] - unable to abbreviate asset, no delimeter found', {
-      code: SwapErrorTypes.MAKE_MEMO_FAILED,
+      code: SwapErrorType.MAKE_MEMO_FAILED,
     })
   }
   return memo.replace(memo.slice(delimeterIndex, delimeterIndex + abbreviationAmount), '')

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
@@ -6,7 +6,7 @@ import {
   EvmSupportedChainIds,
   QuoteFeeData,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
 } from '../../../../../api'
 import { bn, bnOrZero } from '../../../../utils/bignumber'
 import { APPROVAL_GAS_LIMIT } from '../../../../utils/constants'
@@ -59,6 +59,6 @@ export const getEvmTxFees = async ({
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorTypes.TRADE_QUOTE_FAILED })
+    throw new SwapError('[getThorTxInfo]', { cause: e, code: SwapErrorType.TRADE_QUOTE_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/utxoTxFees/getUtxoTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/utxoTxFees/getUtxoTxFees.ts
@@ -1,7 +1,7 @@
 import { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { QuoteFeeData, SwapError, SwapErrorTypes, UtxoSupportedChainIds } from '../../../../../api'
+import { QuoteFeeData, SwapError, SwapErrorType, UtxoSupportedChainIds } from '../../../../../api'
 import { bn } from '../../../../utils/bignumber'
 
 type GetUtxoTxFeesInput = {
@@ -58,6 +58,6 @@ export const getUtxoTxFees = async ({
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getUtxoTxFees]', { cause: e, code: SwapErrorTypes.TRADE_QUOTE_FAILED })
+    throw new SwapError('[getUtxoTxFees]', { cause: e, code: SwapErrorType.TRADE_QUOTE_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/utils/helpers/helpers.ts
@@ -8,7 +8,7 @@ import {
   EvmSupportedChainAdapter,
   EvmSupportedChainIds,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   TradeQuote,
 } from '../../../api'
 import { MAX_ALLOWANCE } from '../../cow/utils/constants'
@@ -87,7 +87,7 @@ export const isApprovalRequired = async ({
     if (!allowanceOnChain) {
       throw new SwapError(`[isApprovalRequired] - No allowance data`, {
         details: { allowanceContract, receiveAddress },
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
     }
 
@@ -99,7 +99,7 @@ export const isApprovalRequired = async ({
     if (e instanceof SwapError) throw e
     throw new SwapError('[isApprovalRequired]', {
       cause: e,
-      code: SwapErrorTypes.ALLOWANCE_REQUIRED_FAILED,
+      code: SwapErrorType.ALLOWANCE_REQUIRED_FAILED,
     })
   }
 }
@@ -152,14 +152,14 @@ export const grantAllowance = async <T extends EvmSupportedChainIds>({
       return broadcastedTxId
     } else {
       throw new SwapError('[grantAllowance] - invalid HDWallet config', {
-        code: SwapErrorTypes.SIGN_AND_BROADCAST_FAILED,
+        code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
       })
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[grantAllowance]', {
       cause: e,
-      code: SwapErrorTypes.GRANT_ALLOWANCE_FAILED,
+      code: SwapErrorType.GRANT_ALLOWANCE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
+++ b/packages/swapper/src/swappers/zrx/ZrxSwapper.ts
@@ -12,7 +12,7 @@ import {
   EvmSupportedChainIds,
   GetEvmTradeQuoteInput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   Swapper,
   SwapperName,
   SwapperType,
@@ -47,7 +47,7 @@ export class ZrxSwapper<T extends EvmSupportedChainIds> implements Swapper<T> {
         return SwapperType.ZrxAvalanche
       default:
         throw new SwapError('[getType]', {
-          code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+          code: SwapErrorType.UNSUPPORTED_CHAIN,
         })
     }
   }

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -1,7 +1,7 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 
-import { MinMaxOutput, SwapError, SwapErrorTypes } from '../../../api'
+import { MinMaxOutput, SwapError, SwapErrorType } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { MAX_ZRX_TRADE } from '../utils/constants'
 import { getUsdRate } from '../utils/helpers/helpers'
@@ -15,7 +15,7 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
         buyAsset.chainId === sellAsset.chainId
       )
     ) {
-      throw new SwapError('[getZrxMinMax]', { code: SwapErrorTypes.UNSUPPORTED_PAIR })
+      throw new SwapError('[getZrxMinMax]', { code: SwapErrorType.UNSUPPORTED_PAIR })
     }
 
     const usdRate = await getUsdRate({ ...sellAsset })
@@ -28,6 +28,6 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getZrxMinMax]', { cause: e, code: SwapErrorTypes.MIN_MAX_FAILED })
+    throw new SwapError('[getZrxMinMax]', { cause: e, code: SwapErrorType.MIN_MAX_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -5,7 +5,7 @@ import {
   EvmSupportedChainIds,
   GetEvmTradeQuoteInput,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
   SwapSource,
   TradeQuote,
 } from '../../../api'
@@ -32,7 +32,7 @@ export async function getZrxTradeQuote<T extends EvmSupportedChainIds>(
       throw new SwapError(
         '[getZrxTradeQuote] - Both assets need to be on the same supported EVM chain to use Zrx',
         {
-          code: SwapErrorTypes.UNSUPPORTED_PAIR,
+          code: SwapErrorType.UNSUPPORTED_PAIR,
           details: { buyAssetChainId: buyAsset.chainId, sellAssetChainId: sellAsset.chainId },
         },
       )
@@ -127,6 +127,6 @@ export async function getZrxTradeQuote<T extends EvmSupportedChainIds>(
     return tradeQuote as TradeQuote<T>
   } catch (e) {
     if (e instanceof SwapError) throw e
-    throw new SwapError('[getZrxTradeQuote]', { cause: e, code: SwapErrorTypes.TRADE_QUOTE_FAILED })
+    throw new SwapError('[getZrxTradeQuote]', { cause: e, code: SwapErrorType.TRADE_QUOTE_FAILED })
   }
 }

--- a/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/zrx/utils/helpers/helpers.ts
@@ -3,7 +3,7 @@ import { AssetId, avalancheAssetId, ethAssetId, fromAssetId } from '@shapeshifto
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
 
-import { SwapError, SwapErrorTypes } from '../../../../api'
+import { SwapError, SwapErrorType } from '../../../../api'
 import { bn, bnOrZero } from '../../../utils/bignumber'
 import { ZrxPriceResponse } from '../../types'
 import { zrxServiceFactory } from '../zrxService'
@@ -17,7 +17,7 @@ export const baseUrlFromChainId = (chainId: string): string => {
       return 'https://avalanche.api.0x.org/'
     default:
       throw new SwapError(`baseUrlFromChainId] - Unsupported chainId: ${chainId}`, {
-        code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+        code: SwapErrorType.UNSUPPORTED_CHAIN,
       })
   }
 }
@@ -31,7 +31,7 @@ export const usdcContractFromChainId = (chainId: string): string => {
       return '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e'
     default:
       throw new SwapError(`usdcContractFromChainId] - Unsupported chainId: ${chainId}`, {
-        code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+        code: SwapErrorType.UNSUPPORTED_CHAIN,
       })
   }
 }
@@ -71,7 +71,7 @@ export const getUsdRate = async (asset: Asset): Promise<string> => {
     const price = bnOrZero(rateResponse.data.price)
     if (!price.gt(0))
       throw new SwapError('[getUsdRate] - Failed to get price data', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
       })
 
     return bn(1).dividedBy(price).toString()
@@ -79,7 +79,7 @@ export const getUsdRate = async (asset: Asset): Promise<string> => {
     if (e instanceof SwapError) throw e
     throw new SwapError('[getUsdRate]', {
       cause: e,
-      code: SwapErrorTypes.USD_RATE_FAILED,
+      code: SwapErrorType.USD_RATE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprovalNeeded/zrxApprovalNeeded.ts
@@ -5,7 +5,7 @@ import {
   ApprovalNeededOutput,
   EvmSupportedChainIds,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
 } from '../../../api'
 import { erc20AllowanceAbi } from '../../utils/abi/erc20Allowance-abi'
 import { bnOrZero } from '../../utils/bignumber'
@@ -23,7 +23,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
   try {
     if (sellAsset.chainId !== adapter.getChainId()) {
       throw new SwapError('[zrxApprovalNeeded] - sellAsset chainId is not supported', {
-        code: SwapErrorTypes.UNSUPPORTED_CHAIN,
+        code: SwapErrorType.UNSUPPORTED_CHAIN,
         details: { chainId: sellAsset.chainId },
       })
     }
@@ -39,7 +39,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
 
     if (!quote.allowanceContract) {
       throw new SwapError('[zrxApprovalNeeded] - allowanceTarget is required', {
-        code: SwapErrorTypes.VALIDATION_FAILED,
+        code: SwapErrorType.VALIDATION_FAILED,
         details: { chainId: sellAsset.chainId },
       })
     }
@@ -55,7 +55,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
 
     if (!quote.feeData.chainSpecific?.gasPriceCryptoBaseUnit)
       throw new SwapError('[zrxApprovalNeeded] - no gas price with quote', {
-        code: SwapErrorTypes.RESPONSE_ERROR,
+        code: SwapErrorType.RESPONSE_ERROR,
         details: { feeData: quote.feeData },
       })
     return {
@@ -65,7 +65,7 @@ export async function zrxApprovalNeeded<T extends EvmSupportedChainIds>(
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxApprovalNeeded]', {
       cause: e,
-      code: SwapErrorTypes.CHECK_APPROVAL_FAILED,
+      code: SwapErrorType.CHECK_APPROVAL_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.ts
+++ b/packages/swapper/src/swappers/zrx/zrxApprove/zrxApprove.ts
@@ -3,7 +3,7 @@ import {
   ApproveInfiniteInput,
   EvmSupportedChainIds,
   SwapError,
-  SwapErrorTypes,
+  SwapErrorType,
 } from '../../../api'
 import { erc20Abi } from '../../utils/abi/erc20-abi'
 import { APPROVAL_GAS_LIMIT } from '../../utils/constants'
@@ -51,7 +51,7 @@ export async function zrxApproveAmount<T extends EvmSupportedChainIds>(
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxApproveAmount]', {
       cause: e,
-      code: SwapErrorTypes.APPROVE_AMOUNT_FAILED,
+      code: SwapErrorType.APPROVE_AMOUNT_FAILED,
     })
   }
 }
@@ -66,7 +66,7 @@ export async function zrxApproveInfinite<T extends EvmSupportedChainIds>(
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxApproveInfinite]', {
       cause: e,
-      code: SwapErrorTypes.APPROVE_INFINITE_FAILED,
+      code: SwapErrorType.APPROVE_INFINITE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -2,7 +2,7 @@ import { fromAssetId } from '@shapeshiftoss/caip'
 import { AxiosResponse } from 'axios'
 import * as rax from 'retry-axios'
 
-import { BuildTradeInput, EvmSupportedChainIds, SwapError, SwapErrorTypes } from '../../../api'
+import { BuildTradeInput, EvmSupportedChainIds, SwapError, SwapErrorType } from '../../../api'
 import { erc20AllowanceAbi } from '../../utils/abi/erc20Allowance-abi'
 import { bnOrZero } from '../../utils/bignumber'
 import { APPROVAL_GAS_LIMIT, DEFAULT_SLIPPAGE } from '../../utils/constants'
@@ -38,7 +38,7 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
 
     if (buyAsset.chainId !== adapterChainId) {
       throw new SwapError(`[zrxBuildTrade] - buyAsset must be on chainId ${adapterChainId}`, {
-        code: SwapErrorTypes.VALIDATION_FAILED,
+        code: SwapErrorType.VALIDATION_FAILED,
         details: { chainId: sellAsset.chainId },
       })
     }
@@ -146,7 +146,7 @@ export async function zrxBuildTrade<T extends EvmSupportedChainIds>(
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxBuildTrade]', {
-      code: SwapErrorTypes.BUILD_TRADE_FAILED,
+      code: SwapErrorType.BUILD_TRADE_FAILED,
     })
   }
 }

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
@@ -1,6 +1,6 @@
 import { numberToHex } from 'web3-utils'
 
-import { EvmSupportedChainIds, SwapError, SwapErrorTypes, TradeResult } from '../../../api'
+import { EvmSupportedChainIds, SwapError, SwapErrorType, TradeResult } from '../../../api'
 import { ZrxExecuteTradeInput, ZrxSwapperDeps } from '../types'
 import { isNativeEvmAsset } from '../utils/helpers/helpers'
 
@@ -46,14 +46,14 @@ export async function zrxExecuteTrade<T extends EvmSupportedChainIds>(
       return { tradeId: txid }
     } else {
       throw new SwapError('[zrxExecuteTrade]', {
-        code: SwapErrorTypes.SIGN_AND_BROADCAST_FAILED,
+        code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
       })
     }
   } catch (e) {
     if (e instanceof SwapError) throw e
     throw new SwapError('[zrxExecuteTrade]', {
       cause: e,
-      code: SwapErrorTypes.EXECUTE_TRADE_FAILED,
+      code: SwapErrorType.EXECUTE_TRADE_FAILED,
     })
   }
 }


### PR DESCRIPTION
"Use a singular name for most Enum types, but use a plural name for Enum types that are bit fields." - [MSDN](https://learn.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/4x252001(v=vs.71)?redirectedfrom=MSDN)

Contributes to https://github.com/shapeshift/web/issues/2925