### PR TITLE
feat: enable Avalanche on THORSwapper

### DIFF
--- a/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
+++ b/packages/swapper/src/swappers/thorchain/ThorchainSwapper.ts
@@ -70,7 +70,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
     [KnownChainIds.BitcoinCashMainnet]: true,
     [KnownChainIds.CosmosMainnet]: true,
     [KnownChainIds.ThorchainMainnet]: true,
-    [KnownChainIds.AvalancheMainnet]: false,
+    [KnownChainIds.AvalancheMainnet]: true,
     [KnownChainIds.OptimismMainnet]: false,
   }
 
@@ -82,7 +82,7 @@ export class ThorchainSwapper implements Swapper<ChainId> {
     [KnownChainIds.BitcoinCashMainnet]: true,
     [KnownChainIds.CosmosMainnet]: true,
     [KnownChainIds.ThorchainMainnet]: true,
-    [KnownChainIds.AvalancheMainnet]: false,
+    [KnownChainIds.AvalancheMainnet]: true,
     [KnownChainIds.OptimismMainnet]: false,
   }
 


### PR DESCRIPTION
Undoes https://github.com/shapeshift/lib/pull/1135 and enables Avalanche trading on THORSwapper.

Very important when testing:

1. Swaps into and out of Avalanche assets via THORSwapper succeed, and land in the expected account
2. Multi-account swaps (e.g. from account 2, into account 3 etc) work as expected for swaps with Avalanche assets (via THORSwappeR)