### PR TITLE
feat(swapper): add memo assertion

### DIFF
--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
@@ -79,5 +79,9 @@ describe('assertIsValidMemo', () => {
     expect(() =>
       assertIsValidMemo('s:RUNE.BTC:Bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
     ).toThrow()
+
+    expect(() =>
+      assertIsValidMemo('s:BTC.BTC:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+    ).toThrow()
   })
 })

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
@@ -1,6 +1,6 @@
 import { bchChainId, ethChainId, thorchainChainId } from '@shapeshiftoss/caip'
 
-import { isValidMemoAddress } from './assertIsValidMemo'
+import { assertIsValidMemo, isValidMemoAddress } from './assertIsValidMemo'
 
 describe('isValidMemoAddress', () => {
   it('should validate memo address', () => {
@@ -19,7 +19,7 @@ describe('isValidMemoAddress', () => {
     expect(
       isValidMemoAddress(
         thorchainChainId,
-        'THOR.ETH',
+        'RUNE.ETH',
         'thor1j5jxvwd33rz66r88vwwwayvncjadx9jy5hvvqw',
       ),
     ).toBe(true)
@@ -53,5 +53,31 @@ describe('isValidMemoAddress', () => {
     expect(
       isValidMemoAddress(ethChainId, 'ETH.ETH', 'bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h'),
     ).toBe(false)
+  })
+})
+
+describe('assertIsValidMemo', () => {
+  it('should assert memo is valid', () => {
+    expect(() =>
+      assertIsValidMemo('s:BTC.BTC:bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+    ).not.toThrow()
+
+    expect(() =>
+      assertIsValidMemo('s:ETH.ETH:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+    ).not.toThrow()
+
+    expect(() =>
+      assertIsValidMemo('s:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+    ).not.toThrow()
+  })
+
+  it('should throw on invalid memo', () => {
+    expect(() =>
+      assertIsValidMemo('s:BTC.BTC:zc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+    ).toThrow()
+
+    expect(() =>
+      assertIsValidMemo('s:RUNE.BTC:Bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+    ).toThrow()
   })
 })

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.test.ts
@@ -1,0 +1,57 @@
+import { bchChainId, ethChainId, thorchainChainId } from '@shapeshiftoss/caip'
+
+import { isValidMemoAddress } from './assertIsValidMemo'
+
+describe('isValidMemoAddress', () => {
+  it('should validate memo address', () => {
+    expect(
+      isValidMemoAddress(ethChainId, 'ETH.ETH', '0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741'),
+    ).toBe(true)
+
+    expect(
+      isValidMemoAddress(
+        bchChainId,
+        'BCH.ETH',
+        'bitcoincash:qpqze9nw77en2v4du4ud0d02t72qkafqe5nk8vrk7f',
+      ),
+    ).toBe(true)
+
+    expect(
+      isValidMemoAddress(
+        thorchainChainId,
+        'THOR.ETH',
+        'thor1j5jxvwd33rz66r88vwwwayvncjadx9jy5hvvqw',
+      ),
+    ).toBe(true)
+  })
+
+  it('should fail memo address validation when chainId does not match', () => {
+    expect(
+      isValidMemoAddress(
+        ethChainId,
+        'BCH.ETH',
+        'bitcoincash:qpqze9nw77en2v4du4ud0d02t72qkafqe5nk8vrk7f',
+      ),
+    ).toBe(false)
+
+    expect(
+      isValidMemoAddress(ethChainId, 'ETH.ETH', 'bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h'),
+    ).toBe(false)
+
+    expect(
+      isValidMemoAddress(bchChainId, 'BCH.ETH', 'bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h'),
+    ).toBe(false)
+  })
+
+  it('should fail memo address validation when address does not match', () => {
+    expect(
+      isValidMemoAddress(bchChainId, 'BCH.ETH', 'bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h'),
+    ).toBe(false)
+  })
+
+  it('should fail memo address validation when chainId and address do not match', () => {
+    expect(
+      isValidMemoAddress(ethChainId, 'ETH.ETH', 'bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h'),
+    ).toBe(false)
+  })
+})

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
@@ -27,7 +27,7 @@ const thorChainAssetToChainId: Map<string, ChainId> = new Map([
   ['RUNE', thorchainChainId],
 ])
 
-export const isValidAddress = (chainId: ChainId, thorId: string, address: string): boolean => {
+export const isValidMemoAddress = (chainId: ChainId, thorId: string, address: string): boolean => {
   switch (true) {
     case thorId.startsWith('ETH.'):
     case thorId.startsWith('AVAX.'):
@@ -39,10 +39,9 @@ export const isValidAddress = (chainId: ChainId, thorId: string, address: string
       const chainLabel = chainIdToChainLabel(chainId)
       return WAValidator.validate(address, chainLabel)
     }
-    case thorId.startsWith('GAIA:'):
+    case thorId.startsWith('GAIA.'):
       return address.startsWith('cosmos')
-    case thorId.startsWith('RUNE:'):
-    case thorId.startsWith('THOR:'):
+    case thorId.startsWith('RUNE.'):
       return address.startsWith('thor')
     default:
       return false
@@ -58,7 +57,7 @@ export const assertIsValidMemo = (memo: string): void => {
   const address = memoParts[2]
   const buyAssetChainId = thorChainAssetToChainId.get(pool.split('.')[0])
   const isAddressValid = buyAssetChainId
-    ? isValidAddress(buyAssetChainId, pool, address)
+    ? isValidMemoAddress(buyAssetChainId, pool, address)
     : undefined
 
   if (!isAddressValid) {

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
@@ -1,0 +1,75 @@
+import {
+  avalancheChainId,
+  bchChainId,
+  binanceChainId,
+  btcChainId,
+  ChainId,
+  cosmosChainId,
+  dogeChainId,
+  ethChainId,
+  ltcChainId,
+  thorchainChainId,
+} from '@shapeshiftoss/caip'
+import { chainIdToChainLabel } from '@shapeshiftoss/chain-adapters'
+import WAValidator from 'multicoin-address-validator'
+
+import { SwapError, SwapErrorType } from '../../../../api'
+
+const thorChainAssetToChainId: Map<string, ChainId> = new Map([
+  ['ETH', ethChainId],
+  ['AVAX', avalancheChainId],
+  ['BTC', btcChainId],
+  ['BCH', bchChainId],
+  ['LTC', ltcChainId],
+  ['BNB', binanceChainId],
+  ['DOGE', dogeChainId],
+  ['GAIA', cosmosChainId],
+  ['RUNE', thorchainChainId],
+])
+
+export const isValidAddress = (chainId: ChainId, thorId: string, address: string): boolean => {
+  switch (true) {
+    case thorId.startsWith('ETH.'):
+    case thorId.startsWith('AVAX.'):
+    case thorId.startsWith('BTC.'):
+    case thorId.startsWith('BCH.'):
+    case thorId.startsWith('LTC.'):
+    case thorId.startsWith('BNB.'):
+    case thorId.startsWith('DOGE.'): {
+      const chainLabel = chainIdToChainLabel(chainId)
+      return WAValidator.validate(address, chainLabel)
+    }
+    case thorId.startsWith('GAIA:'):
+      return address.startsWith('cosmos')
+    case thorId.startsWith('RUNE:'):
+    case thorId.startsWith('THOR:'):
+      return address.startsWith('thor')
+    default:
+      return false
+  }
+}
+
+export const assertIsValidMemo = (memo: string): void => {
+  // BTC (and likely other utxo coins) can only support up to 80 character (byte) memos
+  const MAX_MEMO_LENGTH = 80
+
+  const memoParts = memo.split(':')
+  const pool = memoParts[1]
+  const address = memoParts[2]
+  const buyAssetChainId = thorChainAssetToChainId.get(pool.split('.')[0])
+  const isAddressValid = buyAssetChainId
+    ? isValidAddress(buyAssetChainId, pool, address)
+    : undefined
+
+  if (!isAddressValid) {
+    throw new SwapError(`[makeSwapMemo] - memo ${memo} invalid`, {
+      code: SwapErrorType.MAKE_MEMO_FAILED,
+    })
+  }
+
+  if (memo.length > MAX_MEMO_LENGTH) {
+    throw new SwapError(`[makeSwapMemo] - memo length exceeds ${MAX_MEMO_LENGTH} characters`, {
+      code: SwapErrorType.MAKE_MEMO_FAILED,
+    })
+  }
+}

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
@@ -51,11 +51,13 @@ export const isValidMemoAddress = (chainId: ChainId, thorId: string, address: st
 export const assertIsValidMemo = (memo: string): void => {
   // BTC (and likely other utxo coins) can only support up to 80 character (byte) memos
   const MAX_MEMO_LENGTH = 80
+  const MEMO_PART_DELIMITER = ':'
+  const POOL_PART_DELIMITER = '.'
 
-  const memoParts = memo.split(':')
+  const memoParts = memo.split(MEMO_PART_DELIMITER)
   const pool = memoParts[1]
   const address = memoParts[2]
-  const buyAssetChainId = thorChainAssetToChainId.get(pool.split('.')[0])
+  const buyAssetChainId = thorChainAssetToChainId.get(pool.split(POOL_PART_DELIMITER)[0])
   const isAddressValid = buyAssetChainId
     ? isValidMemoAddress(buyAssetChainId, pool, address)
     : undefined

--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts
@@ -2,9 +2,7 @@ import { adapters, thorchainAssetId } from '@shapeshiftoss/caip'
 
 import { SwapError, SwapErrorType } from '../../../../api'
 import { THORCHAIN_AFFILIATE_BIPS, THORCHAIN_AFFILIATE_NAME } from '../constants'
-
-// BTC (and likely other utxo coins) can only support up to 80 character (byte) memos
-const MAX_MEMO_LENGTH = 80
+import { assertIsValidMemo } from './assertIsValidMemo'
 
 /**
  * definition of THORChain asset notation
@@ -78,12 +76,7 @@ export const makeSwapMemo: MakeSwapMemo = ({ buyAssetId, destinationAddress, lim
   const abbreviatedThorAssetId = abbreviateThorAssetId(fullThorAssetId)
 
   const memo = `s:${abbreviatedThorAssetId}:${parsedDestinationAddress}:${limit}:${THORCHAIN_AFFILIATE_NAME}:${THORCHAIN_AFFILIATE_BIPS}`
-
-  if (memo.length > MAX_MEMO_LENGTH) {
-    throw new SwapError(`[makeSwapMemo] - memo length exceeds ${MAX_MEMO_LENGTH} characters`, {
-      code: SwapErrorType.MAKE_MEMO_FAILED,
-    })
-  }
+  assertIsValidMemo(memo)
 
   return memo
 }


### PR DESCRIPTION
Assert that a memo is valid and throw if not - prevents invalid memos from ending up in THORSwap trades.