### PR TITLE
chore: upgrade bignumber.js to match web

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "^0.26.1",
     "bech32": "^2.0.0",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "bitcoinjs-lib": "^5.2.0",
     "coinselect": "^3.1.13",
     "ethers": "^5.4.7",

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.5.3",
     "axios": "^0.26.1",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "lodash": "^4.17.21",
     "web3": "1.7.4",
     "web3-core": "1.7.4",

--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.3",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "lodash": "^4.17.21",
     "web3": "1.7.4",
     "web3-core": "1.7.4",

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.5.3",
     "@yfi/sdk": "^1.2.0",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "lodash": "^4.17.21",
     "web3": "1.7.4",
     "web3-core": "1.7.4",

--- a/packages/investor/package.json
+++ b/packages/investor/package.json
@@ -28,6 +28,6 @@
   "devDependencies": {
     "@shapeshiftoss/hdwallet-core": "^1.43.0",
     "@shapeshiftoss/types": "8.1.0",
-    "bignumber.js": "^9.0.2"
+    "bignumber.js": "^9.1.1"
   }
 }

--- a/packages/market-service/package.json
+++ b/packages/market-service/package.json
@@ -30,7 +30,7 @@
     "@yfi/sdk": "^1.2.0",
     "axios": "^0.26.1",
     "axios-rate-limit": "^1.3.0",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "dayjs": "^1.10.6",
     "p-ratelimit": "^1.0.1"
   },

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "axios": "^0.26.1",
     "axios-cache-adapter": "^2.7.3",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "lodash": "^4.17.21",
     "retry-axios": "^2.6.0",
     "web3": "1.7.4"

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@yfi/sdk": "^1.2.0",
     "axios": "^0.26.1",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.1",
     "ethers": "^5.5.3",
     "isomorphic-ws": "^4.0.1",
     "ws": "^8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,6 +4364,11 @@ bignumber.js@^9.0.0, bignumber.js@^9.0.1, bignumber.js@^9.0.2:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
   integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
 
+bignumber.js@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
+  integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
+
 bin-links@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-2.3.0.tgz#1ff241c86d2c29b24ae52f49544db5d78a4eb967"


### PR DESCRIPTION
- due to mismatched versions, there were bignumber warning being thrown in web when locally linked