### PR TITLE
feat(swapper): add multi-account support to CoW Swap

### DIFF
--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -28,6 +28,8 @@ jest.mock('@shapeshiftoss/chain-adapters', () => {
     ...actualChainAdapters,
     ethereum: {
       ChainAdapter: {
+        // TODO: test account 0+
+        getBIP44Params: jest.fn(() => actualChainAdapters.ethereum.ChainAdapter.defaultBIP44Params),
         defaultBIP44Params: actualChainAdapters.ethereum.ChainAdapter.defaultBIP44Params,
         signMessage: jest.fn(() => Promise.resolve(Signature)),
       },

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.ts
@@ -1,5 +1,5 @@
 import { ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
-import { ethereum, SignMessageInput, toAddressNList } from '@shapeshiftoss/chain-adapters'
+import { SignMessageInput, toAddressNList } from '@shapeshiftoss/chain-adapters'
 import { ETHSignMessage } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { AxiosResponse } from 'axios'
@@ -34,6 +34,7 @@ export async function cowExecuteTrade(
     buyAsset,
     feeAmountInSellTokenCryptoBaseUnit: feeAmountInSellToken,
     sellAmountDeductFeeCryptoBaseUnit: sellAmountWithoutFee,
+    accountNumber,
   } = cowTrade
 
   const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } = fromAssetId(
@@ -81,7 +82,7 @@ export async function cowExecuteTrade(
     // For more info, check hashOrder method implementation
     const orderDigest = hashOrder(domain(1, COW_SWAP_SETTLEMENT_ADDRESS), orderToSign)
 
-    const bip44Params = ethereum.ChainAdapter.defaultBIP44Params
+    const bip44Params = adapter.getBIP44Params({ accountNumber })
     const message: SignMessageInput<ETHSignMessage> = {
       messageToSign: {
         addressNList: toAddressNList(bip44Params),


### PR DESCRIPTION
Add multi-account support to CoW Swap.

To test, link locally and perform a swap on CoW Swap using an account > 0.

When confirming the trade the `POST` request to `https://api.cow.fi/mainnet/api/v1/orders/` should no longer error.

Successful trade on account 1: https://explorer.cow.fi/orders/0x2810939c88381c99c118a23344a9294c12595b9f3e3904925f1f77c43324a0db4f6b667cb7f5c55bb8f1155675d69a606b67ef0863bf974d

<img width="411" alt="Screenshot 2023-01-12 at 3 49 57 pm" src="https://user-images.githubusercontent.com/97164662/211978892-9cba8389-2120-4784-b75f-45db045033e9.png">
