### PR TITLE
fix: having / on end was negating cache banefits

### DIFF
--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -16,7 +16,7 @@ import { OSMOSIS_PRECISION } from './constants'
 import { IbcTransferInput, PoolInfo } from './types'
 
 // Create cached axios service for pools endpoint because it gets called a LOT
-const cache = createCache(3000, ['/osmosis/gamm/v1beta1/pools/'])
+const cache = createCache(3000, ['/osmosis/gamm/v1beta1/pools'])
 const osmoPoolsService = axios.create({
   timeout: 10000,
   headers: {


### PR DESCRIPTION
Fixes a small mixtake with osmo pools caching. 

Nothing was "broken" but we werent getting cache benefits