### PR TITLE
chore: add identicon generation to avalanche and optimism

### DIFF
--- a/packages/asset-service/src/generateAssetData/avalanche/index.ts
+++ b/packages/asset-service/src/generateAssetData/avalanche/index.ts
@@ -1,19 +1,19 @@
 import { avalancheChainId } from '@shapeshiftoss/caip'
 
+import { Asset } from '../../service/AssetService'
 import { getRenderedIdenticonBase64 } from '../../service/GenerateAssetIcon'
 import { avax } from '../baseAssets'
 import * as coingecko from '../coingecko'
 
-export const getAssets = async () => {
+export const getAssets = async (): Promise<Asset[]> => {
   const assets = await coingecko.getAssets(avalancheChainId)
-  assets.push(avax)
-  return assets.map((asset) => {
-    if (!asset.icon) {
-      asset.icon = getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
+  return [...assets, avax].map((asset) => ({
+    ...asset,
+    icon:
+      asset.icon ||
+      getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
         identiconImage: { size: 128, background: [45, 55, 72, 255] },
         identiconText: { symbolScale: 7, enableShadow: true },
-      })
-    }
-    return asset
-  })
+      }),
+  }))
 }

--- a/packages/asset-service/src/generateAssetData/avalanche/index.ts
+++ b/packages/asset-service/src/generateAssetData/avalanche/index.ts
@@ -1,10 +1,19 @@
 import { avalancheChainId } from '@shapeshiftoss/caip'
 
+import { getRenderedIdenticonBase64 } from '../../service/GenerateAssetIcon'
 import { avax } from '../baseAssets'
 import * as coingecko from '../coingecko'
 
 export const getAssets = async () => {
   const assets = await coingecko.getAssets(avalancheChainId)
   assets.push(avax)
-  return assets
+  return assets.map((asset) => {
+    if (!asset.icon) {
+      asset.icon = getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
+        identiconImage: { size: 128, background: [45, 55, 72, 255] },
+        identiconText: { symbolScale: 7, enableShadow: true },
+      })
+    }
+    return asset
+  })
 }

--- a/packages/asset-service/src/generateAssetData/optimism/index.ts
+++ b/packages/asset-service/src/generateAssetData/optimism/index.ts
@@ -1,10 +1,19 @@
 import { optimismChainId } from '@shapeshiftoss/caip'
 
+import { getRenderedIdenticonBase64 } from '../../service/GenerateAssetIcon'
 import { optimism } from '../baseAssets'
 import * as coingecko from '../coingecko'
 
 export const getAssets = async () => {
   const assets = await coingecko.getAssets(optimismChainId)
   assets.push(optimism)
-  return assets
+  return assets.map((asset) => {
+    if (!asset.icon) {
+      asset.icon = getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
+        identiconImage: { size: 128, background: [45, 55, 72, 255] },
+        identiconText: { symbolScale: 7, enableShadow: true },
+      })
+    }
+    return asset
+  })
 }

--- a/packages/asset-service/src/generateAssetData/optimism/index.ts
+++ b/packages/asset-service/src/generateAssetData/optimism/index.ts
@@ -6,14 +6,13 @@ import * as coingecko from '../coingecko'
 
 export const getAssets = async () => {
   const assets = await coingecko.getAssets(optimismChainId)
-  assets.push(optimism)
-  return assets.map((asset) => {
-    if (!asset.icon) {
-      asset.icon = getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
+  return [...assets, optimism].map((asset) => ({
+    ...asset,
+    icon:
+      asset.icon ||
+      getRenderedIdenticonBase64(asset.assetId, asset.symbol, {
         identiconImage: { size: 128, background: [45, 55, 72, 255] },
         identiconText: { symbolScale: 7, enableShadow: true },
-      })
-    }
-    return asset
-  })
+      }),
+  }))
 }


### PR DESCRIPTION
- `icon` field is required and in the case of missing icon, avalanche and optimism weren't generating identicons as placeholder