### PR TITLE
fix(asset-service): update viewblock url

### DIFF
--- a/packages/asset-service/src/generateAssetData/baseAssets.ts
+++ b/packages/asset-service/src/generateAssetData/baseAssets.ts
@@ -114,9 +114,9 @@ export const thorchain: Asset = {
   precision: 8,
   color: '#33FF99',
   icon: 'https://assets.coincap.io/assets/icons/rune@2x.png',
-  explorer: 'https://v2.viewblock.io/thorchain',
-  explorerAddressLink: 'https://v2.viewblock.io/thorchain/address/',
-  explorerTxLink: 'https://v2.viewblock.io/thorchain/tx/',
+  explorer: 'https://viewblock.io/thorchain',
+  explorerAddressLink: 'https://viewblock.io/thorchain/address/',
+  explorerTxLink: 'https://viewblock.io/thorchain/tx/',
 }
 
 export const optimism: Asset = {

--- a/packages/asset-service/src/service/generatedAssetData.json
+++ b/packages/asset-service/src/service/generatedAssetData.json
@@ -3199,9 +3199,9 @@
     "precision": 8,
     "color": "#33FF99",
     "icon": "https://assets.coincap.io/assets/icons/rune@2x.png",
-    "explorer": "https://v2.viewblock.io/thorchain",
-    "explorerAddressLink": "https://v2.viewblock.io/thorchain/address/",
-    "explorerTxLink": "https://v2.viewblock.io/thorchain/tx/"
+    "explorer": "https://viewblock.io/thorchain",
+    "explorerAddressLink": "https://viewblock.io/thorchain/address/",
+    "explorerTxLink": "https://viewblock.io/thorchain/tx/"
   },
   "eip155:1/erc20:0x00000000000045166c45af0fc6e4cf31d9e14b9a": {
     "assetId": "eip155:1/erc20:0x00000000000045166c45af0fc6e4cf31d9e14b9a",

--- a/packages/swapper/src/swappers/utils/test-data/assets.ts
+++ b/packages/swapper/src/swappers/utils/test-data/assets.ts
@@ -121,7 +121,7 @@ export const RUNE: Asset = {
   precision: 8,
   color: '#33FF99',
   icon: 'https://assets.coincap.io/assets/icons/rune@2x.png',
-  explorer: 'https://v2.viewblock.io/thorchain',
-  explorerAddressLink: 'https://v2.viewblock.io/thorchain/address/',
-  explorerTxLink: 'https://v2.viewblock.io/thorchain/tx/',
+  explorer: 'https://viewblock.io/thorchain',
+  explorerAddressLink: 'https://viewblock.io/thorchain/address/',
+  explorerTxLink: 'https://viewblock.io/thorchain/tx/',
 }


### PR DESCRIPTION
Friends with https://github.com/shapeshift/web/pull/3650

> Viewblock V2 is now just Viewblock. We don't need to prefix URLs with `v2` anymore.
>
> @kaladinlight I know you don't use Twitter, so FYI: https://twitter.com/viewblock/status/1615537947729858562