### PR TITLE
feat: disable Yearn in market-service / unchained-client

### DIFF
--- a/packages/market-service/src/market-service-manager.ts
+++ b/packages/market-service/src/market-service-manager.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
+// import { JsonRpcProvider } from '@ethersproject/providers'
 import {
   FindAllMarketArgs,
   HistoryData,
@@ -7,16 +7,16 @@ import {
   MarketDataArgs,
   PriceHistoryArgs,
 } from '@shapeshiftoss/types'
-import { Yearn } from '@yfi/sdk'
 
+// import { Yearn } from '@yfi/sdk'
 import { MarketService } from './api'
 import { CoinCapMarketService } from './coincap/coincap'
 import { CoinGeckoMarketService } from './coingecko/coingecko'
 import { FoxyMarketService } from './foxy/foxy'
 import { IdleMarketService } from './idle/idle'
 import { OsmosisMarketService } from './osmosis/osmosis'
-import { YearnTokenMarketCapService } from './yearn/yearn-tokens'
-import { YearnVaultMarketCapService } from './yearn/yearn-vaults'
+// import { YearnTokenMarketCapService } from './yearn/yearn-tokens'
+// import { YearnVaultMarketCapService } from './yearn/yearn-vaults'
 
 export type ProviderUrls = {
   jsonRpcProviderUrl: string
@@ -34,23 +34,22 @@ export class MarketServiceManager {
   marketProviders: MarketService[]
 
   constructor(args: MarketServiceManagerArgs) {
-    const { coinGeckoAPIKey = '', providerUrls, yearnChainReference } = args
-
-    const { jsonRpcProviderUrl } = providerUrls
+    const { coinGeckoAPIKey = '', providerUrls } = args
 
     // TODO(0xdef1cafe): after chain agnosticism, we need to dependency inject a chainReference here
     // YearnVaultMarketCapService deps
-    const network = yearnChainReference ?? 1 // 1 for mainnet
-    const provider = new JsonRpcProvider(jsonRpcProviderUrl)
-    const yearnSdk = new Yearn(network, { provider })
+    // const network = yearnChainReference ?? 1 // 1 for mainnet
+    // const provider = new JsonRpcProvider(providerUrls.jsonRpcProviderUrl)
+    // const yearnSdk = new Yearn(network, { provider })
 
     this.marketProviders = [
       // Order of this MarketProviders array constitutes the order of providers we will be checking first.
       // More reliable providers should be listed first.
       new CoinGeckoMarketService({ coinGeckoAPIKey }),
       new CoinCapMarketService(),
-      new YearnVaultMarketCapService({ yearnSdk }),
-      new YearnTokenMarketCapService({ yearnSdk }),
+      // Yearn is currently borked upstream
+      // new YearnVaultMarketCapService({ yearnSdk }),
+      // new YearnTokenMarketCapService({ yearnSdk }),
       new IdleMarketService({ coinGeckoAPIKey, providerUrls }),
       new OsmosisMarketService(),
       new FoxyMarketService({ coinGeckoAPIKey, providerUrls }),

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@yfi/sdk": "^1.2.0",
+    "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",
     "ethers": "^5.5.3",
     "isomorphic-ws": "^4.0.1",

--- a/packages/unchained-client/src/evm/ethereum/parser/__tests__/ethereum.test.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/__tests__/ethereum.test.ts
@@ -1146,7 +1146,7 @@ describe('parseTx', () => {
         data: {
           assetId: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
           method: 'approve',
-          parser: 'yearn',
+          parser: 'erc20',
           value: '392318858461667547739736838950479151006397215279002157055',
         },
         status: TxStatus.Confirmed,
@@ -1173,10 +1173,7 @@ describe('parseTx', () => {
         address,
         chainId: 'eip155:1',
         confirmations: tx.confirmations,
-        data: {
-          method: 'deposit',
-          parser: 'yearn',
-        },
+        data: undefined,
         status: TxStatus.Confirmed,
         fee: {
           value: '18139009291874667',
@@ -1220,10 +1217,7 @@ describe('parseTx', () => {
         address,
         chainId: 'eip155:1',
         confirmations: tx.confirmations,
-        data: {
-          method: 'withdraw',
-          parser: 'yearn',
-        },
+        data: undefined,
         status: TxStatus.Confirmed,
         fee: {
           value: '19460274119661600',
@@ -1267,10 +1261,7 @@ describe('parseTx', () => {
         address,
         chainId: 'eip155:1',
         confirmations: tx.confirmations,
-        data: {
-          method: 'deposit',
-          parser: 'yearn',
-        },
+        data: undefined,
         status: TxStatus.Confirmed,
         fee: {
           value: '9099683709794574',

--- a/packages/unchained-client/src/evm/ethereum/parser/index.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/index.ts
@@ -8,7 +8,7 @@ import * as foxy from './foxy'
 import * as thor from './thor'
 import * as uniV2 from './uniV2'
 import * as weth from './weth'
-// import * as yearn from './yearn'
+import * as yearn from './yearn'
 
 export class TransactionParser extends BaseTransactionParser<Tx> {
   constructor(args: TransactionParserArgs) {
@@ -19,8 +19,7 @@ export class TransactionParser extends BaseTransactionParser<Tx> {
     // due to the current parser logic, order here matters (register most generic first to most specific last)
     // weth and yearn have the same sigHash for deposit(), but the weth parser is stricter resulting in faster processing times
     this.registerParsers([
-      // Yearn is currently borked upstream
-      // new yearn.Parser({ chainId: this.chainId, provider: this.provider }),
+      new yearn.Parser({ chainId: this.chainId }),
       new foxy.Parser(),
       new weth.Parser({ chainId: this.chainId, provider: this.provider }),
       new uniV2.Parser({ chainId: this.chainId, provider: this.provider }),

--- a/packages/unchained-client/src/evm/ethereum/parser/index.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/index.ts
@@ -8,7 +8,7 @@ import * as foxy from './foxy'
 import * as thor from './thor'
 import * as uniV2 from './uniV2'
 import * as weth from './weth'
-import * as yearn from './yearn'
+// import * as yearn from './yearn'
 
 export class TransactionParser extends BaseTransactionParser<Tx> {
   constructor(args: TransactionParserArgs) {
@@ -19,7 +19,8 @@ export class TransactionParser extends BaseTransactionParser<Tx> {
     // due to the current parser logic, order here matters (register most generic first to most specific last)
     // weth and yearn have the same sigHash for deposit(), but the weth parser is stricter resulting in faster processing times
     this.registerParsers([
-      new yearn.Parser({ chainId: this.chainId, provider: this.provider }),
+      // Yearn is currently borked upstream
+      // new yearn.Parser({ chainId: this.chainId, provider: this.provider }),
       new foxy.Parser(),
       new weth.Parser({ chainId: this.chainId, provider: this.provider }),
       new uniV2.Parser({ chainId: this.chainId, provider: this.provider }),


### PR DESCRIPTION
#### Description

Part of web spew cleaning - disabled Yearn in market-service and unchained-client.

See current grep for `yfi.sdk`.

- `market-service` is directly consumed in web, thus will reduce spew instantly
- `unchained-client`parsers are consumed in `chain-adapters` and will require an internal bump as a follow-up
- `caip` and `asset-service` usages are within a generate-once script kind of context, thus are not explicitly required to cleanup spew. Removing Yearn from there. Removing them from there would effectively mean Yearn assets wouldn't show up nor be able to be parsed as CAIPs anymore, removing the Yearn featureset fully, which is a product question. 

```shell
$ rg -l -g !**/node_modules** yfi.sdk

packages/market-service/src/marketDataCLI.ts
packages/market-service/src/market-service-manager.ts
packages/asset-service/src/generateAssetData/ethereum/yearnVaults.ts
packages/market-service/src/market-service.test.ts
packages/market-service/src/yearn/yearnMockData.ts
packages/market-service/src/yearn/yearn-vaults.test.ts
packages/market-service/src/yearn/yearn-tokens.test.ts
packages/market-service/src/yearn/yearn-tokens.ts
packages/market-service/src/yearn/yearn-vaults.ts
packages/asset-service/package.json
packages/market-service/package.json
packages/unchained-client/src/evm/ethereum/parser/yearn.ts
packages/unchained-client/src/evm/ethereum/parser/__tests__/ethereum.test.ts
packages/unchained-client/package.json
yarn.lock
packages/investor-yearn/src/YearnInvestor.ts
packages/investor-yearn/src/YearnOpportunity.ts
packages/investor-yearn/package.json
packages/caip/src/adapters/yearn/utils.ts
packages/caip/src/adapters/yearn/utils.test.ts
packages/caip/package.json
__mocks__/@yfi/sdk.ts
```