### PR TITLE
fix: cowswap buyAmountCryptoBaseUnit logic

### DIFF
--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -176,7 +176,7 @@ const expectedTradeQuoteSmallAmountWethToFox: TradeQuote<KnownChainIds.EthereumM
     networkFeeCryptoBaseUnit: '0',
   },
   sellAmountBeforeFeesCryptoBaseUnit: '1000000000000',
-  buyAmountCryptoBaseUnit: '145018118182475950905', // 14501 FOX
+  buyAmountCryptoBaseUnit: '0', // 0 FOX
   sources: [{ name: SwapperName.CowSwap, proportion: '1' }],
   allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
   buyAsset: FOX,


### PR DESCRIPTION
There is a logic error in the `getCowSwapTradeQuote` function. 

If we attempt to sell an amount that is less than the CoW Swap minimum, we get a quote using the minimum amount to ensure we still get a quote back.

The issue was that we are _always_ passing the buy asset amount that this minimum sell amount would buy (from the quote response) in the `buyAmountCryptoBaseUnit` field, regardless of if we made the minimum or not.

This is leading to inflated CoW Swap ratios which were rugging swapper selection UI, among a host of other bugs relating to minimum amounts.

To test this you'll need to be running https://github.com/shapeshift/web/pull/4177 on `web`, then:

1. Attempt to replicate the bug in https://github.com/shapeshift/web/issues/4168
2. With `REACT_APP_FEATURE_TRADE_RATES` enabled, we should no longer see negative amounts for CoW Swap, and it should be in it's correct place in the list (i.e. not "best" when it's worse than 0x) - trading a very small amount of FOX for ETH is a good way to get rates from CoW Swap, THORSwap and 0x and test this.

Closes https://github.com/shapeshift/web/issues/4168

Note for you @gomesalexandre, as I know you'll find it(!) - this does not yet fix the minimum amounts issue, which is separate, and fixed in https://github.com/shapeshift/web/pull/4178.