### PR TITLE
feat: optimism l1 fees

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -38,14 +38,8 @@ import {
   toAddressNList,
   toRootDerivationPath,
 } from '../utils'
-import { bn, bnOrZero } from '../utils/bignumber'
-import {
-  BuildCustomTxInput,
-  EstimateFeeDataInput,
-  EstimateGasRequest,
-  Fees,
-  GasFeeDataEstimate,
-} from './types'
+import { bnOrZero } from '../utils/bignumber'
+import { BuildCustomTxInput, EstimateGasRequest, Fees, GasFeeDataEstimate } from './types'
 import { getErc20Data, getGeneratedAssetData } from './utils'
 
 export const evmChainIds = [

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -58,7 +58,8 @@ const makeGetGasFeesMockedResponse = (overrideArgs?: {
   maxPriorityFeePerGas?: string
 }) => merge({ gasPrice: '5', maxFeePerGas: '300', maxPriorityFeePerGas: '10' }, overrideArgs)
 
-const makeEstimateGasMockedResponse = (overrideArgs?: string) => overrideArgs ?? '21000'
+const makeEstimateGasMockedResponse = (overrideArgs?: { gasLimit?: string }) =>
+  merge({ gasLimit: '21000' }, overrideArgs)
 
 const makeGetAccountMockResponse = (balance: {
   balance: string
@@ -80,7 +81,7 @@ const makeGetAccountMockResponse = (balance: {
 const makeChainAdapterArgs = (overrideArgs?: {
   providers?: { http: unchained.avalanche.V1Api }
   chainId?: EvmChainId
-}): ChainAdapterArgs =>
+}): ChainAdapterArgs<unchained.avalanche.V1Api> =>
   merge(
     {
       providers: {

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -2,10 +2,11 @@ import { ASSET_REFERENCE, AssetId, avalancheAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterDisplayName, GasFeeDataEstimate } from '../../types'
+import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GetFeeDataInput } from '../../types'
-import { bn } from '../../utils/bignumber'
+import { bn, bnOrZero } from '../../utils/bignumber'
 import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.AvalancheMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.AvalancheMainnet
@@ -17,7 +18,9 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
     accountNumber: 0,
   }
 
-  constructor(args: ChainAdapterArgs) {
+  private readonly api: unchained.avalanche.V1Api
+
+  constructor(args: ChainAdapterArgs<unchained.avalanche.V1Api>) {
     super({
       chainId: DEFAULT_CHAIN_ID,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
@@ -25,6 +28,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
       ...args,
     })
 
+    this.api = args.providers.http
     this.assetId = avalancheAssetId
     this.parser = new unchained.avalanche.TransactionParser({
       chainId: this.chainId,
@@ -54,31 +58,31 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   async getGasFeeData(): Promise<GasFeeDataEstimate> {
     const feeData = await this.providers.http.getGasFees()
 
-    const nc = { fast: bn(1.2), average: bn(1), slow: bn(0.8) }
+    const scalars = { fast: bn(1.2), average: bn(1), slow: bn(0.8) }
 
     return {
       fast: {
-        gasPrice: calcFee(feeData.gasPrice, 'fast', nc),
+        gasPrice: calcFee(feeData.gasPrice, 'fast', scalars),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', nc),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', scalars),
           }),
       },
       average: {
-        gasPrice: calcFee(feeData.gasPrice, 'average', nc),
+        gasPrice: calcFee(feeData.gasPrice, 'average', scalars),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', nc),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', scalars),
           }),
       },
       slow: {
-        gasPrice: calcFee(feeData.gasPrice, 'slow', nc),
+        gasPrice: calcFee(feeData.gasPrice, 'slow', scalars),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', nc),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', scalars),
           }),
       },
     }
@@ -87,7 +91,24 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   async getFeeData(
     input: GetFeeDataInput<KnownChainIds.AvalancheMainnet>,
   ): Promise<FeeDataEstimate<KnownChainIds.AvalancheMainnet>> {
-    const gasFeeData = await this.getGasFeeData()
-    return this.estimateFeeData({ ...input, gasFeeData })
+    const req = await this.buildEstimateGasRequest(input)
+
+    const { gasLimit } = await this.api.estimateGas(req)
+    const { fast, average, slow } = await this.getGasFeeData()
+
+    return {
+      fast: {
+        txFee: bnOrZero(bn(fast.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...fast },
+      },
+      average: {
+        txFee: bnOrZero(bn(average.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...average },
+      },
+      slow: {
+        txFee: bnOrZero(bn(slow.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...slow },
+      },
+    }
   }
 }

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -56,33 +56,33 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   }
 
   async getGasFeeData(): Promise<GasFeeDataEstimate> {
-    const feeData = await this.providers.http.getGasFees()
+    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await this.api.getGasFees()
 
     const scalars = { fast: bn(1.2), average: bn(1), slow: bn(0.8) }
 
     return {
       fast: {
-        gasPrice: calcFee(feeData.gasPrice, 'fast', scalars),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', scalars),
+        gasPrice: calcFee(gasPrice, 'fast', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'fast', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'fast', scalars),
           }),
       },
       average: {
-        gasPrice: calcFee(feeData.gasPrice, 'average', scalars),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', scalars),
+        gasPrice: calcFee(gasPrice, 'average', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'average', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'average', scalars),
           }),
       },
       slow: {
-        gasPrice: calcFee(feeData.gasPrice, 'slow', scalars),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', scalars),
+        gasPrice: calcFee(gasPrice, 'slow', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'slow', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'slow', scalars),
           }),
       },
     }

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -88,7 +88,8 @@ describe('EthereumChainAdapter', () => {
       overrideArgs,
     )
 
-  const makeEstimateGasMockedResponse = (overrideArgs?: string) => overrideArgs ?? '21000'
+  const makeEstimateGasMockedResponse = (overrideArgs?: { gasLimit?: string }) =>
+    merge({ gasLimit: '21000' }, overrideArgs)
 
   const makeGetAccountMockResponse = (balance: {
     balance: string
@@ -110,7 +111,7 @@ describe('EthereumChainAdapter', () => {
   const makeChainAdapterArgs = (overrideArgs?: {
     providers?: { http: unchained.ethereum.V1Api }
     chainId?: EvmChainId
-  }): ChainAdapterArgs =>
+  }): ChainAdapterArgs<unchained.ethereum.V1Api> =>
     merge(
       {
         providers: {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -68,7 +68,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
 
     if (!medianFees) throw new TypeError('ETH Gas Fees should always exist')
 
-    const feeData = await this.providers.http.getGasFees()
+    const { maxFeePerGas, maxPriorityFeePerGas } = await this.api.getGasFees()
 
     const scalars = {
       fast: bnOrZero(bn(medianFees.fast).dividedBy(medianFees.standard)),
@@ -79,26 +79,26 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
     return {
       fast: {
         gasPrice: bnOrZero(medianFees.fast).toString(),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'fast', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'fast', scalars),
           }),
       },
       average: {
         gasPrice: bnOrZero(medianFees.standard).toString(),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'average', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'average', scalars),
           }),
       },
       slow: {
         gasPrice: bnOrZero(medianFees.low).toString(),
-        ...(feeData.maxFeePerGas &&
-          feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', scalars),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', scalars),
+        ...(maxFeePerGas &&
+          maxPriorityFeePerGas && {
+            maxFeePerGas: calcFee(maxFeePerGas, 'slow', scalars),
+            maxPriorityFeePerGas: calcFee(maxPriorityFeePerGas, 'slow', scalars),
           }),
       },
     }

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -3,7 +3,7 @@ import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 
-import { ChainAdapterDisplayName, GasFeeDataEstimate } from '../../types'
+import { ChainAdapterDisplayName } from '../../types'
 import {
   FeeDataEstimate,
   GetFeeDataInput,
@@ -12,7 +12,8 @@ import {
   ZrxGasApiResponse,
 } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { calcFee as calcFee2, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.EthereumMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.EthereumMainnet
@@ -24,7 +25,9 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
     accountNumber: 0,
   }
 
-  constructor(args: ChainAdapterArgs) {
+  private readonly api: unchained.ethereum.V1Api
+
+  constructor(args: ChainAdapterArgs<unchained.ethereum.V1Api>) {
     super({
       chainId: DEFAULT_CHAIN_ID,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
@@ -32,6 +35,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
       ...args,
     })
 
+    this.api = args.providers.http
     this.assetId = ethAssetId
     this.parser = new unchained.ethereum.TransactionParser({
       chainId: this.chainId,
@@ -66,7 +70,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
 
     const feeData = await this.providers.http.getGasFees()
 
-    const nc = {
+    const scalars = {
       fast: bnOrZero(bn(medianFees.fast).dividedBy(medianFees.standard)),
       average: bn(1),
       slow: bnOrZero(bn(medianFees.low).dividedBy(medianFees.standard)),
@@ -77,24 +81,24 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
         gasPrice: bnOrZero(medianFees.fast).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', nc),
+            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'fast', scalars),
+            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'fast', scalars),
           }),
       },
       average: {
         gasPrice: bnOrZero(medianFees.standard).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', nc),
+            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'average', scalars),
+            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'average', scalars),
           }),
       },
       slow: {
         gasPrice: bnOrZero(medianFees.low).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', nc),
-            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', nc),
+            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'slow', scalars),
+            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'slow', scalars),
           }),
       },
     }
@@ -103,8 +107,25 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
   async getFeeData(
     input: GetFeeDataInput<KnownChainIds.EthereumMainnet>,
   ): Promise<FeeDataEstimate<KnownChainIds.EthereumMainnet>> {
-    const gasFeeData = await this.getGasFeeData()
-    return this.estimateFeeData({ ...input, gasFeeData })
+    const req = await this.buildEstimateGasRequest(input)
+
+    const { gasLimit } = await this.api.estimateGas(req)
+    const { fast, average, slow } = await this.getGasFeeData()
+
+    return {
+      fast: {
+        txFee: bnOrZero(bn(fast.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...fast },
+      },
+      average: {
+        txFee: bnOrZero(bn(average.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...average },
+      },
+      slow: {
+        txFee: bnOrZero(bn(slow.gasPrice).times(gasLimit)).toPrecision(),
+        chainSpecific: { gasLimit, ...slow },
+      },
+    }
   }
 
   async validateEnsAddress(address: string): Promise<ValidAddressResult> {

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -12,7 +12,7 @@ import {
   ZrxGasApiResponse,
 } from '../../types'
 import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee as calcFee2, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
 import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.EthereumMainnet]
@@ -81,24 +81,24 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
         gasPrice: bnOrZero(medianFees.fast).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'fast', scalars),
-            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'fast', scalars),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'fast', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'fast', scalars),
           }),
       },
       average: {
         gasPrice: bnOrZero(medianFees.standard).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'average', scalars),
-            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'average', scalars),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'average', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'average', scalars),
           }),
       },
       slow: {
         gasPrice: bnOrZero(medianFees.low).toString(),
         ...(feeData.maxFeePerGas &&
           feeData.maxPriorityFeePerGas && {
-            maxFeePerGas: calcFee2(feeData.maxFeePerGas, 'slow', scalars),
-            maxPriorityFeePerGas: calcFee2(feeData.maxPriorityFeePerGas, 'slow', scalars),
+            maxFeePerGas: calcFee(feeData.maxFeePerGas, 'slow', scalars),
+            maxPriorityFeePerGas: calcFee(feeData.maxPriorityFeePerGas, 'slow', scalars),
           }),
       },
     }

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
@@ -47,13 +47,11 @@ const value = 400
 const makeChainSpecific = (chainSpecificAdditionalProps?: { erc20ContractAddress: string }) =>
   merge({ gasPrice, gasLimit }, chainSpecificAdditionalProps)
 
-const makeGetGasFeesMockedResponse = (overrideArgs?: {
-  gasPrice?: string
-  maxFeePerGas?: string
-  maxPriorityFeePerGas?: string
-}) => merge({ gasPrice: '5', maxFeePerGas: '300', maxPriorityFeePerGas: '10' }, overrideArgs)
+const makeGetGasFeesMockedResponse = (overrideArgs?: { gasPrice?: string; l1GasPrice?: string }) =>
+  merge({ gasPrice: '5', l1GasPrice: '10' }, overrideArgs)
 
-const makeEstimateGasMockedResponse = (overrideArgs?: string) => overrideArgs ?? '21000'
+const makeEstimateGasMockedResponse = (overrideArgs?: { gasLimit?: string; l1GasLimit?: string }) =>
+  merge({ gasLimit: '21000', l1GasLimit: '3500' }, overrideArgs)
 
 const makeGetAccountMockResponse = (balance: {
   balance: string
@@ -75,7 +73,7 @@ const makeGetAccountMockResponse = (balance: {
 const makeChainAdapterArgs = (overrideArgs?: {
   providers?: { http: unchained.optimism.V1Api }
   chainId?: EvmChainId
-}): ChainAdapterArgs =>
+}): ChainAdapterArgs<unchained.optimism.V1Api> =>
   merge(
     {
       providers: {
@@ -134,21 +132,21 @@ describe('OptimismChainAdapter', () => {
               gasLimit: '21000',
               gasPrice: '5',
             },
-            txFee: '105000',
+            txFee: '140000',
           },
           fast: {
             chainSpecific: {
               gasLimit: '21000',
               gasPrice: '6',
             },
-            txFee: '126000',
+            txFee: '161000',
           },
           slow: {
             chainSpecific: {
               gasLimit: '21000',
               gasPrice: '5',
             },
-            txFee: '105000',
+            txFee: '140000',
           },
         }),
       )

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
@@ -2,10 +2,11 @@ import { ASSET_REFERENCE, AssetId, optimismAssetId } from '@shapeshiftoss/caip'
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { ChainAdapterDisplayName, GasFeeDataEstimate } from '../../types'
+import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GetFeeDataInput } from '../../types'
-import { bn } from '../../utils/bignumber'
+import { bn, bnOrZero } from '../../utils/bignumber'
 import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OptimismMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OptimismMainnet
@@ -17,7 +18,9 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.OptimismMainnet> 
     accountNumber: 0,
   }
 
-  constructor(args: ChainAdapterArgs) {
+  private readonly api: unchained.optimism.V1Api
+
+  constructor(args: ChainAdapterArgs<unchained.optimism.V1Api>) {
     super({
       chainId: DEFAULT_CHAIN_ID,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
@@ -25,6 +28,7 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.OptimismMainnet> 
       ...args,
     })
 
+    this.api = args.providers.http
     this.assetId = optimismAssetId
     this.parser = new unchained.optimism.TransactionParser({
       chainId: this.chainId,
@@ -51,28 +55,46 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.OptimismMainnet> 
     return this.assetId
   }
 
-  async getGasFeeData(): Promise<GasFeeDataEstimate> {
-    const feeData = await this.providers.http.getGasFees()
+  async getGasFeeData(): Promise<GasFeeDataEstimate & { l1GasPrice: string }> {
+    const { gasPrice, l1GasPrice } = await this.api.getGasFees()
 
-    const nc = { fast: bn(1.1), average: bn(1), slow: bn(0.9) }
+    const scalars = { fast: bn(1.1), average: bn(1), slow: bn(0.9) }
 
     return {
-      fast: {
-        gasPrice: calcFee(feeData.gasPrice, 'fast', nc),
-      },
-      average: {
-        gasPrice: calcFee(feeData.gasPrice, 'average', nc),
-      },
-      slow: {
-        gasPrice: calcFee(feeData.gasPrice, 'slow', nc),
-      },
+      fast: { gasPrice: calcFee(gasPrice, 'fast', scalars) },
+      average: { gasPrice: calcFee(gasPrice, 'average', scalars) },
+      slow: { gasPrice: calcFee(gasPrice, 'slow', scalars) },
+      l1GasPrice,
     }
   }
 
   async getFeeData(
     input: GetFeeDataInput<KnownChainIds.OptimismMainnet>,
   ): Promise<FeeDataEstimate<KnownChainIds.OptimismMainnet>> {
-    const gasFeeData = await this.getGasFeeData()
-    return this.estimateFeeData({ ...input, gasFeeData })
+    const req = await this.buildEstimateGasRequest(input)
+
+    const { gasLimit, l1GasLimit } = await this.api.estimateGas(req)
+    const { fast, average, slow, l1GasPrice } = await this.getGasFeeData()
+
+    return {
+      fast: {
+        txFee: bnOrZero(
+          bn(fast.gasPrice).times(gasLimit).plus(bn(l1GasPrice).times(l1GasLimit)),
+        ).toPrecision(),
+        chainSpecific: { gasLimit, ...fast },
+      },
+      average: {
+        txFee: bnOrZero(
+          bn(average.gasPrice).times(gasLimit).plus(bn(l1GasPrice).times(l1GasLimit)),
+        ).toPrecision(),
+        chainSpecific: { gasLimit, ...average },
+      },
+      slow: {
+        txFee: bnOrZero(
+          bn(slow.gasPrice).times(gasLimit).plus(bn(l1GasPrice).times(l1GasLimit)),
+        ).toPrecision(),
+        chainSpecific: { gasLimit, ...slow },
+      },
+    }
   }
 }

--- a/packages/chain-adapters/src/evm/types.ts
+++ b/packages/chain-adapters/src/evm/types.ts
@@ -1,11 +1,37 @@
+import { ChainId } from '@shapeshiftoss/caip'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
-import { AssetBalance } from '../types'
+import * as common from '../types'
 
 export type Account = {
   nonce: number
-  tokens?: AssetBalance[]
+  tokens?: common.AssetBalance[]
+}
+
+export type BuildCustomTxInput = {
+  wallet: HDWallet
+  accountNumber: number
+  to: string
+  data: string
+  value: string
+  gasLimit: string
+} & Fees
+
+export type BuildTxInput = {
+  gasLimit: string
+  erc20ContractAddress?: string
+} & Fees
+
+export type EstimateFeeDataInput<T extends ChainId> = common.GetFeeDataInput<T> & {
+  gasFeeData: GasFeeDataEstimate
+}
+
+export type EstimateGasRequest = {
+  from: string
+  to: string
+  value: string
+  data: string
 }
 
 export type FeeData = {
@@ -27,24 +53,18 @@ export type Fees =
       maxPriorityFeePerGas: string
     }
 
-export type BuildTxInput = {
-  gasLimit: string
-  erc20ContractAddress?: string
-} & Fees
+export type GasFeeData = Omit<FeeData, 'gasLimit'>
+
+export type GasFeeDataEstimate = {
+  [common.FeeDataKey.Fast]: GasFeeData
+  [common.FeeDataKey.Average]: GasFeeData
+  [common.FeeDataKey.Slow]: GasFeeData
+}
 
 export type GetFeeDataInput = {
   contractAddress?: string
   from: string
   contractData?: string
 }
-
-export type BuildCustomTxInput = {
-  wallet: HDWallet
-  accountNumber: number
-  to: string
-  data: string
-  value: string
-  gasLimit: string
-} & Fees
 
 export type TransactionMetadata = unchained.evm.TxMetadata

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -14,6 +14,8 @@ import * as cosmossdk from './cosmossdk/types'
 import * as evm from './evm/types'
 import * as utxo from './utxo/types'
 
+export { cosmossdk, evm, utxo }
+
 type ChainSpecificAccount<T> = ChainSpecific<
   T,
   {
@@ -68,14 +70,6 @@ type ChainSpecificFeeData<T> = ChainSpecific<
 export type FeeData<T extends ChainId> = {
   txFee: string
 } & ChainSpecificFeeData<T>
-
-export type GasFeeData = Omit<evm.FeeData, 'gasLimit'>
-
-export type GasFeeDataEstimate = {
-  [FeeDataKey.Fast]: GasFeeData
-  [FeeDataKey.Average]: GasFeeData
-  [FeeDataKey.Slow]: GasFeeData
-}
 
 export type FeeDataEstimate<T extends ChainId> = {
   [FeeDataKey.Slow]: FeeData<T>
@@ -238,10 +232,6 @@ export type GetFeeDataInput<T extends ChainId> = {
   value: string
   sendMax?: boolean
 } & ChainSpecificGetFeeDataInput<T>
-
-export type EstimateFeeDataInput<T extends ChainId> = GetFeeDataInput<T> & {
-  gasFeeData: GasFeeDataEstimate
-}
 
 export enum ValidAddressResultType {
   Valid = 'valid',

--- a/packages/swapper/src/swappers/thorchain/utils/test-data/setupThorswapDeps.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/test-data/setupThorswapDeps.ts
@@ -1,5 +1,5 @@
 import { ethAssetId } from '@shapeshiftoss/caip'
-import { ChainAdapter, FeeDataKey, GasFeeDataEstimate } from '@shapeshiftoss/chain-adapters'
+import { ChainAdapter, evm, FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import Web3 from 'web3'
 
@@ -23,7 +23,7 @@ export const setupThorswapDeps = (): ThorchainSwapperDeps => {
         getFeeData: jest.fn(() => feeData),
         getFeeAssetId: jest.fn(() => ethAssetId),
         getGasFeeData: jest.fn(
-          (): GasFeeDataEstimate => ({
+          (): evm.GasFeeDataEstimate => ({
             [FeeDataKey.Slow]: {
               gasPrice: '1',
               maxFeePerGas: '2',


### PR DESCRIPTION
- separate evm specific types from common chain adapter types
- add generic type for `ChainAdapterArgs` for explicit api type in concrete chain adapter
- update response payload for `estimateGas`
- re-refactor shared gas estimation logic to allow handling of l1 fees on optimism
- add l1 transaction fee to the existing l2 transaction fee for an accurate estimation of total transaction fees required for optimism tx