### PR TITLE
feat(utxoSelect): use `input.from` as change address if passed

### DIFF
--- a/packages/chain-adapters/src/utxo/utxoSelect/index.test.ts
+++ b/packages/chain-adapters/src/utxo/utxoSelect/index.test.ts
@@ -205,6 +205,7 @@ describe('utxoSelect', () => {
           value: 1000,
         },
         {
+          address: '15uud35JNGQboswqGeGGhTttGcX413VGcw',
           value: 98774,
         },
       ],

--- a/packages/chain-adapters/src/utxo/utxoSelect/index.ts
+++ b/packages/chain-adapters/src/utxo/utxoSelect/index.ts
@@ -44,6 +44,10 @@ export const utxoSelect = (input: UTXOSelectInput) => {
     return coinSelect<unchained.bitcoin.Utxo>(utxos, outputs, Number(input.satoshiPerByte))
   })()
 
+  /**
+   * note - the 0-indexed output is the `to` address, and if `input.from` is included as an argument, the
+   * 1-indexed output will be the change address, which we overwrite below
+   */
   if (input.from && result?.outputs?.[1]?.value) {
     // If input contains a `from` param, inputs will be filtered to only keep UTXOs from that address
     // The change address will be set to this from address, so that it can be reused

--- a/packages/chain-adapters/src/utxo/utxoSelect/index.ts
+++ b/packages/chain-adapters/src/utxo/utxoSelect/index.ts
@@ -44,5 +44,14 @@ export const utxoSelect = (input: UTXOSelectInput) => {
     return coinSelect<unchained.bitcoin.Utxo>(utxos, outputs, Number(input.satoshiPerByte))
   })()
 
+  if (input.from && result?.outputs?.[1]?.value) {
+    // If input contains a `from` param, inputs will be filtered to only keep UTXOs from that address
+    // The change address will be set to this from address, so that it can be reused
+    // Reusing addresses is an xpub antipattern and totally voids UTXO privacy guarantees, thus input.from should only be used
+    // when dealing with destinations that expect address reuse e.g THORSwap
+    const { value } = result.outputs[1]
+    result.outputs[1] = { address: input.from, value }
+  }
+
   return { ...result, outputs: result.outputs?.filter((o) => !o.script) }
 }

--- a/packages/chain-adapters/src/utxo/utxoSelect/index.ts
+++ b/packages/chain-adapters/src/utxo/utxoSelect/index.ts
@@ -48,7 +48,7 @@ export const utxoSelect = (input: UTXOSelectInput) => {
     // If input contains a `from` param, inputs will be filtered to only keep UTXOs from that address
     // The change address will be set to this from address, so that it can be reused
     // Reusing addresses is an xpub antipattern and totally voids UTXO privacy guarantees, thus input.from should only be used
-    // when dealing with destinations that expect address reuse e.g THORSwap
+    // when dealing with destinations that expect address reuse e.g THORChain savers
     const { value } = result.outputs[1]
     result.outputs[1] = { address: input.from, value }
   }


### PR DESCRIPTION
#### Description

If `input.from` is passed, the intent is to escape hatch the xpub privacy guarantees for destination addresses which business logic expect a single input address e.g THORSwap.

This PR makes sure we not only filter out UTXOs when `from` is passed, but also use it as a change address. This is effectively mimicking the behavior of wallets using a single *address* for UTXOs e.g THORSwap vs `wallets` using xpubs e.g us.

If the change address is automatically selected to be the next receive address, then this means either the `from` flow would work only once, or a Tx would have to be made to the previously used `from` address to populate an UTXO with the right value.

https://live.blockcypher.com/btc/tx/262848622bf782971dffa316dc755e9a2fac24555c4d847ce9356a889c0488f8/