### PR TITLE
feat(swapper): update default slippage to .2%

### DIFF
--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
@@ -51,7 +51,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '6.2049517907881932',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('574407')
+    expect(limit).toBe('592056')
   })
 
   it('should get limit when buy asset is EVM non-fee asset and sell asset is a UTXO', async () => {
@@ -71,7 +71,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '6.2049517907881932',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('56613')
+    expect(limit).toBe('59316')
   })
 
   it('should get limit when buy asset is RUNE and sell asset is not', async () => {
@@ -91,7 +91,7 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '0.0318228582',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('2388981500')
+    expect(limit).toBe('2459464864')
   })
 
   it('should get limit when sell asset is RUNE and buy asset is not', async () => {
@@ -113,6 +113,6 @@ describe('getLimit', () => {
       buyAssetTradeFeeUsd: '0.0000000026',
     }
     const limit = await getLimit(getLimitArgs)
-    expect(limit).toBe('35991584136')
+    expect(limit).toBe('37051458730')
   })
 })

--- a/packages/swapper/src/swappers/utils/constants.ts
+++ b/packages/swapper/src/swappers/utils/constants.ts
@@ -1,3 +1,3 @@
 export const APPROVAL_GAS_LIMIT = '100000' // Most approvals are around 40k, we've seen 72k in the wild, so 100000 for safety.
-export const DEFAULT_SLIPPAGE = '0.03' // 3%
+export const DEFAULT_SLIPPAGE = '0.002' // .2%
 export const ALLOWABLE_MARKET_MOVEMENT = '0.01' // 1%


### PR DESCRIPTION
#### Description

Updates `DEFAULT_SLIPPAGE` (a.k.a the default slippage for trades we can't get a dynamic slippage for, and which don't have a user-passed slippage, which isn't implemented in the view layer yet) to 0.2%.

To be consumed in web when this is published, **after updating `DEFAULT_SLIPPAGE` there as well**.