### PR TITLE
fix: update osmosis min fee to comply with v15.0.0 min consensus fee update

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -2,7 +2,6 @@ import { AssetId, ChainId, fromChainId, generateAssetIdFromOsmosisDenom } from '
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
-import BigNumber from 'bignumber.js'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -56,16 +55,6 @@ export const assertIsValidatorAddress = (validator: string, chainId: CosmosSdkCh
   if (CHAIN_ID_TO_BECH32_VAL_PREFIX[chainId] !== bech32.decode(validator).prefix) {
     throw new Error(`CosmosSdkBaseAdapter: invalid validator address ${validator}`)
   }
-}
-
-type ConfirmationSpeed = 'slow' | 'average' | 'fast'
-
-export const calcFee = (
-  fee: string | number | BigNumber,
-  speed: ConfirmationSpeed,
-  scalars: Record<ConfirmationSpeed, BigNumber>,
-): string => {
-  return bnOrZero(fee).times(scalars[speed]).toFixed(0, BigNumber.ROUND_CEIL).toString()
 }
 
 const transformValidator = (validator: unchained.cosmossdk.types.Validator): Validator => ({

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -2,6 +2,7 @@ import { AssetId, ChainId, fromChainId, generateAssetIdFromOsmosisDenom } from '
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
+import BigNumber from 'bignumber.js'
 
 import { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -55,6 +56,16 @@ export const assertIsValidatorAddress = (validator: string, chainId: CosmosSdkCh
   if (CHAIN_ID_TO_BECH32_VAL_PREFIX[chainId] !== bech32.decode(validator).prefix) {
     throw new Error(`CosmosSdkBaseAdapter: invalid validator address ${validator}`)
   }
+}
+
+type ConfirmationSpeed = 'slow' | 'average' | 'fast'
+
+export const calcFee = (
+  fee: string | number | BigNumber,
+  speed: ConfirmationSpeed,
+  scalars: Record<ConfirmationSpeed, BigNumber>,
+): string => {
+  return bnOrZero(fee).times(scalars[speed]).toFixed(0, BigNumber.ROUND_CEIL).toString()
 }
 
 const transformValidator = (validator: unchained.cosmossdk.types.Validator): Validator => ({

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -16,13 +16,15 @@ import {
   GetFeeDataInput,
   SignTxInput,
 } from '../../types'
-import { toAddressNList } from '../../utils'
+import { bn, calcFee, toAddressNList } from '../../utils'
 import {
   assertIsValidatorAddress,
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
 import { Message, ValidatorAction } from '../types'
+
+export const MIN_FEE = '2500'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.CosmosMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.CosmosMainnet
@@ -275,12 +277,15 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
   }: Partial<GetFeeDataInput<KnownChainIds.CosmosMainnet>>): Promise<
     FeeDataEstimate<KnownChainIds.CosmosMainnet>
   > {
+    const gasLimit = '250000'
+    const scalars = { fast: bn(2), average: bn(1.5), slow: bn(1) }
+
     // We currently don't have a way to query validators to get dynamic fees, so they are hard coded.
     // When we find a strategy to make this more dynamic, we can use 'sendMax' to define max amount.
     return {
-      fast: { txFee: '5000', chainSpecific: { gasLimit: '250000' } },
-      average: { txFee: '3500', chainSpecific: { gasLimit: '250000' } },
-      slow: { txFee: '2500', chainSpecific: { gasLimit: '250000' } },
+      fast: { txFee: calcFee(MIN_FEE, 'fast', scalars), chainSpecific: { gasLimit } },
+      average: { txFee: calcFee(MIN_FEE, 'average', scalars), chainSpecific: { gasLimit } },
+      slow: { txFee: calcFee(MIN_FEE, 'slow', scalars), chainSpecific: { gasLimit } },
     }
   }
 

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -19,10 +19,9 @@ import {
   SignTxInput,
 } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
+import { bn, calcFee } from '../../utils'
 import {
   assertIsValidatorAddress,
-  calcFee,
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'

--- a/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/osmosis/OsmosisChainAdapter.ts
@@ -19,12 +19,16 @@ import {
   SignTxInput,
 } from '../../types'
 import { toAddressNList } from '../../utils'
+import { bn } from '../../utils/bignumber'
 import {
   assertIsValidatorAddress,
+  calcFee,
   ChainAdapterArgs,
   CosmosSdkBaseAdapter,
 } from '../CosmosSdkBaseAdapter'
 import { Message, ValidatorAction } from '../types'
+
+export const MIN_FEE = '2500'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OsmosisMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OsmosisMainnet
@@ -329,12 +333,15 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.OsmosisMain
   }: Partial<GetFeeDataInput<KnownChainIds.OsmosisMainnet>>): Promise<
     FeeDataEstimate<KnownChainIds.OsmosisMainnet>
   > {
+    const gasLimit = '300000'
+    const scalars = { fast: bn(2), average: bn(1.5), slow: bn(1) }
+
     // We currently don't have a way to query validators to get dynamic fees, so they are hard coded.
     // When we find a strategy to make this more dynamic, we can use 'sendMax' to define max amount.
     return {
-      fast: { txFee: '5000', chainSpecific: { gasLimit: '300000' } },
-      average: { txFee: '3500', chainSpecific: { gasLimit: '300000' } },
-      slow: { txFee: '2500', chainSpecific: { gasLimit: '300000' } },
+      fast: { txFee: calcFee(MIN_FEE, 'fast', scalars), chainSpecific: { gasLimit } },
+      average: { txFee: calcFee(MIN_FEE, 'average', scalars), chainSpecific: { gasLimit } },
+      slow: { txFee: calcFee(MIN_FEE, 'slow', scalars), chainSpecific: { gasLimit } },
     }
   }
 

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -11,7 +11,6 @@ import {
 } from '@shapeshiftoss/hdwallet-core'
 import { BIP44Params, KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import BigNumber from 'bignumber.js'
 import { utils } from 'ethers'
 import WAValidator from 'multicoin-address-validator'
 import { numberToHex } from 'web3-utils'
@@ -66,16 +65,6 @@ export const isEvmChainId = (
   maybeEvmChainId: string | EvmChainId,
 ): maybeEvmChainId is EvmChainId => {
   return evmChainIds.includes(maybeEvmChainId as EvmChainId)
-}
-
-type ConfirmationSpeed = 'slow' | 'average' | 'fast'
-
-export const calcFee = (
-  fee: string | number | BigNumber,
-  speed: ConfirmationSpeed,
-  scalars: Record<ConfirmationSpeed, BigNumber>,
-): string => {
-  return bnOrZero(fee).times(scalars[speed]).toFixed(0, BigNumber.ROUND_CEIL).toString()
 }
 
 type EvmApi =

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -4,8 +4,8 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GetFeeDataInput } from '../../types'
-import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { bn, bnOrZero, calcFee } from '../../utils'
+import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
 import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.AvalancheMainnet]

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.ts
@@ -4,8 +4,8 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GetFeeDataInput } from '../../types'
-import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { bn, bnOrZero, calcFee } from '../../utils'
+import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
 import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.BnbSmartChainMainnet]

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -11,8 +11,8 @@ import {
   ValidAddressResultType,
   ZrxGasApiResponse,
 } from '../../types'
-import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { bn, bnOrZero, calcFee } from '../../utils'
+import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
 import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.EthereumMainnet]

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
@@ -4,8 +4,8 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import { ChainAdapterDisplayName } from '../../types'
 import { FeeDataEstimate, GetFeeDataInput } from '../../types'
-import { bn, bnOrZero } from '../../utils/bignumber'
-import { calcFee, ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
+import { bn, bnOrZero, calcFee } from '../../utils'
+import { ChainAdapterArgs, EvmBaseAdapter } from '../EvmBaseAdapter'
 import { GasFeeDataEstimate } from '../types'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OptimismMainnet]

--- a/packages/chain-adapters/src/utils/fees.ts
+++ b/packages/chain-adapters/src/utils/fees.ts
@@ -1,0 +1,12 @@
+import BigNumber from 'bignumber.js'
+
+import { FeeDataKey } from '../types'
+import { bnOrZero } from './bignumber'
+
+export type ConfirmationSpeed = `${FeeDataKey}`
+export type Fee = string | number | BigNumber
+export type Scalars = Record<ConfirmationSpeed, BigNumber>
+
+export const calcFee = (fee: Fee, speed: ConfirmationSpeed, scalars: Scalars): string => {
+  return bnOrZero(fee).times(scalars[speed]).toFixed(0, BigNumber.ROUND_CEIL).toString()
+}

--- a/packages/chain-adapters/src/utils/index.ts
+++ b/packages/chain-adapters/src/utils/index.ts
@@ -6,7 +6,9 @@ import {
   fromChainId,
 } from '@shapeshiftoss/caip'
 
+export * from './bignumber'
 export * from './bip44'
+export * from './fees'
 export * from './utxoUtils'
 
 export const getAssetNamespace = (type: string): AssetNamespace => {

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -44,8 +44,6 @@ import {
 } from './utils/helpers'
 import { OsmosisTradeResult, OsmoSwapperDeps } from './utils/types'
 
-export const OSMOSIS_MIN_FEE = '750'
-
 export type OsmosisSupportedChainId = KnownChainIds.CosmosMainnet | KnownChainIds.OsmosisMainnet
 
 export type OsmosisSupportedChainAdapter = cosmos.ChainAdapter | osmosis.ChainAdapter
@@ -413,7 +411,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
         this.deps.cosmosUrl,
         buyAssetDenom,
         OSMO_COSMO_CHANNEL,
-        OSMOSIS_MIN_FEE,
+        osmosis.MIN_FEE,
         accountNumber,
         ibcAccountNumber,
         ibcSequence,

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -44,6 +44,8 @@ import {
 } from './utils/helpers'
 import { OsmosisTradeResult, OsmoSwapperDeps } from './utils/types'
 
+export const OSMOSIS_MIN_FEE = '750'
+
 export type OsmosisSupportedChainId = KnownChainIds.CosmosMainnet | KnownChainIds.OsmosisMainnet
 
 export type OsmosisSupportedChainAdapter = cosmos.ChainAdapter | osmosis.ChainAdapter
@@ -411,7 +413,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
         this.deps.cosmosUrl,
         buyAssetDenom,
         OSMO_COSMO_CHANNEL,
-        '0',
+        OSMOSIS_MIN_FEE,
         accountNumber,
         ibcAccountNumber,
         ibcSequence,

--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -6,7 +6,7 @@ import { find } from 'lodash'
 
 import { SwapError, SwapErrorType, TradeResult } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
-import { OSMOSIS_MIN_FEE, OsmosisSupportedChainAdapter } from '../OsmosisSwapper'
+import { OsmosisSupportedChainAdapter } from '../OsmosisSwapper'
 import { OSMOSIS_PRECISION } from './constants'
 import { osmoService } from './osmoService'
 import { IbcTransferInput, PoolInfo } from './types'
@@ -303,7 +303,7 @@ export const buildTradeTx = async ({
     fee: {
       amount: [
         {
-          amount: OSMOSIS_MIN_FEE,
+          amount: osmosis.MIN_FEE,
           denom: 'uosmo',
         },
       ],

--- a/packages/swapper/src/swappers/osmosis/utils/helpers.ts
+++ b/packages/swapper/src/swappers/osmosis/utils/helpers.ts
@@ -6,7 +6,7 @@ import { find } from 'lodash'
 
 import { SwapError, SwapErrorType, TradeResult } from '../../../api'
 import { bn, bnOrZero } from '../../utils/bignumber'
-import { OsmosisSupportedChainAdapter } from '../OsmosisSwapper'
+import { OSMOSIS_MIN_FEE, OsmosisSupportedChainAdapter } from '../OsmosisSwapper'
 import { OSMOSIS_PRECISION } from './constants'
 import { osmoService } from './osmoService'
 import { IbcTransferInput, PoolInfo } from './types'
@@ -303,7 +303,7 @@ export const buildTradeTx = async ({
     fee: {
       amount: [
         {
-          amount: '0',
+          amount: OSMOSIS_MIN_FEE,
           denom: 'uosmo',
         },
       ],


### PR DESCRIPTION
- single const
- use `MIN_FEE` in osmosis swapper
- use `MIN_FEE` with `calcFee` + `scalar` for `getFeeData`