### PR TITLE
feat(swapper): export `getInboundAddressDataForChain`

### DIFF
--- a/packages/swapper/src/swappers/index.ts
+++ b/packages/swapper/src/swappers/index.ts
@@ -1,5 +1,6 @@
 export * from './zrx/ZrxSwapper'
 export * from './thorchain/ThorchainSwapper'
+export { getInboundAddressDataForChain } from './thorchain/utils/getInboundAddressDataForChain'
 export * from './test/TestSwapper'
 export * from './osmosis/OsmosisSwapper'
 export * from './cow/CowSwapper'

--- a/packages/swapper/src/swappers/thorchain/utils/getInboundAddressDataForChain.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getInboundAddressDataForChain.ts
@@ -6,6 +6,7 @@ import { thorService } from './thorService'
 export const getInboundAddressDataForChain = async (
   daemonUrl: string,
   assetId: AssetId | undefined,
+  excludeHalted = true,
 ): Promise<InboundAddressResponse | undefined> => {
   if (!assetId) return undefined
   const assetPoolId = adapters.assetIdToPoolAssetId({ assetId })
@@ -14,5 +15,7 @@ export const getInboundAddressDataForChain = async (
     `${daemonUrl}/lcd/thorchain/inbound_addresses`,
   )
   const activeInboundAddresses = inboundAddresses.filter((a) => !a.halted)
-  return activeInboundAddresses.find((inbound) => inbound.chain === assetChainSymbol)
+  return (excludeHalted ? activeInboundAddresses : inboundAddresses).find(
+    (inbound) => inbound.chain === assetChainSymbol,
+  )
 }


### PR DESCRIPTION
- Exports `getInboundAddressDataForChain` for consumption in `web`, whereby a hook is used to check for pool halts if THORSwapper is used
- Adds a new flag, `excludeHalted`, to `getInboundAddressDataForChain`, allowing `web` to receive all pools and explicitly check if a pool is halted (enables a fail-closed approach in `web`)

Contributes to https://github.com/shapeshift/web/issues/2925