### PR TITLE
fix: cowswap minimum flag

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -180,8 +180,8 @@ export type SwapSource = {
 }
 
 export interface MinMaxOutput {
-  minimum: string
-  maximum: string
+  minimumAmountCryptoHuman: string
+  maximumAmountCryptoHuman: string
 }
 
 export type ApprovalNeededOutput = {

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -19,14 +19,14 @@ const DEPS = {
 describe('getCowSwapMinMax', () => {
   it('returns minimum and maximum', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, WETH)
-    expect(minMax.minimum).toBe('80')
-    expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('80')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
   it('returns minimum and maximum for ETH as buy asset', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, ETH)
-    expect(minMax.minimum).toBe('80')
-    expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('80')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
   it('fails on non erc 20 sell assets and non ETH-mainnet buy assets', async () => {

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -23,11 +23,13 @@ export const getCowSwapMinMax = async (
 
     const usdRate = await getUsdRate(deps, sellAsset)
 
-    const minimum = bn(MIN_COWSWAP_VALUE_USD).dividedBy(bnOrZero(usdRate)).toString() // $10 worth of the sell token.
-    const maximum = MAX_COWSWAP_TRADE // Arbitrarily large value. 10e+28 here.
+    const minimumAmountCryptoHuman = bn(MIN_COWSWAP_VALUE_USD)
+      .dividedBy(bnOrZero(usdRate))
+      .toString() // $10 worth of the sell token.
+    const maximumAmountCryptoHuman = MAX_COWSWAP_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -121,6 +121,10 @@ export async function getCowSwapTradeQuote(
       },
     } = quoteResponse
 
+    const quoteSellAmountPlusFeesCryptoBaseUnit = bnOrZero(sellAmountCryptoBaseUnit).plus(
+      feeAmountInSellTokenCryptoBaseUnit,
+    )
+
     const buyCryptoAmount = bn(buyAmountCryptoBaseUnit).div(
       bn(10).exponentiatedBy(buyAsset.precision),
     )
@@ -151,7 +155,7 @@ export async function getCowSwapTradeQuote(
 
     const feeData = feeDataOptions['fast']
 
-    const isQuoteSellAmountBelowMinimum = bnOrZero(sellAmountCryptoBaseUnit).lt(
+    const isQuoteSellAmountBelowMinimum = quoteSellAmountPlusFeesCryptoBaseUnit.lt(
       minQuoteSellAmountCryptoBaseUnit,
     )
     // If isQuoteSellAmountBelowMinimum we don't want to replace it with normalizedSellAmount

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -118,12 +118,12 @@ export class OsmosisSwapper implements Swapper<ChainId> {
   async getMinMax(input: { sellAsset: Asset }): Promise<MinMaxOutput> {
     const { sellAsset } = input
     const usdRate = await this.getUsdRate({ ...sellAsset })
-    const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString()
-    const maximum = MAX_SWAPPER_SELL
+    const minimumAmountCryptoHuman = bn(1).dividedBy(bnOrZero(usdRate)).toString()
+    const maximumAmountCryptoHuman = MAX_SWAPPER_SELL
 
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   }
 
@@ -231,7 +231,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       this.deps.osmoUrl,
     )
 
-    const { minimum, maximum } = await this.getMinMax(input)
+    const { minimumAmountCryptoHuman, maximumAmountCryptoHuman } = await this.getMinMax(input)
 
     const osmosisAdapter = this.deps.adapterManager.get(osmosisChainId) as
       | osmosis.ChainAdapter
@@ -252,8 +252,8 @@ export class OsmosisSwapper implements Swapper<ChainId> {
         sellAssetTradeFeeUsd: '0',
         buyAssetTradeFeeUsd,
       },
-      maximum,
-      minimumCryptoHuman: minimum, // TODO(gomes): shorthand?
+      maximum: maximumAmountCryptoHuman,
+      minimumCryptoHuman: minimumAmountCryptoHuman, // TODO(gomes): shorthand?
       accountNumber,
       rate,
       sellAsset,

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
@@ -13,8 +13,8 @@ jest.mock('../utils/helpers/helpers', () => ({
 describe('getZrxMinMax', () => {
   it('returns minimum and maximum', async () => {
     const minMax = await getZrxMinMax(FOX, WETH)
-    expect(minMax.minimum).toBe('1')
-    expect(minMax.maximum).toBe(MAX_ZRX_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('1')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_ZRX_TRADE)
   })
 
   it('fails on invalid evm asset', async () => {

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -20,11 +20,11 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
 
     const usdRate = await getUsdRate({ ...sellAsset })
 
-    const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString() // $1 worth of the sell token.
-    const maximum = MAX_ZRX_TRADE // Arbitrarily large value. 10e+28 here.
+    const minimumAmountCryptoHuman = bn(1).dividedBy(bnOrZero(usdRate)).toString() // $1 worth of the sell token.
+    const maximumAmountCryptoHuman = MAX_ZRX_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -40,8 +40,11 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
     const buyToken = assetToToken(buyAsset)
     const sellToken = assetToToken(sellAsset)
 
-    const { minimum, maximum } = await getZrxMinMax(sellAsset, buyAsset)
-    const minQuotesellAmountCryptoBaseUnit = bnOrZero(minimum).times(
+    const { minimumAmountCryptoHuman, maximumAmountCryptoHuman } = await getZrxMinMax(
+      sellAsset,
+      buyAsset,
+    )
+    const minQuotesellAmountCryptoBaseUnit = bnOrZero(minimumAmountCryptoHuman).times(
       bn(10).exponentiatedBy(sellAsset.precision),
     )
 
@@ -99,8 +102,8 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
 
     const tradeQuote: TradeQuote<ZrxSupportedChainId> = {
       rate,
-      minimumCryptoHuman: minimum,
-      maximum,
+      minimumCryptoHuman: minimumAmountCryptoHuman,
+      maximum: maximumAmountCryptoHuman,
       feeData: {
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),


### PR DESCRIPTION
Tip for reviewers: the only actual logic change in this PR is in https://github.com/shapeshift/lib/commit/65beae0c4ad9fff1cd2c94b50fbf5f276e27b289, the reset is just renaming.

Existing logic incorrectly assumes that the `sellAmountCryptoBaseUnit` is the amount not including fees.

In reality, CoW Swap subtracts any trading fees from the `sellAmountCryptoBaseUnit` value in the returned response, so we need to add them back on to get the true "sell amount" of the sell asset.

This is causing the UI to show that the "sell amount is lower than the fee" when the sell amount is above the minimum by less than the fee amount.

To test, attempt to use CoW swap to trade, say, $21 - this should now work, whereas previously is would not until you sold $20 plus the fee amount.

Also refactors the naming of `minimum` and `maximum` to show their actual units.