### PR TITLE
feat(swapper): unrug THOR swaps to RUNE

### DIFF
--- a/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/assertIsValidMemo.ts
@@ -41,7 +41,10 @@ export const isValidMemoAddress = (chainId: ChainId, thorId: string, address: st
     }
     case thorId.startsWith('GAIA.'):
       return address.startsWith('cosmos')
-    case thorId.startsWith('RUNE.'):
+    // Note that this case doesn't contain a dot
+    // See https://github.com/shapeshift/lib/blob/6b5c9c8e855ffb68d865cfae8f545e7a819a9667/packages/swapper/src/swappers/thorchain/utils/makeSwapMemo/makeSwapMemo.ts#L10
+    // RUNE isn't a pool, it is the native asset of the THORChain network
+    case thorId.startsWith('RUNE'):
       return address.startsWith('thor')
     default:
       return false


### PR DESCRIPTION
#### Description

Fixes swaps to RUNE - rugged by one character with the same assumption as before.
RUNE isn't a pool, it is the native asset of the THOR network

#### Screenshot

<img width="406" alt="image" src="https://user-images.githubusercontent.com/17035424/221690781-fa799a7e-a141-45bd-87c2-2c7a2d86000a.png">