### PR TITLE
chore: bump @shapeshiftoss/chain-adapters dependencies

### DIFF
--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -37,13 +37,13 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1"

--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -36,14 +36,14 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -37,14 +37,14 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
     "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/types": "^8.1.0",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.0.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/investor-foxy": "^7.0.0",
     "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/types": "^8.1.0",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@shapeshiftoss/asset-service": "^8.0.1",
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.5.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/types": "^8.1.0"
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@shapeshiftoss/asset-service": "^8.0.1",
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/chain-adapters": "^10.5.0",
+    "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.42.0",
     "@shapeshiftoss/types": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,20 @@
     axios-retry "^3.2.5"
     ws "^8.8.0"
 
+"@shapeshiftoss/chain-adapters@^10.0.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.14.0.tgz#92ee0d607910e307ee3b53014c015d99718ea857"
+  integrity sha512-6l7fUK54zQYwExKtQVvpyjuQuXXoK5B8yOxuwJ192ZkwlsMbj2HfAJnqPWqvakbZhHMkyjbJuMaiGRf8LSP8LA==
+  dependencies:
+    axios "^0.26.1"
+    bech32 "^2.0.0"
+    bignumber.js "^9.0.2"
+    bitcoinjs-lib "^5.2.0"
+    coinselect "^3.1.13"
+    ethers "^5.4.7"
+    multicoin-address-validator "^0.5.12"
+    web3-utils "1.7.4"
+
 "@shapeshiftoss/common-api@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-8.1.0.tgz#243f356d467478c5d09f82a86bda75af37624ba7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,20 +3091,6 @@
     axios-retry "^3.2.5"
     ws "^8.8.0"
 
-"@shapeshiftoss/chain-adapters@^10.0.0":
-  version "10.14.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.14.0.tgz#92ee0d607910e307ee3b53014c015d99718ea857"
-  integrity sha512-6l7fUK54zQYwExKtQVvpyjuQuXXoK5B8yOxuwJ192ZkwlsMbj2HfAJnqPWqvakbZhHMkyjbJuMaiGRf8LSP8LA==
-  dependencies:
-    axios "^0.26.1"
-    bech32 "^2.0.0"
-    bignumber.js "^9.0.2"
-    bitcoinjs-lib "^5.2.0"
-    coinselect "^3.1.13"
-    ethers "^5.4.7"
-    multicoin-address-validator "^0.5.12"
-    web3-utils "1.7.4"
-
 "@shapeshiftoss/common-api@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/common-api/-/common-api-8.1.0.tgz#243f356d467478c5d09f82a86bda75af37624ba7"


### PR DESCRIPTION
`@shapeshiftoss/chain-adapters` is out of date in `@shapeshiftoss/swapper`, causing CI to fail.

This PR bumps `@shapeshiftoss/chain-adapters` a major version to `11.0.0` for all packages.