### PR TITLE
fix(swapper): osmo swapper cached url, small refactor

### DIFF
--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -10,21 +10,10 @@ import {
   SwapErrorType,
   TradeResult,
 } from '../../../api'
-import { createCache } from '../../../utils'
 import { bn, bnOrZero } from '../../utils/bignumber'
 import { OSMOSIS_PRECISION } from './constants'
+import { osmoService } from './osmoService'
 import { IbcTransferInput, PoolInfo } from './types'
-
-// Create cached axios service for pools endpoint because it gets called a LOT
-const cache = createCache(3000, ['/osmosis/gamm/v1beta1/pools/'])
-const osmoPoolsService = axios.create({
-  timeout: 10000,
-  headers: {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  },
-  adapter: cache.adapter,
-})
 
 export interface SymbolDenomMapping {
   OSMO: string
@@ -132,7 +121,7 @@ const findPool = async (sellAssetSymbol: string, buyAssetSymbol: string, osmoUrl
 
   const poolsResponse = await (async () => {
     try {
-      return osmoPoolsService.get(poolsUrl)
+      return osmoService.get(poolsUrl)
     } catch (e) {
       throw new SwapError('failed to get pool', {
         code: SwapErrorType.POOL_NOT_FOUND,

--- a/packages/swapper/src/swappers/osmosis/utils/osmoService.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/osmoService.ts
@@ -1,0 +1,18 @@
+import axios, { AxiosRequestConfig } from 'axios'
+
+import { createCache } from '../../../utils'
+
+const maxAge = 3 * 1000 // 3 seconds
+const cachedUrls = ['/osmosis/gamm/v1beta1/pools']
+const cache = createCache(maxAge, cachedUrls)
+
+const axiosConfig: AxiosRequestConfig = {
+  timeout: 10000,
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+  adapter: cache.adapter,
+}
+
+export const osmoService = axios.create(axiosConfig)


### PR DESCRIPTION
* moves the osmosis swapper axios cache configuration to a separate file to match the pattern used in other swappers
* removes the trailing '/' from the osmoService cached URL so that calls to the `/gamm/v1beta1/pools` endpoint are cached properly