### PR TITLE
fix(swapper): osmosis multi-account swaps

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -89,6 +89,7 @@ type CommonTradeInput = {
   sendMax: boolean
   receiveAddress: string
   accountNumber: number
+  receiveAccountNumber?: number
 }
 
 export type GetEvmTradeQuoteInput = CommonTradeInput & {
@@ -139,6 +140,7 @@ export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
 
 export interface Trade<C extends ChainId> extends TradeBase<C> {
   receiveAddress: string
+  receiveAccountNumber?: number
 }
 
 export type ExecuteTradeInput<C extends ChainId> = {
@@ -230,6 +232,7 @@ export enum SwapErrorType {
   POOL_NOT_FOUND = 'POOL_NOT_FOUND',
   GET_TRADE_TXS_FAILED = 'GET_TRADE_TXS_FAILED',
   TRADE_FAILED = 'TRADE_FAILED',
+  RECEIVE_ACCOUNT_NUMBER_NOT_PROVIDED = 'RECEIVE_ACCOUNT_NUMBER_NOT_PROVIDED',
 }
 export interface Swapper<T extends ChainId> {
   /** Human-readable swapper name */

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -163,6 +163,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       sellAmountBeforeFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
       receiveAddress,
       accountNumber,
+      receiveAccountNumber,
     } = args
 
     if (!sellAmountCryptoBaseUnit) {
@@ -206,6 +207,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       sellAmountBeforeFeesCryptoBaseUnit: sellAmountCryptoBase, // TODO(gomes): wat?
       sellAsset,
       accountNumber,
+      receiveAccountNumber,
       sources: [{ name: SwapperName.Osmosis, proportion: '100' }],
     }
   }
@@ -268,8 +270,14 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       buyAsset,
       sellAmountBeforeFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
       accountNumber,
+      receiveAccountNumber,
       receiveAddress,
     } = trade
+
+    if (!receiveAccountNumber)
+      throw new SwapError('Receive account number not provided', {
+        code: SwapErrorType.RECEIVE_ACCOUNT_NUMBER_NOT_PROVIDED,
+      })
 
     const isFromOsmo = sellAsset.assetId === osmosisAssetId
     const sellAssetDenom = symbolDenomMapping[sellAsset.symbol as keyof SymbolDenomMapping]
@@ -357,7 +365,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
     const cosmosAddress = isFromOsmo ? receiveAddress : sellAddress
     const signTxInput = await buildTradeTx({
       osmoAddress,
-      accountNumber,
+      accountNumber: receiveAccountNumber,
       adapter: osmosisAdapter,
       buyAssetDenom,
       sellAssetDenom,


### PR DESCRIPTION
* fixes ATOM(account 0) -> OSMO(account 1) trades as reported by [TShifty](https://discord.com/channels/554694662431178782/1066088208905031681/1078117897060225124).
* note: there is probably a way to accomplish the same thing making better use of the type system than sticking an optional field onto the base trade types. I played around with this for a while, but ended up reverting to the naiive case for expediency. If you've got any suggestions, please let me know and I'll be happy to fix.