### PR TITLE
feat(investor-idle): expose IdleOpportunity strategy

### DIFF
--- a/packages/investor-idle/src/IdleOpportunity.ts
+++ b/packages/investor-idle/src/IdleOpportunity.ts
@@ -82,6 +82,7 @@ export class IdleOpportunity
    */
   readonly id: string
   readonly version: string
+  readonly strategy: string
   readonly name: string
   readonly displayName: string
   readonly isApprovalRequired: true
@@ -152,6 +153,7 @@ export class IdleOpportunity
       },
     }
     this.version = `${vault.protocolName} ${vault.strategy}`.trim()
+    this.strategy = vault.strategy
     this.name = vault.poolName
     this.displayName = vault.poolName
     this.isNew = false


### PR DESCRIPTION
#### Description

Does what it says on the box, exposing `strategy` so that web can consume it and populate Idle tags for @reallybeard consumption