### PR TITLE
feat (chain-adapters): add shapeshift tracking id to cosmos-sdk transactions

### DIFF
--- a/packages/chain-adapters/src/constants.ts
+++ b/packages/chain-adapters/src/constants.ts
@@ -1,0 +1,1 @@
+export const SHAPESHIFT_TRACKING_ID = 'shapeshift'

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -4,6 +4,7 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
 
 import { ChainAdapter as IChainAdapter } from '../api'
+import { SHAPESHIFT_TRACKING_ID } from '../constants'
 import { ErrorHandler } from '../error/ErrorHandler'
 import {
   Account,
@@ -292,7 +293,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
       accountNumber,
       chainSpecific: { gas, fee },
       msg,
-      memo = '',
+      memo,
     } = tx
 
     const bip44Params = this.getBIP44Params({ accountNumber })
@@ -301,7 +302,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
       fee: { amount: [{ amount: bnOrZero(fee).toString(), denom: this.denom }], gas },
       msg: [msg],
       signatures: [],
-      memo,
+      memo: memo ?? SHAPESHIFT_TRACKING_ID, // Apply tracking ID to all transactions where no memo is provided. Pass '' in memo field when tracking ID should not be applied.
     }
 
     const txToSign = {

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -98,6 +98,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
         value,
         wallet,
       } = tx
+      tx.memo ??= ''
 
       const from = await this.getAddress({ accountNumber, wallet })
       const account = await this.getAccount(from)

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -119,6 +119,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
         value,
         wallet,
       } = tx
+      tx.memo ??= ''
 
       const from = await this.getAddress({ accountNumber, wallet })
       const account = await this.getAccount(from)

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -122,6 +122,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
         value,
         wallet,
       } = tx
+      tx.memo ??= ''
 
       const from = await this.getAddress({ accountNumber, wallet })
       const account = await this.getAccount(from)


### PR DESCRIPTION
* add shapeshift tracking id to all cosmos-sdk transactions except sends.
* tracking ID will be overridden by any pre-existing memo data