### PR TITLE
fix: isQuoteSellAmountBelowMinimum

### DIFF
--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -113,6 +113,10 @@ export async function getCowSwapTradeQuote(
       },
     } = quoteResponse
 
+    const quoteSellAmountPlusFeesCryptoBaseUnit = bnOrZero(sellAmountCryptoBaseUnit).plus(
+      feeAmountInSellTokenCryptoBaseUnit,
+    )
+
     const buyCryptoAmount = bn(buyAmountCryptoBaseUnit).div(
       bn(10).exponentiatedBy(buyAsset.precision),
     )
@@ -143,7 +147,9 @@ export async function getCowSwapTradeQuote(
 
     const feeData = feeDataOptions['fast']
 
-    const isQuoteSellAmountBelowMinimum = bnOrZero(sellAmountCryptoBaseUnit).lt(minQuoteSellAmount)
+    const isQuoteSellAmountBelowMinimum = bnOrZero(quoteSellAmountPlusFeesCryptoBaseUnit).lt(
+      minQuoteSellAmount,
+    )
     // If isQuoteSellAmountBelowMinimum we don't want to replace it with normalizedSellAmount
     // The purpose of this was to get a quote from CowSwap even with small amounts
     const quoteSellAmountCryptoBaseUnit = isQuoteSellAmountBelowMinimum


### PR DESCRIPTION
Existing logic incorrectly assumes that the `sellAmountCryptoBaseUnit` is the amount not including fees.

In reality, CoW Swap subtracts any trading fees from the `sellAmountCryptoBaseUnit` value in the returned response, so we need to add them back on to get the true "sell amount" of the sell asset.

This is causing the UI to show that the "sell amount is lower than the fee" when the sell amount is above the minimum by less than the fee amount.

To test, attempt to use CoW swap to trade, say, $21 - this should now work, whereas previously is would not until you sold $20 plus the fee amount.