### PR TITLE
fix(common): osmosis keepkey swaps

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -38,16 +38,16 @@
   },
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
-    "@shapeshiftoss/hdwallet-native": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
+    "@shapeshiftoss/hdwallet-native": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.11.0",
     "bs58check": "^2.0.2"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
-    "@shapeshiftoss/hdwallet-native": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
+    "@shapeshiftoss/hdwallet-native": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1",
     "@types/bs58check": "^2.1.0",

--- a/packages/investor-foxy/package.json
+++ b/packages/investor-foxy/package.json
@@ -38,13 +38,13 @@
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1"
   }

--- a/packages/investor-idle/package.json
+++ b/packages/investor-idle/package.json
@@ -37,14 +37,14 @@
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"

--- a/packages/investor-yearn/package.json
+++ b/packages/investor-yearn/package.json
@@ -38,14 +38,14 @@
   "peerDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1"
   },
   "devDependencies": {
     "@shapeshiftoss/caip": "^8.4.2",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/investor": "^3.0.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.0.2"

--- a/packages/investor/package.json
+++ b/packages/investor/package.json
@@ -26,7 +26,7 @@
     "test": "jest --coverage"
   },
   "devDependencies": {
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/types": "8.1.0",
     "bignumber.js": "^9.1.1"
   }

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -35,7 +35,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/errors": "^1.1.2",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "@shapeshiftoss/caip": "^8.0.0",
     "@shapeshiftoss/chain-adapters": "^11.0.0",
     "@shapeshiftoss/errors": "^1.1.2",
-    "@shapeshiftoss/hdwallet-core": "^1.43.0",
+    "@shapeshiftoss/hdwallet-core": "^1.46.0",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^10.0.1",
     "@types/readline-sync": "^1.4.4",


### PR DESCRIPTION
* Depends on https://github.com/shapeshift/hdwallet/pull/600
* Updates hdwallet dependencies 
* HDWallet-keepkey v1.46.0 contains a fix for the Osmosis IBC transfer command. That package is not directly included in this repo, but this will keep the hdwallet package numbers in sync.