### PR TITLE
fix: use cosmos sdk account number in osmo buildTradeTx

### DIFF
--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -295,6 +295,8 @@ export const buildTradeTx = async ({
 }) => {
   const responseAccount = await adapter.getAccount(osmoAddress)
 
+  // note - this is a cosmos sdk specific account_number, not a bip44Params accountNumber
+  const account_number = responseAccount.chainSpecific.accountNumber || '0'
   const sequence = responseAccount.chainSpecific.sequence || '0'
 
   const tx: Osmosis.StdTx = {
@@ -337,7 +339,7 @@ export const buildTradeTx = async ({
       tx,
       addressNList: toAddressNList(bip44Params),
       chain_id: CHAIN_REFERENCE.OsmosisMainnet,
-      account_number: accountNumber.toString(),
+      account_number,
       sequence,
     },
     wallet,


### PR DESCRIPTION
this was my mistake in a recent refactor - the Osmosis `account_number` that is returned from the `getAccount` call is *not* the same as the `accountNumber` that is used to construct `BIP44Params`

this PR reverts to using the correct `account_number` when building the trade tx, as per @elmutt @toshisat
